### PR TITLE
feat: add first-class tag management tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,44 @@ List projects in a workspace.
 #### `toggl_list_clients`
 List clients in a workspace.
 
+### Tag Management
+
+#### `toggl_list_tags`
+List all tags in a workspace.
+```json
+{
+  "workspace_id": 123456
+}
+```
+
+#### `toggl_create_tag`
+Create a new tag.
+```json
+{
+  "name": "billable",
+  "workspace_id": 123456
+}
+```
+
+#### `toggl_update_tag`
+Rename an existing tag.
+```json
+{
+  "tag_id": 789,
+  "name": "new-name",
+  "workspace_id": 123456
+}
+```
+
+#### `toggl_delete_tag`
+Delete a tag from a workspace.
+```json
+{
+  "tag_id": 789,
+  "workspace_id": 123456
+}
+```
+
 ### Cache Management
 
 #### `toggl_warm_cache`

--- a/src/cache-manager.ts
+++ b/src/cache-manager.ts
@@ -237,19 +237,12 @@ export class CacheManager {
   async getTag(id: number, workspaceId: number): Promise<Tag | null> {
     const cached = this.getCached(this.tags, id);
     if (cached) return cached;
-    
+
     if (!this.api) return null;
-    
-    try {
-      const tag = await this.api.getTag(workspaceId, id);
-      if (tag) {
-        this.setCached(this.tags, id, tag);
-      }
-      return tag;
-    } catch (error) {
-      console.error(`Failed to fetch tag ${id}:`, error);
-      return null;
-    }
+
+    // Fetch all tags for the workspace (populates cache) and find by ID
+    const tags = await this.getTags(workspaceId);
+    return tags.find(t => t.id === id) || null;
   }
   
   async getTags(workspaceId: number): Promise<Tag[]> {

--- a/src/cache-manager.ts
+++ b/src/cache-manager.ts
@@ -377,7 +377,23 @@ export class CacheManager {
     
     return hydrated;
   }
-  
+
+  // Invalidate a single tag from cache
+  invalidateTag(tagId: number): void {
+    this.tags.delete(tagId);
+  }
+
+  // Invalidate all tags for a workspace (used after create/update/delete)
+  invalidateTagsForWorkspace(workspaceId: number): void {
+    const toDelete: number[] = [];
+    this.tags.forEach((entry, key) => {
+      if (entry.data.workspace_id === workspaceId) {
+        toDelete.push(key);
+      }
+    });
+    toDelete.forEach(key => this.tags.delete(key));
+  }
+
   // Clear cache
   clearCache(): void {
     this.workspaces.clear();

--- a/src/index.ts
+++ b/src/index.ts
@@ -335,6 +335,77 @@ const tools: Tool[] = [
     },
   },
   {
+    name: 'toggl_list_tags',
+    description: 'List tags for a workspace',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        workspace_id: {
+          type: 'number',
+          description: 'Workspace ID (uses default if not provided)'
+        }
+      }
+    },
+  },
+  {
+    name: 'toggl_create_tag',
+    description: 'Create a new tag in a workspace',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          description: 'Tag name'
+        },
+        workspace_id: {
+          type: 'number',
+          description: 'Workspace ID (uses default if not provided)'
+        }
+      },
+      required: ['name']
+    },
+  },
+  {
+    name: 'toggl_update_tag',
+    description: 'Rename an existing tag',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tag_id: {
+          type: 'number',
+          description: 'Tag ID to update'
+        },
+        name: {
+          type: 'string',
+          description: 'New tag name'
+        },
+        workspace_id: {
+          type: 'number',
+          description: 'Workspace ID (uses default if not provided)'
+        }
+      },
+      required: ['tag_id', 'name']
+    },
+  },
+  {
+    name: 'toggl_delete_tag',
+    description: 'Delete a tag from a workspace',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tag_id: {
+          type: 'number',
+          description: 'Tag ID to delete'
+        },
+        workspace_id: {
+          type: 'number',
+          description: 'Workspace ID (uses default if not provided)'
+        }
+      },
+      required: ['tag_id']
+    },
+  },
+  {
     name: 'toggl_list_clients',
     description: 'List clients for a workspace',
     inputSchema: {
@@ -746,6 +817,101 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
       
+      case 'toggl_list_tags': {
+        const workspaceId = args?.workspace_id || defaultWorkspaceId;
+        if (!workspaceId) {
+          throw new Error('Workspace ID required (set TOGGL_DEFAULT_WORKSPACE_ID or provide workspace_id)');
+        }
+
+        const tags = await api.getTags(workspaceId as number);
+
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              workspace_id: workspaceId,
+              count: tags.length,
+              tags: tags.map(t => ({
+                id: t.id,
+                name: t.name
+              }))
+            }, null, 2)
+          }]
+        };
+      }
+
+      case 'toggl_create_tag': {
+        const workspaceId = args?.workspace_id || defaultWorkspaceId;
+        if (!workspaceId) {
+          throw new Error('Workspace ID required (set TOGGL_DEFAULT_WORKSPACE_ID or provide workspace_id)');
+        }
+        if (!args?.name) {
+          throw new Error('Tag name is required');
+        }
+
+        const tag = await api.createTag(workspaceId as number, args.name as string);
+        cache.invalidateTagsForWorkspace(workspaceId as number);
+
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              success: true,
+              message: 'Tag created',
+              tag: { id: tag.id, name: tag.name, workspace_id: tag.workspace_id }
+            }, null, 2)
+          }]
+        };
+      }
+
+      case 'toggl_update_tag': {
+        const workspaceId = args?.workspace_id || defaultWorkspaceId;
+        if (!workspaceId) {
+          throw new Error('Workspace ID required (set TOGGL_DEFAULT_WORKSPACE_ID or provide workspace_id)');
+        }
+        if (!args?.tag_id || !args?.name) {
+          throw new Error('Tag ID and new name are required');
+        }
+
+        const tag = await api.updateTag(workspaceId as number, args.tag_id as number, args.name as string);
+        cache.invalidateTag(args.tag_id as number);
+
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              success: true,
+              message: 'Tag updated',
+              tag: { id: tag.id, name: tag.name, workspace_id: tag.workspace_id }
+            }, null, 2)
+          }]
+        };
+      }
+
+      case 'toggl_delete_tag': {
+        const workspaceId = args?.workspace_id || defaultWorkspaceId;
+        if (!workspaceId) {
+          throw new Error('Workspace ID required (set TOGGL_DEFAULT_WORKSPACE_ID or provide workspace_id)');
+        }
+        if (!args?.tag_id) {
+          throw new Error('Tag ID is required');
+        }
+
+        await api.deleteTag(workspaceId as number, args.tag_id as number);
+        cache.invalidateTag(args.tag_id as number);
+
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              success: true,
+              message: 'Tag deleted',
+              tag_id: args.tag_id
+            }, null, 2)
+          }]
+        };
+      }
+
       case 'toggl_list_clients': {
         const workspaceId = args?.workspace_id || defaultWorkspaceId;
         if (!workspaceId) {

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -157,7 +157,19 @@ export class TogglAPI {
   async getTag(workspaceId: number, tagId: number): Promise<Tag> {
     return this.request<Tag>('GET', `/workspaces/${workspaceId}/tags/${tagId}`);
   }
-  
+
+  async createTag(workspaceId: number, name: string): Promise<Tag> {
+    return this.request<Tag>('POST', `/workspaces/${workspaceId}/tags`, { name });
+  }
+
+  async updateTag(workspaceId: number, tagId: number, name: string): Promise<Tag> {
+    return this.request<Tag>('PUT', `/workspaces/${workspaceId}/tags/${tagId}`, { name });
+  }
+
+  async deleteTag(workspaceId: number, tagId: number): Promise<void> {
+    await this.request<void>('DELETE', `/workspaces/${workspaceId}/tags/${tagId}`);
+  }
+
   // Time entry methods
   async getTimeEntries(params?: TimeEntriesRequest): Promise<TimeEntry[]> {
     let endpoint = '/me/time_entries';

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -154,10 +154,6 @@ export class TogglAPI {
     return this.request<Tag[]>('GET', `/workspaces/${workspaceId}/tags`);
   }
   
-  async getTag(workspaceId: number, tagId: number): Promise<Tag> {
-    return this.request<Tag>('GET', `/workspaces/${workspaceId}/tags/${tagId}`);
-  }
-
   async createTag(workspaceId: number, name: string): Promise<Tag> {
     return this.request<Tag>('POST', `/workspaces/${workspaceId}/tags`, { name });
   }


### PR DESCRIPTION
## Summary
- Add 4 new MCP tools: `toggl_list_tags`, `toggl_create_tag`, `toggl_update_tag`, `toggl_delete_tag`
- Add `createTag`, `updateTag`, `deleteTag` methods to the Toggl API client
- Add tag cache invalidation on mutations (`invalidateTag`, `invalidateTagsForWorkspace`)
- Fix: remove `getTag` single-item endpoint (`GET /tags/{id}`) which doesn't exist in the Toggl v9 API and caused repeated 405 errors during time entry hydration
- `CacheManager.getTag()` now uses bulk `getTags()` to fetch and cache all workspace tags at once

## Test plan
- [ ] Verify `toggl_list_tags` returns tags for a workspace
- [ ] Verify `toggl_create_tag` creates a tag and invalidates cache
- [ ] Verify `toggl_update_tag` renames a tag
- [ ] Verify `toggl_delete_tag` removes a tag
- [ ] Verify time entry hydration resolves tag names without 405 errors
- [ ] Verify existing tools (time entries, reports) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)