### PR TITLE
feat: add dashboard-parity filters via Reports API v3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+- Added `toggl_search_time_entries` tool backed by Reports API v3 `POST /reports/api/v3/workspace/{workspace_id}/search/time_entries`, exposing the full Toggl dashboard filter set: `client_ids`, `project_ids`, `task_ids`, `tag_ids`, `user_ids`, `group_ids`, `time_entry_ids`, `description`, `billable`, `min_duration_seconds`, `max_duration_seconds`, `order_by`, `order_dir`, `grouped`, `rounding`, `rounding_minutes`. Auto-paginates via `X-Next-ID` / `X-Next-Row-Number` and expands grouped rows into flat hydrated entries.
+- Extended `toggl_get_time_entries` with client-side post-filters: `description`, `billable`, `user_ids`, `tags` (with `tags_all` for AND semantics), `min_duration_seconds`, `max_duration_seconds`.
+- Added `TimeEntrySearchFilters` and `ReportsSearchRow` types; added `TogglAPI.searchTimeEntries` / `searchTimeEntriesPage` with 429 handling and premium-feature (402) error normalization.
+
 ## 1.0.0 - 2025-09-06
 - Initial public release
 - Added npx usage documentation for Claude Desktop and Cursor

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Dashboard-parity search backed by **Toggl Reports API v3**. Per-workspace, auto-
 }
 ```
 Notes:
-- `billable` is a premium feature; Free-plan workspaces will surface a 402 error.
+- `billable` is a premium feature; Free plan workspaces will surface a 402 error.
 - Date range is required (either `start_date`+`end_date` or a `period`).
 - Pagination is automatic via `X-Next-ID` / `X-Next-Row-Number`; cap traversal with `max_pages`.
 

--- a/README.md
+++ b/README.md
@@ -118,14 +118,52 @@ Edit `.mcp.json` in your project:
 ### Time Tracking
 
 #### `toggl_get_time_entries`
-Get time entries with optional filters.
+Get time entries via `/me/time_entries` with optional client-side filters. Best for small date ranges; for dashboard-parity filtering prefer `toggl_search_time_entries`.
 ```json
 {
-  "period": "today",  // or: yesterday, week, lastWeek, month, lastMonth
+  "period": "today",
   "workspace_id": 123456,
-  "project_id": 789012
+  "project_id": 789012,
+  "description": "review",
+  "billable": true,
+  "tags": ["deep-work", "client-x"],
+  "tags_all": false,
+  "user_ids": [42],
+  "min_duration_seconds": 60,
+  "max_duration_seconds": 14400
 }
 ```
+
+#### `toggl_search_time_entries`
+Dashboard-parity search backed by **Toggl Reports API v3**. Per-workspace, auto-paginates, and expands grouped rows into flat hydrated entries. Supports every filter exposed by the Toggl dashboard: clients, projects, tasks, tags, users, team groups, description text search, billable, duration bounds, ordering, grouping, and workspace rounding. Use `[null]` in any id-array filter to match entries with no value for that field (e.g. entries with no project).
+```json
+{
+  "workspace_id": 123456,
+  "start_date": "2024-09-01",
+  "end_date": "2024-09-30",
+  "client_ids": [9001],
+  "project_ids": [789012, null],
+  "task_ids": [],
+  "tag_ids": [111, 222],
+  "user_ids": [42],
+  "group_ids": [],
+  "description": "migration",
+  "billable": true,
+  "min_duration_seconds": 300,
+  "max_duration_seconds": 28800,
+  "order_by": "duration",
+  "order_dir": "DESC",
+  "grouped": false,
+  "rounding": 1,
+  "rounding_minutes": 15,
+  "page_size": 50,
+  "max_pages": 20
+}
+```
+Notes:
+- `billable` is a premium feature; Free-plan workspaces will surface a 402 error.
+- Date range is required (either `start_date`+`end_date` or a `period`).
+- Pagination is automatic via `X-Next-ID` / `X-Next-Row-Number`; cap traversal with `max_pages`.
 
 #### `toggl_get_current_entry`
 Get the currently running timer.

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,8 @@ import {
   groupEntriesByProject,
   groupEntriesByWorkspace,
   generateProjectSummary,
-  generateWorkspaceSummary
+  generateWorkspaceSummary,
+  effectiveDurationSeconds
 } from './utils.js';
 import type {
   CacheConfig,
@@ -187,7 +188,7 @@ const tools: Tool[] = [
         },
         start_date: { type: 'string', description: 'Start date YYYY-MM-DD (required unless period is given)' },
         end_date: { type: 'string', description: 'End date YYYY-MM-DD' },
-        user_ids: { type: 'array', items: { type: ['number', 'null'] }, description: 'User IDs. Use [null] to match entries with no user.' },
+        user_ids: { type: 'array', items: { type: 'number' }, description: 'User IDs. Unlike client/project/task/tag filters, Reports API does not accept [null] here — every entry has an owner.' },
         project_ids: { type: 'array', items: { type: ['number', 'null'] }, description: 'Project IDs. Use [null] to match entries with no project.' },
         client_ids: { type: 'array', items: { type: ['number', 'null'] }, description: 'Client IDs. Use [null] to match entries with no client.' },
         task_ids: { type: 'array', items: { type: ['number', 'null'] }, description: 'Task IDs. Use [null] to match entries with no task.' },
@@ -485,13 +486,16 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           const ids = new Set(args!.user_ids as number[]);
           entries = entries.filter(e => e.user_id !== undefined && ids.has(e.user_id));
         }
+        // For running timers `duration` encodes a negative start sentinel,
+        // so compare against the effective elapsed seconds instead of
+        // `Math.abs(duration)` (which would explode into a Unix timestamp).
         if (typeof args?.min_duration_seconds === 'number') {
           const min = args!.min_duration_seconds as number;
-          entries = entries.filter(e => Math.abs(e.duration) >= min);
+          entries = entries.filter(e => effectiveDurationSeconds(e) >= min);
         }
         if (typeof args?.max_duration_seconds === 'number') {
           const max = args!.max_duration_seconds as number;
-          entries = entries.filter(e => Math.abs(e.duration) <= max);
+          entries = entries.filter(e => effectiveDurationSeconds(e) <= max);
         }
         if (typeof args?.description === 'string' && (args!.description as string).length > 0) {
           const needle = (args!.description as string).toLowerCase();
@@ -542,7 +546,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const filters: TimeEntrySearchFilters = {
           start_date: startDate,
           end_date: endDate,
-          user_ids: args?.user_ids as (number | null)[] | undefined,
+          user_ids: args?.user_ids as number[] | undefined,
           project_ids: args?.project_ids as (number | null)[] | undefined,
           client_ids: args?.client_ids as (number | null)[] | undefined,
           task_ids: args?.task_ids as (number | null)[] | undefined,

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,8 @@ import {
 } from './utils.js';
 import type {
   CacheConfig,
-  TimeEntry
+  TimeEntry,
+  TimeEntrySearchFilters
 } from './types.js';
 
 // Version for CLI output and server metadata
@@ -148,7 +149,7 @@ const tools: Tool[] = [
   // Time tracking tools
   {
     name: 'toggl_get_time_entries',
-    description: 'Get time entries with optional date range filters. Returns hydrated entries with project/workspace names.',
+    description: 'Get time entries via /me/time_entries with optional client-side filters. Fast for small date ranges. For dashboard-parity filtering (clients, tasks, tags, users, billable, duration bounds, etc.) prefer toggl_search_time_entries.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -157,22 +158,53 @@ const tools: Tool[] = [
           enum: ['today', 'yesterday', 'week', 'lastWeek', 'month', 'lastMonth'],
           description: 'Predefined period to fetch entries for'
         },
-        start_date: {
+        start_date: { type: 'string', description: 'Start date (YYYY-MM-DD format)' },
+        end_date: { type: 'string', description: 'End date (YYYY-MM-DD format)' },
+        workspace_id: { type: 'number', description: 'Filter by workspace ID' },
+        project_id: { type: 'number', description: 'Filter by project ID' },
+        // Post-filter additions (applied after fetch, on hydrated entries).
+        description: { type: 'string', description: 'Case-insensitive substring match on entry description' },
+        billable: { type: 'boolean', description: 'Filter by billable status' },
+        user_ids: { type: 'array', items: { type: 'number' }, description: 'Filter by user IDs (client-side post-filter)' },
+        tags: { type: 'array', items: { type: 'string' }, description: 'Filter by tag names (matches entries containing ANY of the given tags)' },
+        tags_all: { type: 'boolean', description: 'If true, require ALL given tags instead of ANY (default: false)' },
+        min_duration_seconds: { type: 'number', description: 'Minimum duration in seconds' },
+        max_duration_seconds: { type: 'number', description: 'Maximum duration in seconds' }
+      }
+    },
+  },
+  {
+    name: 'toggl_search_time_entries',
+    description: 'Search time entries via Toggl Reports API v3 with full dashboard-parity filters. Per-workspace. Auto-paginates. Returns flat hydrated entries.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        workspace_id: { type: 'number', description: 'Workspace ID (uses default if not provided)' },
+        period: {
           type: 'string',
-          description: 'Start date (YYYY-MM-DD format)'
+          enum: ['today', 'yesterday', 'week', 'lastWeek', 'month', 'lastMonth'],
+          description: 'Predefined period (sets start_date/end_date if those are not provided)'
         },
-        end_date: {
-          type: 'string',
-          description: 'End date (YYYY-MM-DD format)'
-        },
-        workspace_id: {
-          type: 'number',
-          description: 'Filter by workspace ID'
-        },
-        project_id: {
-          type: 'number',
-          description: 'Filter by project ID'
-        }
+        start_date: { type: 'string', description: 'Start date YYYY-MM-DD (required unless period is given)' },
+        end_date: { type: 'string', description: 'End date YYYY-MM-DD' },
+        user_ids: { type: 'array', items: { type: ['number', 'null'] }, description: 'User IDs. Use [null] to match entries with no user.' },
+        project_ids: { type: 'array', items: { type: ['number', 'null'] }, description: 'Project IDs. Use [null] to match entries with no project.' },
+        client_ids: { type: 'array', items: { type: ['number', 'null'] }, description: 'Client IDs. Use [null] to match entries with no client.' },
+        task_ids: { type: 'array', items: { type: ['number', 'null'] }, description: 'Task IDs. Use [null] to match entries with no task.' },
+        tag_ids: { type: 'array', items: { type: ['number', 'null'] }, description: 'Tag IDs. Use [null] to match entries with no tags.' },
+        group_ids: { type: 'array', items: { type: 'number' }, description: 'Team group IDs' },
+        time_entry_ids: { type: 'array', items: { type: 'number' }, description: 'Specific time entry IDs' },
+        description: { type: 'string', description: 'Text search on entry description' },
+        billable: { type: 'boolean', description: 'Billable filter (premium feature — may return 402 on Free plan)' },
+        min_duration_seconds: { type: 'number' },
+        max_duration_seconds: { type: 'number' },
+        order_by: { type: 'string', enum: ['date', 'user', 'duration', 'description', 'last_update'] },
+        order_dir: { type: 'string', enum: ['ASC', 'DESC'] },
+        grouped: { type: 'boolean' },
+        rounding: { type: 'number', description: 'Rounding mode' },
+        rounding_minutes: { type: 'number', enum: [0, 1, 5, 6, 10, 12, 15, 30, 60, 240] },
+        page_size: { type: 'number', description: 'Items per page (default: 50)' },
+        max_pages: { type: 'number', description: 'Max pages to auto-paginate (default: 20)' }
       }
     },
   },
@@ -423,9 +455,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       // Time tracking tools
       case 'toggl_get_time_entries': {
         await ensureCache();
-        
+
         let entries: TimeEntry[];
-        
+
         if (args?.period) {
           const range = getDateRange(args.period as any);
           entries = await api.getTimeEntriesForDateRange(range.start, range.end);
@@ -436,7 +468,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         } else {
           entries = await api.getTimeEntriesForToday();
         }
-        
+
         // Filter by workspace/project if specified
         if (args?.workspace_id) {
           entries = entries.filter(e => e.workspace_id === args.workspace_id);
@@ -444,16 +476,108 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         if (args?.project_id) {
           entries = entries.filter(e => e.project_id === args.project_id);
         }
-        
+
+        // Extended post-filters — applied before hydration where possible.
+        if (typeof args?.billable === 'boolean') {
+          entries = entries.filter(e => e.billable === args.billable);
+        }
+        if (Array.isArray(args?.user_ids) && (args!.user_ids as number[]).length > 0) {
+          const ids = new Set(args!.user_ids as number[]);
+          entries = entries.filter(e => e.user_id !== undefined && ids.has(e.user_id));
+        }
+        if (typeof args?.min_duration_seconds === 'number') {
+          const min = args!.min_duration_seconds as number;
+          entries = entries.filter(e => Math.abs(e.duration) >= min);
+        }
+        if (typeof args?.max_duration_seconds === 'number') {
+          const max = args!.max_duration_seconds as number;
+          entries = entries.filter(e => Math.abs(e.duration) <= max);
+        }
+        if (typeof args?.description === 'string' && (args!.description as string).length > 0) {
+          const needle = (args!.description as string).toLowerCase();
+          entries = entries.filter(e => (e.description || '').toLowerCase().includes(needle));
+        }
+        if (Array.isArray(args?.tags) && (args!.tags as string[]).length > 0) {
+          const wanted = args!.tags as string[];
+          const all = Boolean(args?.tags_all);
+          entries = entries.filter(e => {
+            const have = e.tags || [];
+            return all ? wanted.every(t => have.includes(t)) : wanted.some(t => have.includes(t));
+          });
+        }
+
         // Hydrate with names
         const hydrated = await cache.hydrateTimeEntries(entries);
-        
+
         return {
           content: [{
             type: 'text',
-            text: JSON.stringify({ 
+            text: JSON.stringify({
               count: hydrated.length,
-              entries: hydrated 
+              entries: hydrated
+            }, null, 2)
+          }]
+        };
+      }
+
+      case 'toggl_search_time_entries': {
+        const workspaceId = (args?.workspace_id as number | undefined) || defaultWorkspaceId;
+        if (!workspaceId) {
+          throw new Error('Workspace ID required (set TOGGL_DEFAULT_WORKSPACE_ID or provide workspace_id)');
+        }
+        await ensureCache();
+
+        // Resolve date range: explicit start/end > period > default (this week)
+        let startDate: string | undefined = args?.start_date as string | undefined;
+        let endDate: string | undefined = args?.end_date as string | undefined;
+        if (!startDate && !endDate && args?.period) {
+          const range = getDateRange(args.period as any);
+          startDate = range.start.toISOString().split('T')[0];
+          endDate = range.end.toISOString().split('T')[0];
+        }
+        if (!startDate || !endDate) {
+          throw new Error('Reports API requires both start_date and end_date (or a period).');
+        }
+
+        const filters: TimeEntrySearchFilters = {
+          start_date: startDate,
+          end_date: endDate,
+          user_ids: args?.user_ids as (number | null)[] | undefined,
+          project_ids: args?.project_ids as (number | null)[] | undefined,
+          client_ids: args?.client_ids as (number | null)[] | undefined,
+          task_ids: args?.task_ids as (number | null)[] | undefined,
+          tag_ids: args?.tag_ids as (number | null)[] | undefined,
+          group_ids: args?.group_ids as number[] | undefined,
+          time_entry_ids: args?.time_entry_ids as number[] | undefined,
+          description: args?.description as string | undefined,
+          billable: args?.billable as boolean | undefined,
+          min_duration_seconds: args?.min_duration_seconds as number | undefined,
+          max_duration_seconds: args?.max_duration_seconds as number | undefined,
+          order_by: args?.order_by as TimeEntrySearchFilters['order_by'],
+          order_dir: args?.order_dir as TimeEntrySearchFilters['order_dir'],
+          grouped: args?.grouped as boolean | undefined,
+          rounding: args?.rounding as number | undefined,
+          rounding_minutes: args?.rounding_minutes as number | undefined,
+          page_size: args?.page_size as number | undefined,
+        };
+        // Strip undefined keys so Reports API doesn't see nulls where we mean "unset".
+        for (const k of Object.keys(filters) as (keyof TimeEntrySearchFilters)[]) {
+          if (filters[k] === undefined) delete filters[k];
+        }
+
+        const entries = await api.searchTimeEntries(workspaceId as number, filters, {
+          maxPages: (args?.max_pages as number | undefined) ?? 20,
+        });
+        const hydrated = await cache.hydrateTimeEntries(entries);
+
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              workspace_id: workspaceId,
+              count: hydrated.length,
+              filters,
+              entries: hydrated,
             }, null, 2)
           }]
         };

--- a/src/index.ts
+++ b/src/index.ts
@@ -567,10 +567,6 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           rounding_minutes: args?.rounding_minutes as number | undefined,
           page_size: args?.page_size as number | undefined,
         };
-        // Strip undefined keys so Reports API doesn't see nulls where we mean "unset".
-        for (const k of Object.keys(filters) as (keyof TimeEntrySearchFilters)[]) {
-          if (filters[k] === undefined) delete filters[k];
-        }
 
         const entries = await api.searchTimeEntries(workspaceId as number, filters, {
           maxPages: (args?.max_pages as number | undefined) ?? 20,

--- a/src/index.ts
+++ b/src/index.ts
@@ -532,14 +532,15 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         }
         await ensureCache();
 
-        // Explicit start/end wins; otherwise derive from `period`. Reports
-        // API requires a date range, so we reject if neither is provided.
+        // Explicit start/end wins, but when `period` is supplied we use it
+        // to fill in whichever boundary is missing. Reports API requires a
+        // full date range, so we reject if we still cannot determine both.
         let startDate: string | undefined = args?.start_date as string | undefined;
         let endDate: string | undefined = args?.end_date as string | undefined;
-        if (!startDate && !endDate && args?.period) {
+        if (args?.period && (!startDate || !endDate)) {
           const range = getDateRange(args.period as any);
-          startDate = range.start.toISOString().split('T')[0];
-          endDate = range.end.toISOString().split('T')[0];
+          startDate = startDate ?? range.start.toISOString().split('T')[0];
+          endDate = endDate ?? range.end.toISOString().split('T')[0];
         }
         if (!startDate || !endDate) {
           throw new Error('Reports API requires both start_date and end_date (or a period).');

--- a/src/index.ts
+++ b/src/index.ts
@@ -470,44 +470,45 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           entries = await api.getTimeEntriesForToday();
         }
 
-        // Filter by workspace/project if specified
+        // Build a single predicate list so we walk the array once. `duration`
+        // is compared via `effectiveDurationSeconds` because running timers
+        // encode a negative start-time sentinel, not elapsed seconds.
+        const predicates: Array<(e: TimeEntry) => boolean> = [];
         if (args?.workspace_id) {
-          entries = entries.filter(e => e.workspace_id === args.workspace_id);
+          predicates.push(e => e.workspace_id === args.workspace_id);
         }
         if (args?.project_id) {
-          entries = entries.filter(e => e.project_id === args.project_id);
+          predicates.push(e => e.project_id === args.project_id);
         }
-
-        // Extended post-filters — applied before hydration where possible.
         if (typeof args?.billable === 'boolean') {
-          entries = entries.filter(e => e.billable === args.billable);
+          predicates.push(e => e.billable === args.billable);
         }
-        if (Array.isArray(args?.user_ids) && (args!.user_ids as number[]).length > 0) {
-          const ids = new Set(args!.user_ids as number[]);
-          entries = entries.filter(e => e.user_id !== undefined && ids.has(e.user_id));
+        if (Array.isArray(args?.user_ids) && (args.user_ids as number[]).length > 0) {
+          const ids = new Set(args.user_ids as number[]);
+          predicates.push(e => e.user_id !== undefined && ids.has(e.user_id));
         }
-        // For running timers `duration` encodes a negative start sentinel,
-        // so compare against the effective elapsed seconds instead of
-        // `Math.abs(duration)` (which would explode into a Unix timestamp).
         if (typeof args?.min_duration_seconds === 'number') {
-          const min = args!.min_duration_seconds as number;
-          entries = entries.filter(e => effectiveDurationSeconds(e) >= min);
+          const min = args.min_duration_seconds;
+          predicates.push(e => effectiveDurationSeconds(e) >= min);
         }
         if (typeof args?.max_duration_seconds === 'number') {
-          const max = args!.max_duration_seconds as number;
-          entries = entries.filter(e => effectiveDurationSeconds(e) <= max);
+          const max = args.max_duration_seconds;
+          predicates.push(e => effectiveDurationSeconds(e) <= max);
         }
-        if (typeof args?.description === 'string' && (args!.description as string).length > 0) {
-          const needle = (args!.description as string).toLowerCase();
-          entries = entries.filter(e => (e.description || '').toLowerCase().includes(needle));
+        if (typeof args?.description === 'string' && args.description.length > 0) {
+          const needle = (args.description as string).toLowerCase();
+          predicates.push(e => (e.description || '').toLowerCase().includes(needle));
         }
-        if (Array.isArray(args?.tags) && (args!.tags as string[]).length > 0) {
-          const wanted = args!.tags as string[];
-          const all = Boolean(args?.tags_all);
-          entries = entries.filter(e => {
+        if (Array.isArray(args?.tags) && (args.tags as string[]).length > 0) {
+          const wanted = args.tags as string[];
+          const all = Boolean(args.tags_all);
+          predicates.push(e => {
             const have = e.tags || [];
             return all ? wanted.every(t => have.includes(t)) : wanted.some(t => have.includes(t));
           });
+        }
+        if (predicates.length > 0) {
+          entries = entries.filter(e => predicates.every(p => p(e)));
         }
 
         // Hydrate with names
@@ -531,7 +532,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         }
         await ensureCache();
 
-        // Resolve date range: explicit start/end > period > default (this week)
+        // Explicit start/end wins; otherwise derive from `period`. Reports
+        // API requires a date range, so we reject if neither is provided.
         let startDate: string | undefined = args?.start_date as string | undefined;
         let endDate: string | undefined = args?.end_date as string | undefined;
         if (!startDate && !endDate && args?.period) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -163,7 +163,7 @@ const tools: Tool[] = [
         end_date: { type: 'string', description: 'End date (YYYY-MM-DD format)' },
         workspace_id: { type: 'number', description: 'Filter by workspace ID' },
         project_id: { type: 'number', description: 'Filter by project ID' },
-        // Post-filter additions (applied after fetch, on hydrated entries).
+        // Post-filter additions (applied client-side after fetch, before hydration).
         description: { type: 'string', description: 'Case-insensitive substring match on entry description' },
         billable: { type: 'boolean', description: 'Filter by billable status' },
         user_ids: { type: 'array', items: { type: 'number' }, description: 'Filter by user IDs (client-side post-filter)' },

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -284,12 +284,28 @@ export class TogglAPI {
     const body = JSON.stringify(filters);
     // 402 from the Reports API is issued both for genuinely premium-gated
     // features (e.g. the `billable` filter on a Free workspace) AND as a
-    // transient server-side glitch that clears on retry. Retry once; if it
-    // still 402s, surface a message that covers both possibilities.
-    const maxAttempts = 2;
+    // transient server-side glitch that clears on retry. A true 402 is not
+    // worth many retries (real premium gate, wasted latency), but transport
+    // failures and 429 rate limits need a larger budget — so they are
+    // tracked on separate counters.
+    const maxAttempts = 3;       // network/429 budget
+    const max402Retries = 1;     // 402-specific retry budget
+    let attempts402 = 0;
 
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      const response = await fetch(url, { method: 'POST', headers: this.headers, body });
+      // Only the transport fetch and JSON parse are wrapped so that
+      // deliberate HTTP-error throws below propagate out of the loop.
+      let response: Awaited<ReturnType<typeof fetch>>;
+      try {
+        response = await fetch(url, { method: 'POST', headers: this.headers, body });
+      } catch (error) {
+        if (attempt >= maxAttempts - 1) throw error;
+        const delay = (attempt + 1) * 1000;
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`Reports API request failed (attempt ${attempt + 1}/${maxAttempts}): ${message}. Retrying after ${delay}ms...`);
+        await new Promise(r => setTimeout(r, delay));
+        continue;
+      }
 
       if (response.status === 429) {
         const retryAfterRaw = response.headers.get('Retry-After');
@@ -300,8 +316,9 @@ export class TogglAPI {
         continue;
       }
 
-      if (response.status === 402 && attempt < maxAttempts - 1) {
-        console.error(`Reports API returned 402 (attempt ${attempt + 1}/${maxAttempts}); retrying after 500ms...`);
+      if (response.status === 402 && attempts402 < max402Retries) {
+        attempts402++;
+        console.error(`Reports API returned 402 (402 retry ${attempts402}/${max402Retries}); retrying after 500ms...`);
         await new Promise(r => setTimeout(r, 500));
         continue;
       }
@@ -319,7 +336,17 @@ export class TogglAPI {
         throw new Error(`Reports API error (${response.status}): ${text}`);
       }
 
-      const rows = (await response.json()) as ReportsSearchRow[];
+      let rows: ReportsSearchRow[];
+      try {
+        rows = (await response.json()) as ReportsSearchRow[];
+      } catch (error) {
+        if (attempt >= maxAttempts - 1) throw error;
+        const delay = (attempt + 1) * 1000;
+        const message = error instanceof Error ? error.message : String(error);
+        console.error(`Reports API response parse failed (attempt ${attempt + 1}/${maxAttempts}): ${message}. Retrying after ${delay}ms...`);
+        await new Promise(r => setTimeout(r, delay));
+        continue;
+      }
       const nextIdHeader = response.headers.get('X-Next-ID');
       const nextRowHeader = response.headers.get('X-Next-Row-Number');
       return {

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -11,6 +11,7 @@ import type {
   CreateTimeEntryRequest,
   UpdateTimeEntryRequest,
   TimeEntrySearchFilters,
+  ReportsSearchRequest,
   ReportsSearchRow
 } from './types.js';
 
@@ -271,62 +272,37 @@ export class TogglAPI {
     return this.getTimeEntriesForDateRange(firstDay, lastDay);
   }
   
-  // Reports API endpoints (if needed)
-  async getDetailedReport(workspaceId: number, params: any): Promise<any> {
-    // This would use the Reports API v3 if needed
-    // https://api.track.toggl.com/reports/api/v3/workspace/{workspace_id}/search/time_entries
-    const reportsUrl = `https://api.track.toggl.com/reports/api/v3/workspace/${workspaceId}/search/time_entries`;
-
-    const response = await fetch(reportsUrl, {
-      method: 'POST',
-      headers: this.headers,
-      body: JSON.stringify(params)
-    });
-
-    if (!response.ok) {
-      throw new Error(`Reports API error: ${response.status}`);
-    }
-
-    return response.json();
-  }
-
-  // Reports API v3 detailed search — one page.
-  // Returns rows plus next-page cursor from response headers.
   async searchTimeEntriesPage(
     workspaceId: number,
-    filters: TimeEntrySearchFilters
+    filters: ReportsSearchRequest
   ): Promise<{
     rows: ReportsSearchRow[];
     nextId?: number;
     nextRowNumber?: number;
   }> {
     const url = `https://api.track.toggl.com/reports/api/v3/workspace/${workspaceId}/search/time_entries`;
+    const body = JSON.stringify(filters);
+    // 402 from the Reports API is issued both for genuinely premium-gated
+    // features (e.g. the `billable` filter on a Free workspace) AND as a
+    // transient server-side glitch that clears on retry. Retry once; if it
+    // still 402s, surface a message that covers both possibilities.
+    const maxAttempts = 2;
 
-    const maxAttempts = 3;
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      const response = await fetch(url, {
-        method: 'POST',
-        headers: this.headers,
-        body: JSON.stringify(filters)
-      });
+      const response = await fetch(url, { method: 'POST', headers: this.headers, body });
 
       if (response.status === 429) {
-        const retryAfter = response.headers.get('Retry-After');
-        const delay = retryAfter ? parseInt(retryAfter) * 1000 : (attempt + 1) * 2000;
+        const retryAfterRaw = response.headers.get('Retry-After');
+        const retryAfter = retryAfterRaw ? Number.parseInt(retryAfterRaw, 10) : NaN;
+        const delay = Number.isFinite(retryAfter) ? retryAfter * 1000 : (attempt + 1) * 2000;
         console.error(`Reports API rate limited. Retrying after ${delay}ms...`);
         await new Promise(r => setTimeout(r, delay));
         continue;
       }
 
-      // 402 from Reports API is issued both for genuinely premium-gated
-      // features (e.g. the `billable` filter on a Free workspace) AND as a
-      // transient server-side glitch on otherwise valid requests. Retry with
-      // backoff; if it still 402s on the last attempt, surface a message that
-      // covers both possibilities.
       if (response.status === 402 && attempt < maxAttempts - 1) {
-        const delay = (attempt + 1) * 1000;
-        console.error(`Reports API returned 402 (attempt ${attempt + 1}/${maxAttempts}); retrying after ${delay}ms...`);
-        await new Promise(r => setTimeout(r, delay));
+        console.error(`Reports API returned 402 (attempt ${attempt + 1}/${maxAttempts}); retrying after 500ms...`);
+        await new Promise(r => setTimeout(r, 500));
         continue;
       }
 
@@ -334,7 +310,7 @@ export class TogglAPI {
         const text = await response.text();
         if (response.status === 402) {
           throw new Error(
-            `Reports API returned 402 for workspace ${workspaceId} after ${maxAttempts} attempts. ` +
+            `Reports API returned 402 for workspace ${workspaceId}. ` +
             `This can mean: (1) a filter you used requires a premium plan (e.g. 'billable'), or ` +
             `(2) a transient Toggl server-side glitch — retry in a moment. ` +
             `Server response: ${text}`
@@ -348,36 +324,25 @@ export class TogglAPI {
       const nextRowHeader = response.headers.get('X-Next-Row-Number');
       return {
         rows: rows || [],
-        nextId: nextIdHeader ? parseInt(nextIdHeader) : undefined,
-        nextRowNumber: nextRowHeader ? parseInt(nextRowHeader) : undefined,
+        nextId: nextIdHeader ? Number.parseInt(nextIdHeader, 10) : undefined,
+        nextRowNumber: nextRowHeader ? Number.parseInt(nextRowHeader, 10) : undefined,
       };
     }
 
     throw new Error('Reports API: max retries reached');
   }
 
-  // Reports API v3 detailed search — auto-paginates and returns flat TimeEntry[].
-  // Expands each returned row (description+project+user bucket) into one entry
-  // per nested time_entries element, merging row-level fields onto each entry.
   async searchTimeEntries(
     workspaceId: number,
     filters: TimeEntrySearchFilters,
     options: { maxPages?: number } = {}
   ): Promise<TimeEntry[]> {
     const maxPages = options.maxPages ?? 20;
-    const pageSize = filters.page_size ?? 50;
-
+    const payload: ReportsSearchRequest = { ...filters, page_size: filters.page_size ?? 50 };
     const entries: TimeEntry[] = [];
-    let cursor: { first_id?: number; first_row_number?: number } = {
-      first_id: filters.first_id,
-      first_row_number: filters.first_row_number,
-    };
 
     for (let page = 0; page < maxPages; page++) {
-      const { rows, nextId, nextRowNumber } = await this.searchTimeEntriesPage(
-        workspaceId,
-        { ...filters, page_size: pageSize, ...cursor }
-      );
+      const { rows, nextId, nextRowNumber } = await this.searchTimeEntriesPage(workspaceId, payload);
 
       for (const row of rows) {
         for (const te of row.time_entries) {
@@ -399,7 +364,8 @@ export class TogglAPI {
       }
 
       if (!nextId || !nextRowNumber) break;
-      cursor = { first_id: nextId, first_row_number: nextRowNumber };
+      payload.first_id = nextId;
+      payload.first_row_number = nextRowNumber;
     }
 
     return entries;

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -302,7 +302,8 @@ export class TogglAPI {
   }> {
     const url = `https://api.track.toggl.com/reports/api/v3/workspace/${workspaceId}/search/time_entries`;
 
-    for (let attempt = 0; attempt < 3; attempt++) {
+    const maxAttempts = 3;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
       const response = await fetch(url, {
         method: 'POST',
         headers: this.headers,
@@ -317,12 +318,26 @@ export class TogglAPI {
         continue;
       }
 
+      // 402 from Reports API is issued both for genuinely premium-gated
+      // features (e.g. the `billable` filter on a Free workspace) AND as a
+      // transient server-side glitch on otherwise valid requests. Retry with
+      // backoff; if it still 402s on the last attempt, surface a message that
+      // covers both possibilities.
+      if (response.status === 402 && attempt < maxAttempts - 1) {
+        const delay = (attempt + 1) * 1000;
+        console.error(`Reports API returned 402 (attempt ${attempt + 1}/${maxAttempts}); retrying after ${delay}ms...`);
+        await new Promise(r => setTimeout(r, delay));
+        continue;
+      }
+
       if (!response.ok) {
         const text = await response.text();
         if (response.status === 402) {
           throw new Error(
-            `Reports API feature not enabled for workspace ${workspaceId} (402). ` +
-            `The 'billable' filter and some advanced features require a premium plan.`
+            `Reports API returned 402 for workspace ${workspaceId} after ${maxAttempts} attempts. ` +
+            `This can mean: (1) a filter you used requires a premium plan (e.g. 'billable'), or ` +
+            `(2) a transient Toggl server-side glitch — retry in a moment. ` +
+            `Server response: ${text}`
           );
         }
         throw new Error(`Reports API error (${response.status}): ${text}`);

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -363,7 +363,14 @@ export class TogglAPI {
         }
       }
 
-      if (!nextId || !nextRowNumber) break;
+      // Use explicit undefined/NaN checks so a legitimate 0 cursor value
+      // (possible if Toggl ever uses it) is not mistaken for end-of-results.
+      if (
+        nextId === undefined || Number.isNaN(nextId) ||
+        nextRowNumber === undefined || Number.isNaN(nextRowNumber)
+      ) {
+        break;
+      }
       payload.first_id = nextId;
       payload.first_row_number = nextRowNumber;
     }

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -345,7 +345,7 @@ export class TogglAPI {
       const { rows, nextId, nextRowNumber } = await this.searchTimeEntriesPage(workspaceId, payload);
 
       for (const row of rows) {
-        for (const te of row.time_entries) {
+        for (const te of row.time_entries ?? []) {
           entries.push({
             id: te.id,
             workspace_id: workspaceId,

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -9,7 +9,9 @@ import type {
   TimeEntry,
   TimeEntriesRequest,
   CreateTimeEntryRequest,
-  UpdateTimeEntryRequest
+  UpdateTimeEntryRequest,
+  TimeEntrySearchFilters,
+  ReportsSearchRow
 } from './types.js';
 
 export class TogglAPI {
@@ -274,17 +276,117 @@ export class TogglAPI {
     // This would use the Reports API v3 if needed
     // https://api.track.toggl.com/reports/api/v3/workspace/{workspace_id}/search/time_entries
     const reportsUrl = `https://api.track.toggl.com/reports/api/v3/workspace/${workspaceId}/search/time_entries`;
-    
+
     const response = await fetch(reportsUrl, {
       method: 'POST',
       headers: this.headers,
       body: JSON.stringify(params)
     });
-    
+
     if (!response.ok) {
       throw new Error(`Reports API error: ${response.status}`);
     }
-    
+
     return response.json();
+  }
+
+  // Reports API v3 detailed search — one page.
+  // Returns rows plus next-page cursor from response headers.
+  async searchTimeEntriesPage(
+    workspaceId: number,
+    filters: TimeEntrySearchFilters
+  ): Promise<{
+    rows: ReportsSearchRow[];
+    nextId?: number;
+    nextRowNumber?: number;
+  }> {
+    const url = `https://api.track.toggl.com/reports/api/v3/workspace/${workspaceId}/search/time_entries`;
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: this.headers,
+        body: JSON.stringify(filters)
+      });
+
+      if (response.status === 429) {
+        const retryAfter = response.headers.get('Retry-After');
+        const delay = retryAfter ? parseInt(retryAfter) * 1000 : (attempt + 1) * 2000;
+        console.error(`Reports API rate limited. Retrying after ${delay}ms...`);
+        await new Promise(r => setTimeout(r, delay));
+        continue;
+      }
+
+      if (!response.ok) {
+        const text = await response.text();
+        if (response.status === 402) {
+          throw new Error(
+            `Reports API feature not enabled for workspace ${workspaceId} (402). ` +
+            `The 'billable' filter and some advanced features require a premium plan.`
+          );
+        }
+        throw new Error(`Reports API error (${response.status}): ${text}`);
+      }
+
+      const rows = (await response.json()) as ReportsSearchRow[];
+      const nextIdHeader = response.headers.get('X-Next-ID');
+      const nextRowHeader = response.headers.get('X-Next-Row-Number');
+      return {
+        rows: rows || [],
+        nextId: nextIdHeader ? parseInt(nextIdHeader) : undefined,
+        nextRowNumber: nextRowHeader ? parseInt(nextRowHeader) : undefined,
+      };
+    }
+
+    throw new Error('Reports API: max retries reached');
+  }
+
+  // Reports API v3 detailed search — auto-paginates and returns flat TimeEntry[].
+  // Expands each returned row (description+project+user bucket) into one entry
+  // per nested time_entries element, merging row-level fields onto each entry.
+  async searchTimeEntries(
+    workspaceId: number,
+    filters: TimeEntrySearchFilters,
+    options: { maxPages?: number } = {}
+  ): Promise<TimeEntry[]> {
+    const maxPages = options.maxPages ?? 20;
+    const pageSize = filters.page_size ?? 50;
+
+    const entries: TimeEntry[] = [];
+    let cursor: { first_id?: number; first_row_number?: number } = {
+      first_id: filters.first_id,
+      first_row_number: filters.first_row_number,
+    };
+
+    for (let page = 0; page < maxPages; page++) {
+      const { rows, nextId, nextRowNumber } = await this.searchTimeEntriesPage(
+        workspaceId,
+        { ...filters, page_size: pageSize, ...cursor }
+      );
+
+      for (const row of rows) {
+        for (const te of row.time_entries) {
+          entries.push({
+            id: te.id,
+            workspace_id: workspaceId,
+            project_id: row.project_id ?? undefined,
+            task_id: row.task_id ?? undefined,
+            user_id: row.user_id,
+            description: row.description,
+            billable: row.billable,
+            tag_ids: row.tag_ids,
+            start: te.start,
+            stop: te.stop,
+            duration: te.seconds,
+            at: te.at,
+          });
+        }
+      }
+
+      if (!nextId || !nextRowNumber) break;
+      cursor = { first_id: nextId, first_row_number: nextRowNumber };
+    }
+
+    return entries;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -196,6 +196,55 @@ export interface WorkspaceSummary {
   entry_count: number;
 }
 
+// Dashboard-equivalent filter set for Reports API v3 detailed search.
+// Mirrors https://engineering.toggl.com/docs/track/reports/detailed_reports/
+// Use [null] in id-array filters to match entries with no value for that field.
+export interface TimeEntrySearchFilters {
+  start_date?: string;  // YYYY-MM-DD (required by Reports API)
+  end_date?: string;    // YYYY-MM-DD
+  user_ids?: (number | null)[];
+  project_ids?: (number | null)[];
+  client_ids?: (number | null)[];
+  task_ids?: (number | null)[];
+  tag_ids?: (number | null)[];
+  group_ids?: number[];
+  time_entry_ids?: number[];
+  description?: string;
+  billable?: boolean;     // premium feature
+  min_duration_seconds?: number;
+  max_duration_seconds?: number;
+  order_by?: 'date' | 'user' | 'duration' | 'description' | 'last_update';
+  order_dir?: 'ASC' | 'DESC';
+  grouped?: boolean;
+  rounding?: number;
+  rounding_minutes?: number;
+  page_size?: number;
+  // Pagination cursors returned by previous response
+  first_id?: number;
+  first_row_number?: number;
+  first_timestamp?: number;
+}
+
+// Raw row from Reports API v3 detailed search (grouped=false still returns
+// one row per description+project+user bucket with nested time_entries).
+export interface ReportsSearchRow {
+  user_id: number;
+  username?: string;
+  project_id?: number | null;
+  task_id?: number | null;
+  description?: string;
+  billable?: boolean;
+  tag_ids?: number[];
+  row_number?: number;
+  time_entries: Array<{
+    id: number;
+    seconds: number;
+    start: string;
+    stop?: string;
+    at?: string;
+  }>;
+}
+
 // API request/response interfaces
 export interface TimeEntriesRequest {
   start_date?: string;  // ISO 8601 date

--- a/src/types.ts
+++ b/src/types.ts
@@ -196,7 +196,7 @@ export interface WorkspaceSummary {
   entry_count: number;
 }
 
-// Dashboard-equivalent filter set for Reports API v3 detailed search.
+// User-facing dashboard-equivalent filter set for Reports API v3 detailed search.
 // Mirrors https://engineering.toggl.com/docs/track/reports/detailed_reports/
 // Use [null] in id-array filters to match entries with no value for that field.
 export interface TimeEntrySearchFilters {
@@ -219,7 +219,10 @@ export interface TimeEntrySearchFilters {
   rounding?: number;
   rounding_minutes?: number;
   page_size?: number;
-  // Pagination cursors returned by previous response
+}
+
+// Internal request shape including cursor fields owned by the pagination loop.
+export interface ReportsSearchRequest extends TimeEntrySearchFilters {
   first_id?: number;
   first_row_number?: number;
   first_timestamp?: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -202,7 +202,7 @@ export interface WorkspaceSummary {
 export interface TimeEntrySearchFilters {
   start_date?: string;  // YYYY-MM-DD (required by Reports API)
   end_date?: string;    // YYYY-MM-DD
-  user_ids?: (number | null)[];
+  user_ids?: number[];
   project_ids?: (number | null)[];
   client_ids?: (number | null)[];
   task_ids?: (number | null)[];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -155,10 +155,9 @@ export function calculateTotalDuration(entries: HydratedTimeEntry[]): number {
 
 // Create a report entry from a hydrated time entry
 export function createReportEntry(entry: HydratedTimeEntry): ReportEntry {
-  const duration = entry.duration < 0
-    ? Math.floor((Date.now() - new Date(entry.start).getTime()) / 1000)
-    : entry.duration;
-    
+  const duration = effectiveDurationSeconds(entry);
+
+
   return {
     id: entry.id,
     workspace: entry.workspace_name,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -138,15 +138,19 @@ export function groupEntriesByWorkspace(entries: HydratedTimeEntry[]): Map<strin
   return grouped;
 }
 
+// Resolve an entry's elapsed seconds, handling running timers whose
+// `duration` field encodes a negative start-time sentinel rather than
+// real seconds. Safe for both running and stopped entries.
+export function effectiveDurationSeconds(entry: { duration: number; start: string }): number {
+  if (entry.duration < 0) {
+    return Math.floor((Date.now() - new Date(entry.start).getTime()) / 1000);
+  }
+  return entry.duration;
+}
+
 // Calculate total duration from entries
 export function calculateTotalDuration(entries: HydratedTimeEntry[]): number {
-  return entries.reduce((total, entry) => {
-    // Handle running timers (negative duration)
-    const duration = entry.duration < 0 
-      ? Math.floor((Date.now() - new Date(entry.start).getTime()) / 1000)
-      : entry.duration;
-    return total + duration;
-  }, 0);
+  return entries.reduce((total, entry) => total + effectiveDurationSeconds(entry), 0);
 }
 
 // Create a report entry from a hydrated time entry

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -157,7 +157,6 @@ export function calculateTotalDuration(entries: HydratedTimeEntry[]): number {
 export function createReportEntry(entry: HydratedTimeEntry): ReportEntry {
   const duration = effectiveDurationSeconds(entry);
 
-
   return {
     id: entry.id,
     workspace: entry.workspace_name,


### PR DESCRIPTION
## Summary

Adds a new `toggl_search_time_entries` tool backed by **Toggl Reports API v3** (`POST /reports/api/v3/workspace/{workspace_id}/search/time_entries`), exposing the full set of filters that the Toggl web dashboard offers. Also extends the existing `toggl_get_time_entries` with matching client-side post-filters for small date ranges.

### Why

The current `toggl_get_time_entries` only filters on `workspace_id` and `project_id` (single values). The underlying `/me/time_entries` endpoint does not accept any other filters per [Toggl's docs](https://engineering.toggl.com/docs/track/api/time_entries/), so richer filtering has to happen either client-side or by switching to the Reports API, which natively supports the dashboard filter set. This PR takes a hybrid approach:

- A brand-new `toggl_search_time_entries` tool hits Reports API v3 directly and lets users filter by clients, projects, tasks, tags, users, groups, description text, billable, duration bounds, ordering, grouping, and workspace rounding — matching what the dashboard exposes.
- `toggl_get_time_entries` stays backward-compatible, with additional post-filter knobs (`description`, `billable`, `user_ids`, `tags` with optional `tags_all` AND-semantics, `min_duration_seconds`, `max_duration_seconds`) for quick queries where spinning up a Reports call is overkill.

### New tool: `toggl_search_time_entries`

Filters supported (all optional except date range):

| Filter | Type | Notes |
|---|---|---|
| `start_date` / `end_date` | `YYYY-MM-DD` | Required (or provide `period`) |
| `period` | enum | Shortcut; same values as other tools |
| `client_ids` / `project_ids` / `task_ids` / `tag_ids` | `(number \| null)[]` | Use `[null]` to match entries with no value |
| `user_ids` | `number[]` | |
| `group_ids` | `number[]` | Team groups |
| `time_entry_ids` | `number[]` | |
| `description` | `string` | Text search |
| `billable` | `boolean` | Premium-only; 402 surfaced with a clear error |
| `min_duration_seconds` / `max_duration_seconds` | `number` | |
| `order_by` | `date` / `user` / `duration` / `description` / `last_update` | |
| `order_dir` | `ASC` / `DESC` | |
| `grouped` | `boolean` | |
| `rounding` / `rounding_minutes` | `number` | |
| `page_size` / `max_pages` | `number` | Pagination is automatic |

Pagination uses the `X-Next-ID` / `X-Next-Row-Number` headers and feeds them back as `first_id` / `first_row_number` on the next request. Grouped rows are expanded so that each nested `time_entries[i]` becomes one flat `TimeEntry`, merging row-level fields (`project_id`, `task_id`, `description`, `billable`, `tag_ids`, `user_id`). The result is then passed through the existing `hydrateTimeEntries` cache pipeline so callers get the same shape as the other tools.

### Changes to `toggl_get_time_entries`

Purely additive and backward-compatible. Adds post-filters applied after fetch, before hydration:

- `description` (case-insensitive substring)
- `billable` (boolean)
- `user_ids` (number[])
- `tags` (string[]) + optional `tags_all` (AND instead of OR)
- `min_duration_seconds` / `max_duration_seconds`

### Implementation notes

- New types `TimeEntrySearchFilters` and `ReportsSearchRow` in `src/types.ts`.
- New methods `TogglAPI.searchTimeEntriesPage` (single page, 429 retry, 402 normalization) and `TogglAPI.searchTimeEntries` (auto-pagination with `maxPages` cap) in `src/toggl-api.ts`.
- No new dependencies.
- `npm run build` passes cleanly.

## Test plan

- [x] `npm install && npm run build` — passes
- [ ] Manual: call `toggl_search_time_entries` with each filter individually against a real workspace
- [ ] Manual: verify pagination by setting `page_size: 5` against a workspace with 20+ entries in range
- [ ] Manual: verify `[null]` semantics for `project_ids` / `client_ids` returns unassigned entries
- [ ] Manual: verify 402 path on a Free workspace when `billable` is set
- [ ] Manual: verify existing `toggl_get_time_entries` still behaves identically when no new filters are passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)