### PR TITLE
feat: add billable support to start_timer and new update_entry tool

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,9 @@
         "prettier": "^3.1.0",
         "tsx": "^4.6.0",
         "typescript": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -733,6 +736,7 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -902,6 +906,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1239,6 +1244,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -2492,6 +2498,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/index.ts
+++ b/src/index.ts
@@ -211,8 +211,63 @@ const tools: Tool[] = [
           type: 'array',
           items: { type: 'string' },
           description: 'Tags for the entry'
+        },
+        billable: {
+          type: 'boolean',
+          description: 'Whether the time entry is billable (requires Toggl paid plan)'
         }
       }
+    },
+  },
+  {
+    name: 'toggl_update_entry',
+    description: 'Update an existing time entry (change billable status, description, project, tags, etc.)',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        time_entry_id: {
+          type: 'number',
+          description: 'The ID of the time entry to update'
+        },
+        workspace_id: {
+          type: 'number',
+          description: 'Workspace ID the time entry belongs to'
+        },
+        description: {
+          type: 'string',
+          description: 'New description'
+        },
+        project_id: {
+          type: 'number',
+          description: 'New project ID'
+        },
+        task_id: {
+          type: 'number',
+          description: 'New task ID'
+        },
+        billable: {
+          type: 'boolean',
+          description: 'Whether the time entry is billable'
+        },
+        tags: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'New tags (replaces existing tags)'
+        },
+        start: {
+          type: 'string',
+          description: 'New start time (ISO 8601 format)'
+        },
+        stop: {
+          type: 'string',
+          description: 'New stop time (ISO 8601 format)'
+        },
+        duration: {
+          type: 'number',
+          description: 'New duration in seconds'
+        }
+      },
+      required: ['time_entry_id', 'workspace_id']
     },
   },
   {
@@ -499,7 +554,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           args?.description as string | undefined,
           args?.project_id as number | undefined,
           args?.task_id as number | undefined,
-          args?.tags as string[] | undefined
+          args?.tags as string[] | undefined,
+          args?.billable as boolean | undefined
         );
         
         await ensureCache();
@@ -549,6 +605,40 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
       
+      case 'toggl_update_entry': {
+        const workspaceId = args?.workspace_id as number;
+        const timeEntryId = args?.time_entry_id as number;
+        if (!workspaceId || !timeEntryId) {
+          throw new Error('Both workspace_id and time_entry_id are required');
+        }
+
+        const updates: Record<string, any> = {};
+        if (args?.description !== undefined) updates.description = args.description;
+        if (args?.project_id !== undefined) updates.project_id = args.project_id;
+        if (args?.task_id !== undefined) updates.task_id = args.task_id;
+        if (args?.billable !== undefined) updates.billable = args.billable;
+        if (args?.tags !== undefined) updates.tags = args.tags;
+        if (args?.start !== undefined) updates.start = args.start;
+        if (args?.stop !== undefined) updates.stop = args.stop;
+        if (args?.duration !== undefined) updates.duration = args.duration;
+
+        const updated = await api.updateTimeEntry(workspaceId, timeEntryId, updates);
+
+        await ensureCache();
+        const hydrated = await cache.hydrateTimeEntries([updated]);
+
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              success: true,
+              message: 'Time entry updated',
+              entry: hydrated[0]
+            }, null, 2)
+          }]
+        };
+      }
+
       // Reporting tools
       case 'toggl_daily_report': {
         await ensureCache();

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -205,16 +205,17 @@ export class TogglAPI {
     await this.request<void>('DELETE', `/workspaces/${workspaceId}/time_entries/${timeEntryId}`);
   }
   
-  async startTimer(workspaceId: number, description?: string, projectId?: number, taskId?: number, tags?: string[]): Promise<TimeEntry> {
+  async startTimer(workspaceId: number, description?: string, projectId?: number, taskId?: number, tags?: string[], billable?: boolean): Promise<TimeEntry> {
     const entry: Partial<CreateTimeEntryRequest> = {
       description,
       project_id: projectId,
       task_id: taskId,
       tags,
+      billable,
       start: new Date().toISOString(),
       duration: -1 // Negative duration indicates running timer
     };
-    
+
     return this.createTimeEntry(workspaceId, entry);
   }
   


### PR DESCRIPTION
## Summary

- Add `billable` parameter to `toggl_start_timer` tool, passing it through to `startTimer()` and `createTimeEntry()`
- Add new `toggl_update_entry` tool that exposes the existing `updateTimeEntry()` API method for modifying time entries (billable status, description, project, tags, start/stop times, duration)

The underlying Toggl API v9 and the TypeScript types (`CreateTimeEntryRequest`, `UpdateTimeEntryRequest`) already supported both features — they were just not wired up to MCP tool schemas.

## Motivation

AI agents managing time tracking need to:
1. Start billable timers directly (instead of relying on project defaults)
2. Correct time entries after the fact (e.g. mark as billable, fix descriptions, reassign projects)

Without these tools, users must manually open Toggl to make corrections, which defeats the purpose of MCP-based automation.

Closes #7

## Changes

| File | Change |
|---|---|
| `src/toggl-api.ts` | Add `billable` parameter to `startTimer()` |
| `src/index.ts` | Add `billable` to `toggl_start_timer` schema, add `toggl_update_entry` tool definition + handler |

No changes to types, cache, utils, or existing tool behavior. Fully backward compatible.

## Test plan

- [ ] `toggl_start_timer` with `billable: true` creates a billable entry
- [ ] `toggl_start_timer` without `billable` preserves existing behavior (uses project default)
- [ ] `toggl_update_entry` can toggle `billable` on an existing entry
- [ ] `toggl_update_entry` can modify description, project_id, tags, start/stop/duration
- [ ] `toggl_update_entry` returns hydrated entry with project/workspace names