### PR TITLE
chore: align SDK and CI baseline

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,35 +1,21 @@
-GNU GENERAL PUBLIC LICENSE
-Version 3, 29 June 2007
+MIT License
 
-Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
-Everyone is permitted to copy and distribute verbatim copies
-of this license document, but changing it is not allowed.
+Copyright (c) 2025 Very Good Plugins
 
-Preamble
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-The GNU General Public License is a free, copyleft license for
-software and other kinds of works.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-The licenses for most software and other practical works are designed
-to take away your freedom to share and change the works. By contrast,
-the GNU General Public License is intended to guarantee your freedom to
-share and change all versions of a program--to make sure it remains free
-software for all its users. We, the Free Software Foundation, use the
-GNU General Public License for most of our software; it applies also to
-any other work released this way by its authors. You can apply it to
-your programs, too.
-
-[License text abbreviated for brevity in this file. For the full legal text, see https://www.gnu.org/licenses/gpl-3.0.txt]
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program. If not, see <https://www.gnu.org/licenses/>.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ npm test
 
 ## License
 
-GPL-3.0
+MIT
 
 ## Support
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4499,6 +4499,474 @@
         }
       }
     },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/vitest/node_modules/@vitest/mocker": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
@@ -4524,6 +4992,50 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/vitest/node_modules/picomatch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,9 +7,9 @@
     "": {
       "name": "@verygoodplugins/mcp-toggl",
       "version": "1.0.0",
-      "license": "GPL-3.0",
+      "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^0.5.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^17.4.2",
         "node-fetch": "^3.3.2",
         "zod": "^3.22.4"
@@ -25,12 +25,12 @@
         "eslint-config-prettier": "^10.1.8",
         "prettier": "^3.1.0",
         "tsx": "^4.6.0",
-        "typescript": "^5.3.0",
+        "typescript": "^6.0.3",
         "typescript-eslint": "^8.59.1",
         "vitest": "^4.1.5"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -748,6 +748,18 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -843,15 +855,66 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-0.5.0.tgz",
-      "integrity": "sha512-RXgulUX6ewvxjAG0kOpLMEdXXWkzWgaoCGaA2CwNW7cQCIphjpJhjpHSiaPdVCnisjRF/0Cm9KWHUuIoeiAblQ==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
       "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
         "raw-body": "^3.0.0",
-        "zod": "^3.23.8"
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.4",
@@ -1376,6 +1439,19 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1415,6 +1491,45 @@
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
       }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ajv-formats/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "node_modules/ansi-styles": {
       "version": "4.3.0",
@@ -1468,6 +1583,30 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -1475,6 +1614,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/callsites": {
@@ -1541,6 +1709,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/content-type": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
@@ -1557,11 +1738,45 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -1585,7 +1800,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1637,12 +1851,71 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
       "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.25.9",
@@ -1685,6 +1958,12 @@
         "@esbuild/win32-ia32": "0.25.9",
         "@esbuild/win32-x64": "0.25.9"
       }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
     },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
@@ -1929,6 +2208,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -1939,11 +2248,71 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+      "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
@@ -1959,6 +2328,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
@@ -1994,6 +2379,27 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/find-up": {
@@ -2046,6 +2452,24 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -2059,6 +2483,52 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -2100,6 +2570,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2110,6 +2592,39 @@
         "node": ">=8"
       }
     },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.15",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+      "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -2118,31 +2633,39 @@
       "license": "MIT"
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
       },
       "engines": {
         "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/ignore": {
@@ -2188,6 +2711,24 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2211,11 +2752,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/istanbul-lib-coverage": {
@@ -2257,6 +2803,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
@@ -2290,6 +2845,12 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -2644,11 +3205,65 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -2676,6 +3291,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/node-domexception": {
       "version": "1.0.0",
@@ -2715,6 +3339,27 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -2725,6 +3370,27 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -2789,6 +3455,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2803,10 +3478,19 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/pathe": {
@@ -2822,6 +3506,15 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.12",
@@ -2878,6 +3571,19 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2888,19 +3594,52 @@
         "node": ">=6"
       }
     },
-    "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
-      "license": "MIT",
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
+        "side-channel": "^1.1.0"
       },
       "engines": {
-        "node": ">= 0.8"
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve-from": {
@@ -2957,6 +3696,22 @@
         "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -2976,6 +3731,51 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
@@ -2986,7 +3786,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -2999,10 +3798,81 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/siginfo": {
@@ -3030,9 +3900,9 @@
       "license": "MIT"
     },
     "node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
@@ -3196,10 +4066,24 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3516,6 +4400,15 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/vitest": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
@@ -3606,474 +4499,6 @@
         }
       }
     },
-    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
-      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/android-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
-      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
-      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/android-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
-      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
-      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
-      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
-      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
-      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
-      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
-      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
-      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
-      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
-      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
-      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
-      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
-      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
-      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
-      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
-      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
-      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
-      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
-      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
-      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/vitest/node_modules/@vitest/mocker": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
@@ -4099,50 +4524,6 @@
         "vite": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vitest/node_modules/esbuild": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
-      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.28.0",
-        "@esbuild/android-arm": "0.28.0",
-        "@esbuild/android-arm64": "0.28.0",
-        "@esbuild/android-x64": "0.28.0",
-        "@esbuild/darwin-arm64": "0.28.0",
-        "@esbuild/darwin-x64": "0.28.0",
-        "@esbuild/freebsd-arm64": "0.28.0",
-        "@esbuild/freebsd-x64": "0.28.0",
-        "@esbuild/linux-arm": "0.28.0",
-        "@esbuild/linux-arm64": "0.28.0",
-        "@esbuild/linux-ia32": "0.28.0",
-        "@esbuild/linux-loong64": "0.28.0",
-        "@esbuild/linux-mips64el": "0.28.0",
-        "@esbuild/linux-ppc64": "0.28.0",
-        "@esbuild/linux-riscv64": "0.28.0",
-        "@esbuild/linux-s390x": "0.28.0",
-        "@esbuild/linux-x64": "0.28.0",
-        "@esbuild/netbsd-arm64": "0.28.0",
-        "@esbuild/netbsd-x64": "0.28.0",
-        "@esbuild/openbsd-arm64": "0.28.0",
-        "@esbuild/openbsd-x64": "0.28.0",
-        "@esbuild/openharmony-arm64": "0.28.0",
-        "@esbuild/sunos-x64": "0.28.0",
-        "@esbuild/win32-arm64": "0.28.0",
-        "@esbuild/win32-ia32": "0.28.0",
-        "@esbuild/win32-x64": "0.28.0"
       }
     },
     "node_modules/vitest/node_modules/picomatch": {
@@ -4249,7 +4630,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -4288,6 +4668,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -4308,6 +4694,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "mcp-toggl": "dist/index.js"
   },
   "scripts": {
-    "build": "rm -rf dist && tsc && npm run postbuild",
+    "build": "rm -rf dist && tsc",
     "postbuild": "chmod +x dist/index.js",
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
@@ -30,7 +30,7 @@
     "productivity"
   ],
   "author": "Very Good Plugins",
-  "license": "GPL-3.0",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/verygoodplugins/mcp-toggl.git"
@@ -51,7 +51,7 @@
     "LICENSE"
   ],
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^0.5.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^17.4.2",
     "node-fetch": "^3.3.2",
     "zod": "^3.22.4"
@@ -64,7 +64,7 @@
     "eslint-config-prettier": "^10.1.8",
     "prettier": "^3.1.0",
     "tsx": "^4.6.0",
-    "typescript": "^5.3.0",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.1",
     "vitest": "^4.1.5"
   }

--- a/src/cache-manager.ts
+++ b/src/cache-manager.ts
@@ -9,7 +9,7 @@ import type {
   HydratedTimeEntry,
   CacheEntry,
   CacheStats,
-  CacheConfig
+  CacheConfig,
 } from './types.js';
 
 export class CacheManager {
@@ -19,32 +19,32 @@ export class CacheManager {
   private tasks: Map<number, CacheEntry<Task>> = new Map();
   private users: Map<number, CacheEntry<User>> = new Map();
   private tags: Map<number, CacheEntry<Tag>> = new Map();
-  
+
   // Track cache performance
   private stats = {
     hits: 0,
     misses: 0,
-    lastReset: new Date()
+    lastReset: new Date(),
   };
-  
+
   private config: CacheConfig;
   private api: any; // Will be set after API client is created
-  
+
   constructor(config: CacheConfig) {
     this.config = config;
   }
-  
+
   setAPI(api: any): void {
     this.api = api;
   }
-  
+
   // Check if cache entry is still valid
   private isValid<T>(entry?: CacheEntry<T>): boolean {
     if (!entry) return false;
     const age = Date.now() - entry.timestamp.getTime();
     return age < entry.ttl;
   }
-  
+
   // Generic cache getter
   private getCached<T>(cache: Map<number, CacheEntry<T>>, id: number): T | null {
     const entry = cache.get(id);
@@ -55,32 +55,33 @@ export class CacheManager {
     this.stats.misses++;
     return null;
   }
-  
+
   // Generic cache setter
   private setCached<T>(cache: Map<number, CacheEntry<T>>, id: number, data: T): void {
     // Enforce max cache size with LRU eviction
-    if (cache.size >= this.config.maxSize / 6) { // Divide by 6 for each cache type
+    if (cache.size >= this.config.maxSize / 6) {
+      // Divide by 6 for each cache type
       const firstKey = cache.keys().next().value;
       if (firstKey !== undefined) {
         cache.delete(firstKey);
       }
     }
-    
+
     cache.set(id, {
       data,
       timestamp: new Date(),
-      ttl: this.config.ttl
+      ttl: this.config.ttl,
     });
   }
-  
+
   // Workspace methods
   async getWorkspace(id: number | undefined): Promise<Workspace | null> {
     if (!id) return null;
     const cached = this.getCached(this.workspaces, id);
     if (cached) return cached;
-    
+
     if (!this.api) return null;
-    
+
     try {
       const workspace = await this.api.getWorkspace(id);
       if (workspace) {
@@ -92,10 +93,10 @@ export class CacheManager {
       return null;
     }
   }
-  
+
   async getWorkspaces(): Promise<Workspace[]> {
     if (!this.api) return [];
-    
+
     try {
       const workspaces = await this.api.getWorkspaces();
       // Cache all fetched workspaces
@@ -108,14 +109,14 @@ export class CacheManager {
       return [];
     }
   }
-  
+
   // Project methods
   async getProject(id: number): Promise<Project | null> {
     const cached = this.getCached(this.projects, id);
     if (cached) return cached;
-    
+
     if (!this.api) return null;
-    
+
     try {
       const project = await this.api.getProject(id);
       if (project) {
@@ -127,10 +128,10 @@ export class CacheManager {
       return null;
     }
   }
-  
+
   async getProjects(workspaceId: number): Promise<Project[]> {
     if (!this.api) return [];
-    
+
     try {
       const projects = await this.api.getProjects(workspaceId);
       // Cache all fetched projects
@@ -143,14 +144,14 @@ export class CacheManager {
       return [];
     }
   }
-  
+
   // Client methods
   async getClient(id: number): Promise<Client | null> {
     const cached = this.getCached(this.clients, id);
     if (cached) return cached;
-    
+
     if (!this.api) return null;
-    
+
     try {
       const client = await this.api.getClient(id);
       if (client) {
@@ -162,10 +163,10 @@ export class CacheManager {
       return null;
     }
   }
-  
+
   async getClients(workspaceId: number): Promise<Client[]> {
     if (!this.api) return [];
-    
+
     try {
       const clients = await this.api.getClients(workspaceId);
       // Cache all fetched clients
@@ -178,14 +179,14 @@ export class CacheManager {
       return [];
     }
   }
-  
+
   // Task methods
   async getTask(id: number, workspaceId: number, projectId: number): Promise<Task | null> {
     const cached = this.getCached(this.tasks, id);
     if (cached) return cached;
-    
+
     if (!this.api) return null;
-    
+
     try {
       const task = await this.api.getTask(workspaceId, projectId, id);
       if (task) {
@@ -197,10 +198,10 @@ export class CacheManager {
       return null;
     }
   }
-  
+
   async getTasks(workspaceId: number, projectId: number): Promise<Task[]> {
     if (!this.api) return [];
-    
+
     try {
       const tasks = await this.api.getTasks(workspaceId, projectId);
       // Cache all fetched tasks
@@ -213,14 +214,14 @@ export class CacheManager {
       return [];
     }
   }
-  
+
   // User methods
   async getUser(id: number): Promise<User | null> {
     const cached = this.getCached(this.users, id);
     if (cached) return cached;
-    
+
     if (!this.api) return null;
-    
+
     try {
       const user = await this.api.getUser(id);
       if (user) {
@@ -232,14 +233,14 @@ export class CacheManager {
       return null;
     }
   }
-  
+
   // Tag methods
   async getTag(id: number, workspaceId: number): Promise<Tag | null> {
     const cached = this.getCached(this.tags, id);
     if (cached) return cached;
-    
+
     if (!this.api) return null;
-    
+
     try {
       const tag = await this.api.getTag(workspaceId, id);
       if (tag) {
@@ -251,10 +252,10 @@ export class CacheManager {
       return null;
     }
   }
-  
+
   async getTags(workspaceId: number): Promise<Tag[]> {
     if (!this.api) return [];
-    
+
     try {
       const tags = await this.api.getTags(workspaceId);
       // Cache all fetched tags
@@ -267,100 +268,97 @@ export class CacheManager {
       return [];
     }
   }
-  
+
   // Warm cache by pre-fetching common entities
   async warmCache(workspaceId?: number): Promise<void> {
     // Log to stderr to avoid interfering with MCP stdio protocol
     console.error('Warming cache...');
-    
+
     try {
       // Fetch all workspaces
       const workspaces = await this.getWorkspaces();
-      
+
       // If workspace specified, fetch its entities
       if (workspaceId) {
         await Promise.all([
           this.getProjects(workspaceId),
           this.getClients(workspaceId),
-          this.getTags(workspaceId)
+          this.getTags(workspaceId),
         ]);
       } else {
         // Fetch entities for all workspaces (be careful with rate limits)
-        for (const ws of workspaces.slice(0, 3)) { // Limit to first 3 workspaces
-          await Promise.all([
-            this.getProjects(ws.id),
-            this.getClients(ws.id),
-            this.getTags(ws.id)
-          ]);
+        for (const ws of workspaces.slice(0, 3)) {
+          // Limit to first 3 workspaces
+          await Promise.all([this.getProjects(ws.id), this.getClients(ws.id), this.getTags(ws.id)]);
         }
       }
-      
+
       console.error('Cache warmed successfully');
     } catch (error) {
       console.error('Failed to warm cache:', error);
     }
   }
-  
+
   // Hydrate time entries with cached names
   async hydrateTimeEntries(entries: TimeEntry[]): Promise<HydratedTimeEntry[]> {
     const hydrated: HydratedTimeEntry[] = [];
-    
+
     // Collect unique IDs to batch fetch if needed
     const workspaceIds = new Set<number>();
     const projectIds = new Set<number>();
-    const taskIds = new Set<{wid: number, pid: number, tid: number}>();
-    
-    entries.forEach(entry => {
+    const taskIds = new Set<{ wid: number; pid: number; tid: number }>();
+
+    entries.forEach((entry) => {
       workspaceIds.add(entry.workspace_id);
       if (entry.project_id) projectIds.add(entry.project_id);
       if (entry.task_id && entry.project_id) {
         taskIds.add({
           wid: entry.workspace_id,
           pid: entry.project_id,
-          tid: entry.task_id
+          tid: entry.task_id,
         });
       }
     });
-    
+
     // Pre-fetch missing entities
-    const projectsToFetch = Array.from(projectIds).filter(id => !this.projects.has(id));
+    const projectsToFetch = Array.from(projectIds).filter((id) => !this.projects.has(id));
     if (projectsToFetch.length > 0 && this.api) {
       console.error(`Fetching ${projectsToFetch.length} missing projects...`);
-      await Promise.all(projectsToFetch.map(id => this.getProject(id)));
+      await Promise.all(projectsToFetch.map((id) => this.getProject(id)));
     }
-    
+
     // Now hydrate each entry
     for (const entry of entries) {
       const hydEntry: HydratedTimeEntry = { ...entry } as HydratedTimeEntry;
-      
+
       // Add workspace name
       const workspace = await this.getWorkspace(entry.workspace_id);
       hydEntry.workspace_name = workspace?.name || `Workspace ${entry.workspace_id}`;
-      
+
       // Add project name and client info
       if (entry.project_id) {
         const project = await this.getProject(entry.project_id);
         hydEntry.project_name = project?.name || `Project ${entry.project_id}`;
-        
+
         if (project?.client_id) {
           hydEntry.client_id = project.client_id;
           const client = await this.getClient(project.client_id);
           hydEntry.client_name = client?.name || `Client ${project.client_id}`;
         }
       }
-      
+
       // Add task name
       if (entry.task_id && entry.project_id) {
         const task = await this.getTask(entry.task_id, entry.workspace_id, entry.project_id);
         hydEntry.task_name = task?.name || `Task ${entry.task_id}`;
       }
-      
+
       // Add user name if available
       if (entry.user_id) {
         const user = await this.getUser(entry.user_id);
         hydEntry.user_name = user?.fullname || user?.email || `User ${entry.user_id}`;
       }
-      
+
       // Add tag names
       if (entry.tag_ids && entry.tag_ids.length > 0) {
         hydEntry.tag_names = [];
@@ -371,13 +369,13 @@ export class CacheManager {
           }
         }
       }
-      
+
       hydrated.push(hydEntry);
     }
-    
+
     return hydrated;
   }
-  
+
   // Clear cache
   clearCache(): void {
     this.workspaces.clear();
@@ -389,10 +387,10 @@ export class CacheManager {
     this.stats = {
       hits: 0,
       misses: 0,
-      lastReset: new Date()
+      lastReset: new Date(),
     };
   }
-  
+
   // Get cache statistics
   getStats(): CacheStats {
     return {
@@ -404,10 +402,10 @@ export class CacheManager {
       tags: this.tags.size,
       hits: this.stats.hits,
       misses: this.stats.misses,
-      lastReset: this.stats.lastReset
+      lastReset: this.stats.lastReset,
     };
   }
-  
+
   // Clear expired entries
   pruneExpired(): void {
     const prune = <T>(cache: Map<number, CacheEntry<T>>) => {
@@ -417,9 +415,9 @@ export class CacheManager {
           expired.push(key);
         }
       });
-      expired.forEach(key => cache.delete(key));
+      expired.forEach((key) => cache.delete(key));
     };
-    
+
     prune(this.workspaces);
     prune(this.projects);
     prune(this.clients);

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,12 +18,9 @@ import {
   groupEntriesByProject,
   groupEntriesByWorkspace,
   generateProjectSummary,
-  generateWorkspaceSummary
+  generateWorkspaceSummary,
 } from './utils.js';
-import type {
-  CacheConfig,
-  TimeEntry
-} from './types.js';
+import type { CacheConfig, TimeEntry } from './types.js';
 
 // Version for CLI output and server metadata
 const VERSION = '1.0.0';
@@ -35,35 +32,37 @@ if (argv.includes('--version') || argv.includes('-v')) {
   process.exit(0);
 }
 if (argv.includes('--help') || argv.includes('-h')) {
-  console.error(`mcp-toggl - Toggl MCP Server\n\n` +
-`Usage:\n` +
-`  npx @verygoodplugins/mcp-toggl@latest [--help] [--version]\n\n` +
-`Environment:\n` +
-`  TOGGL_API_KEY                Required Toggl API token\n` +
-`  TOGGL_DEFAULT_WORKSPACE_ID   Optional default workspace id\n` +
-`  TOGGL_CACHE_TTL              Cache TTL in ms (default: 3600000)\n` +
-`  TOGGL_CACHE_SIZE             Max cached entities (default: 1000)\n\n` +
-`Claude Desktop (claude_desktop_config.json):\n` +
-`  {\n` +
-`    "mcpServers": {\n` +
-`      "mcp-toggl": {\n` +
-`        "command": "npx @verygoodplugins/mcp-toggl@latest",\n` +
-`        "env": { "TOGGL_API_KEY": "your_api_key_here" }\n` +
-`      }\n` +
-`    }\n` +
-`  }\n\n` +
-`Cursor (~/.cursor/mcp.json):\n` +
-`  {\n` +
-`    "mcp": {\n` +
-`      "servers": {\n` +
-`        "mcp-toggl": {\n` +
-`          "command": "npx",\n` +
-`          "args": ["@verygoodplugins/mcp-toggl@latest"],\n` +
-`          "env": { "TOGGL_API_KEY": "your_api_key_here" }\n` +
-`        }\n` +
-`      }\n` +
-`    }\n` +
-`  }\n`);
+  console.error(
+    `mcp-toggl - Toggl MCP Server\n\n` +
+      `Usage:\n` +
+      `  npx @verygoodplugins/mcp-toggl@latest [--help] [--version]\n\n` +
+      `Environment:\n` +
+      `  TOGGL_API_KEY                Required Toggl API token\n` +
+      `  TOGGL_DEFAULT_WORKSPACE_ID   Optional default workspace id\n` +
+      `  TOGGL_CACHE_TTL              Cache TTL in ms (default: 3600000)\n` +
+      `  TOGGL_CACHE_SIZE             Max cached entities (default: 1000)\n\n` +
+      `Claude Desktop (claude_desktop_config.json):\n` +
+      `  {\n` +
+      `    "mcpServers": {\n` +
+      `      "mcp-toggl": {\n` +
+      `        "command": "npx @verygoodplugins/mcp-toggl@latest",\n` +
+      `        "env": { "TOGGL_API_KEY": "your_api_key_here" }\n` +
+      `      }\n` +
+      `    }\n` +
+      `  }\n\n` +
+      `Cursor (~/.cursor/mcp.json):\n` +
+      `  {\n` +
+      `    "mcp": {\n` +
+      `      "servers": {\n` +
+      `        "mcp-toggl": {\n` +
+      `          "command": "npx",\n` +
+      `          "args": ["@verygoodplugins/mcp-toggl@latest"],\n` +
+      `          "env": { "TOGGL_API_KEY": "your_api_key_here" }\n` +
+      `        }\n` +
+      `      }\n` +
+      `    }\n` +
+      `  }\n`
+  );
   process.exit(0);
 }
 
@@ -73,9 +72,7 @@ config({ quiet: true });
 // Validate required environment variables
 // Support a few aliases for convenience/backward-compat
 const RAW_API_KEY =
-  process.env.TOGGL_API_KEY ||
-  process.env.TOGGL_API_TOKEN ||
-  process.env.TOGGL_TOKEN;
+  process.env.TOGGL_API_KEY || process.env.TOGGL_API_TOKEN || process.env.TOGGL_TOKEN;
 
 const API_KEY = RAW_API_KEY?.trim();
 
@@ -93,10 +90,10 @@ if (process.env.TOGGL_API_TOKEN || process.env.TOGGL_TOKEN) {
 const cacheConfig: CacheConfig = {
   ttl: parseInt(process.env.TOGGL_CACHE_TTL || '3600000'),
   maxSize: parseInt(process.env.TOGGL_CACHE_SIZE || '1000'),
-  batchSize: parseInt(process.env.TOGGL_BATCH_SIZE || '100')
+  batchSize: parseInt(process.env.TOGGL_BATCH_SIZE || '100'),
 };
 
-const defaultWorkspaceId = process.env.TOGGL_DEFAULT_WORKSPACE_ID 
+const defaultWorkspaceId = process.env.TOGGL_DEFAULT_WORKSPACE_ID
   ? parseInt(process.env.TOGGL_DEFAULT_WORKSPACE_ID)
   : undefined;
 
@@ -139,247 +136,323 @@ const tools: Tool[] = [
   {
     name: 'toggl_check_auth',
     description: 'Verify Toggl API connectivity and authentication is valid',
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: 'object',
       properties: {},
-      required: []
+      required: [],
     },
   },
   // Time tracking tools
   {
     name: 'toggl_get_time_entries',
-    description: 'Get time entries with optional date range filters. Returns hydrated entries with project/workspace names.',
+    description:
+      'Get time entries with optional date range filters. Returns hydrated entries with project/workspace names.',
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: 'object',
       properties: {
         period: {
           type: 'string',
           enum: ['today', 'yesterday', 'week', 'lastWeek', 'month', 'lastMonth'],
-          description: 'Predefined period to fetch entries for'
+          description: 'Predefined period to fetch entries for',
         },
         start_date: {
           type: 'string',
-          description: 'Start date (YYYY-MM-DD format)'
+          description: 'Start date (YYYY-MM-DD format)',
         },
         end_date: {
           type: 'string',
-          description: 'End date (YYYY-MM-DD format)'
+          description: 'End date (YYYY-MM-DD format)',
         },
         workspace_id: {
           type: 'number',
-          description: 'Filter by workspace ID'
+          description: 'Filter by workspace ID',
         },
         project_id: {
           type: 'number',
-          description: 'Filter by project ID'
-        }
-      }
+          description: 'Filter by project ID',
+        },
+      },
     },
   },
   {
     name: 'toggl_get_current_entry',
     description: 'Get the currently running time entry, if any',
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: 'object',
       properties: {},
-      required: []
+      required: [],
     },
   },
   {
     name: 'toggl_start_timer',
     description: 'Start a new time entry timer',
+    annotations: {
+      readOnlyHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: 'object',
       properties: {
         description: {
           type: 'string',
-          description: 'Description of the time entry'
+          description: 'Description of the time entry',
         },
         workspace_id: {
           type: 'number',
-          description: 'Workspace ID (uses default if not provided)'
+          description: 'Workspace ID (uses default if not provided)',
         },
         project_id: {
           type: 'number',
-          description: 'Project ID (optional)'
+          description: 'Project ID (optional)',
         },
         task_id: {
           type: 'number',
-          description: 'Task ID (optional)'
+          description: 'Task ID (optional)',
         },
         tags: {
           type: 'array',
           items: { type: 'string' },
-          description: 'Tags for the entry'
-        }
-      }
+          description: 'Tags for the entry',
+        },
+      },
     },
   },
   {
     name: 'toggl_stop_timer',
     description: 'Stop the currently running timer',
+    annotations: {
+      readOnlyHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: 'object',
       properties: {},
-      required: []
+      required: [],
     },
   },
-  
+
   // Reporting tools
   {
     name: 'toggl_daily_report',
     description: 'Generate a daily report with hours by project and workspace',
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: 'object',
       properties: {
         date: {
           type: 'string',
-          description: 'Date for report (YYYY-MM-DD format, defaults to today)'
+          description: 'Date for report (YYYY-MM-DD format, defaults to today)',
         },
         format: {
           type: 'string',
           enum: ['json', 'text'],
-          description: 'Output format (default: json)'
-        }
-      }
+          description: 'Output format (default: json)',
+        },
+      },
     },
   },
   {
     name: 'toggl_weekly_report',
     description: 'Generate a weekly report with daily breakdown and project summaries',
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: 'object',
       properties: {
         week_offset: {
           type: 'number',
-          description: 'Week offset from current week (0 = this week, -1 = last week)'
+          description: 'Week offset from current week (0 = this week, -1 = last week)',
         },
         format: {
           type: 'string',
           enum: ['json', 'text'],
-          description: 'Output format (default: json)'
-        }
-      }
+          description: 'Output format (default: json)',
+        },
+      },
     },
   },
   {
     name: 'toggl_project_summary',
     description: 'Get total hours per project for a date range',
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: 'object',
       properties: {
         period: {
           type: 'string',
           enum: ['week', 'lastWeek', 'month', 'lastMonth'],
-          description: 'Predefined period'
+          description: 'Predefined period',
         },
         start_date: {
           type: 'string',
-          description: 'Start date (YYYY-MM-DD format)'
+          description: 'Start date (YYYY-MM-DD format)',
         },
         end_date: {
           type: 'string',
-          description: 'End date (YYYY-MM-DD format)'
+          description: 'End date (YYYY-MM-DD format)',
         },
         workspace_id: {
           type: 'number',
-          description: 'Filter by workspace ID'
-        }
-      }
+          description: 'Filter by workspace ID',
+        },
+      },
     },
   },
   {
     name: 'toggl_workspace_summary',
     description: 'Get total hours per workspace for a date range',
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: 'object',
       properties: {
         period: {
           type: 'string',
           enum: ['week', 'lastWeek', 'month', 'lastMonth'],
-          description: 'Predefined period'
+          description: 'Predefined period',
         },
         start_date: {
           type: 'string',
-          description: 'Start date (YYYY-MM-DD format)'
+          description: 'Start date (YYYY-MM-DD format)',
         },
         end_date: {
           type: 'string',
-          description: 'End date (YYYY-MM-DD format)'
-        }
-      }
+          description: 'End date (YYYY-MM-DD format)',
+        },
+      },
     },
   },
-  
+
   // Management tools
   {
     name: 'toggl_list_workspaces',
     description: 'List all available workspaces',
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: 'object',
       properties: {},
-      required: []
+      required: [],
     },
   },
   {
     name: 'toggl_list_projects',
     description: 'List projects for a workspace',
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: 'object',
       properties: {
         workspace_id: {
           type: 'number',
-          description: 'Workspace ID (uses default if not provided)'
-        }
-      }
+          description: 'Workspace ID (uses default if not provided)',
+        },
+      },
     },
   },
   {
     name: 'toggl_list_clients',
     description: 'List clients for a workspace',
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: 'object',
       properties: {
         workspace_id: {
           type: 'number',
-          description: 'Workspace ID (uses default if not provided)'
-        }
-      }
+          description: 'Workspace ID (uses default if not provided)',
+        },
+      },
     },
   },
-  
+
   // Cache management
   {
     name: 'toggl_warm_cache',
     description: 'Pre-fetch and cache workspace, project, and client data for better performance',
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
     inputSchema: {
       type: 'object',
       properties: {
         workspace_id: {
           type: 'number',
-          description: 'Specific workspace to warm cache for'
-        }
-      }
+          description: 'Specific workspace to warm cache for',
+        },
+      },
     },
   },
   {
     name: 'toggl_cache_stats',
     description: 'Get cache statistics and performance metrics',
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     inputSchema: {
       type: 'object',
       properties: {},
-      required: []
+      required: [],
     },
   },
   {
     name: 'toggl_clear_cache',
     description: 'Clear all cached data',
+    annotations: {
+      readOnlyHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
     inputSchema: {
       type: 'object',
       properties: {},
-      required: []
+      required: [],
     },
-  }
+  },
 ];
 
 // Handle tool listing
@@ -390,7 +463,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 // Handle tool calls
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
-  
+
   try {
     switch (name) {
       // Health/authentication
@@ -405,27 +478,33 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           return `${u}@${domain}`;
         };
         return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({
-              authenticated: true,
-              user: {
-                id: (me as any).id,
-                email: maskEmail((me as any).email),
-                fullname: (me as any).fullname
-              },
-              workspaces: workspaces.map(w => ({ id: w.id, name: w.name })),
-            }, null, 2)
-          }]
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  authenticated: true,
+                  user: {
+                    id: (me as any).id,
+                    email: maskEmail((me as any).email),
+                    fullname: (me as any).fullname,
+                  },
+                  workspaces: workspaces.map((w) => ({ id: w.id, name: w.name })),
+                },
+                null,
+                2
+              ),
+            },
+          ],
         };
       }
 
       // Time tracking tools
       case 'toggl_get_time_entries': {
         await ensureCache();
-        
+
         let entries: TimeEntry[];
-        
+
         if (args?.period) {
           const range = getDateRange(args.period as any);
           entries = await api.getTimeEntriesForDateRange(range.start, range.end);
@@ -436,64 +515,80 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         } else {
           entries = await api.getTimeEntriesForToday();
         }
-        
+
         // Filter by workspace/project if specified
         if (args?.workspace_id) {
-          entries = entries.filter(e => e.workspace_id === args.workspace_id);
+          entries = entries.filter((e) => e.workspace_id === args.workspace_id);
         }
         if (args?.project_id) {
-          entries = entries.filter(e => e.project_id === args.project_id);
+          entries = entries.filter((e) => e.project_id === args.project_id);
         }
-        
+
         // Hydrate with names
         const hydrated = await cache.hydrateTimeEntries(entries);
-        
+
         return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({ 
-              count: hydrated.length,
-              entries: hydrated 
-            }, null, 2)
-          }]
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  count: hydrated.length,
+                  entries: hydrated,
+                },
+                null,
+                2
+              ),
+            },
+          ],
         };
       }
-      
+
       case 'toggl_get_current_entry': {
         const entry = await api.getCurrentTimeEntry();
-        
+
         if (!entry) {
           return {
-            content: [{
-              type: 'text',
-              text: JSON.stringify({ 
-                running: false,
-                message: 'No timer currently running' 
-              })
-            }]
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  running: false,
+                  message: 'No timer currently running',
+                }),
+              },
+            ],
           };
         }
-        
+
         await ensureCache();
         const hydrated = await cache.hydrateTimeEntries([entry]);
-        
+
         return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({ 
-              running: true,
-              entry: hydrated[0] 
-            }, null, 2)
-          }]
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  running: true,
+                  entry: hydrated[0],
+                },
+                null,
+                2
+              ),
+            },
+          ],
         };
       }
-      
+
       case 'toggl_start_timer': {
         const workspaceId = args?.workspace_id || defaultWorkspaceId;
         if (!workspaceId) {
-          throw new Error('Workspace ID required (set TOGGL_DEFAULT_WORKSPACE_ID or provide workspace_id)');
+          throw new Error(
+            'Workspace ID required (set TOGGL_DEFAULT_WORKSPACE_ID or provide workspace_id)'
+          );
         }
-        
+
         const entry = await api.startTimer(
           workspaceId as number,
           args?.description as string | undefined,
@@ -501,124 +596,146 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           args?.task_id as number | undefined,
           args?.tags as string[] | undefined
         );
-        
+
         await ensureCache();
         const hydrated = await cache.hydrateTimeEntries([entry]);
-        
+
         return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({ 
-              success: true,
-              message: 'Timer started',
-              entry: hydrated[0] 
-            }, null, 2)
-          }]
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  success: true,
+                  message: 'Timer started',
+                  entry: hydrated[0],
+                },
+                null,
+                2
+              ),
+            },
+          ],
         };
       }
-      
+
       case 'toggl_stop_timer': {
         const current = await api.getCurrentTimeEntry();
-        
+
         if (!current) {
           return {
-            content: [{
-              type: 'text',
-              text: JSON.stringify({ 
-                success: false,
-                message: 'No timer currently running' 
-              })
-            }]
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  success: false,
+                  message: 'No timer currently running',
+                }),
+              },
+            ],
           };
         }
-        
+
         const stopped = await api.stopTimer(current.workspace_id, current.id);
-        
+
         await ensureCache();
         const hydrated = await cache.hydrateTimeEntries([stopped]);
-        
+
         return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({ 
-              success: true,
-              message: 'Timer stopped',
-              entry: hydrated[0] 
-            }, null, 2)
-          }]
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  success: true,
+                  message: 'Timer stopped',
+                  entry: hydrated[0],
+                },
+                null,
+                2
+              ),
+            },
+          ],
         };
       }
-      
+
       // Reporting tools
       case 'toggl_daily_report': {
         await ensureCache();
-        
+
         const date = args?.date ? new Date(args.date as string) : new Date();
         const nextDay = new Date(date);
         nextDay.setDate(nextDay.getDate() + 1);
-        
+
         const entries = await api.getTimeEntriesForDateRange(date, nextDay);
         const hydrated = await cache.hydrateTimeEntries(entries);
-        
+
         const report = generateDailyReport(date.toISOString().split('T')[0], hydrated);
-        
+
         if (args?.format === 'text') {
           return {
-            content: [{
-              type: 'text',
-              text: formatReportForDisplay(report)
-            }]
+            content: [
+              {
+                type: 'text',
+                text: formatReportForDisplay(report),
+              },
+            ],
           };
         }
-        
+
         return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify(report, null, 2)
-          }]
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(report, null, 2),
+            },
+          ],
         };
       }
-      
+
       case 'toggl_weekly_report': {
         await ensureCache();
-        
+
         const weekOffset = (args?.week_offset as number) || 0;
         const entries = await api.getTimeEntriesForWeek(weekOffset);
         const hydrated = await cache.hydrateTimeEntries(entries);
-        
+
         // Calculate week boundaries
         const today = new Date();
         const dayOfWeek = today.getDay();
         const diff = today.getDate() - dayOfWeek + (dayOfWeek === 0 ? -6 : 1);
         const monday = new Date(today.setDate(diff));
-        monday.setDate(monday.getDate() + (weekOffset * 7));
+        monday.setDate(monday.getDate() + weekOffset * 7);
         const sunday = new Date(monday);
         sunday.setDate(sunday.getDate() + 6);
-        
+
         const report = generateWeeklyReport(monday, sunday, hydrated);
-        
+
         if (args?.format === 'text') {
           return {
-            content: [{
-              type: 'text',
-              text: formatReportForDisplay(report)
-            }]
+            content: [
+              {
+                type: 'text',
+                text: formatReportForDisplay(report),
+              },
+            ],
           };
         }
-        
+
         return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify(report, null, 2)
-          }]
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(report, null, 2),
+            },
+          ],
         };
       }
-      
+
       case 'toggl_project_summary': {
         await ensureCache();
-        
+
         let entries: TimeEntry[];
-        
+
         if (args?.period) {
           const range = getDateRange(args.period as any);
           entries = await api.getTimeEntriesForDateRange(range.start, range.end);
@@ -630,39 +747,45 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           // Default to current week
           entries = await api.getTimeEntriesForWeek(0);
         }
-        
+
         if (args?.workspace_id) {
-          entries = entries.filter(e => e.workspace_id === args.workspace_id);
+          entries = entries.filter((e) => e.workspace_id === args.workspace_id);
         }
-        
+
         const hydrated = await cache.hydrateTimeEntries(entries);
         const byProject = groupEntriesByProject(hydrated);
-        
+
         const summaries: any[] = [];
         byProject.forEach((projectEntries, projectName) => {
           summaries.push(generateProjectSummary(projectName, projectEntries));
         });
-        
+
         // Sort by total hours descending
         summaries.sort((a, b) => b.total_seconds - a.total_seconds);
-        
+
         return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({ 
-              project_count: summaries.length,
-              total_hours: secondsToHours(summaries.reduce((t, s) => t + s.total_seconds, 0)),
-              projects: summaries 
-            }, null, 2)
-          }]
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  project_count: summaries.length,
+                  total_hours: secondsToHours(summaries.reduce((t, s) => t + s.total_seconds, 0)),
+                  projects: summaries,
+                },
+                null,
+                2
+              ),
+            },
+          ],
         };
       }
-      
+
       case 'toggl_workspace_summary': {
         await ensureCache();
-        
+
         let entries: TimeEntry[];
-        
+
         if (args?.period) {
           const range = getDateRange(args.period as any);
           entries = await api.getTimeEntriesForDateRange(range.start, range.end);
@@ -674,168 +797,217 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           // Default to current week
           entries = await api.getTimeEntriesForWeek(0);
         }
-        
+
         const hydrated = await cache.hydrateTimeEntries(entries);
         const byWorkspace = groupEntriesByWorkspace(hydrated);
-        
+
         const summaries: any[] = [];
         byWorkspace.forEach((wsEntries, wsName) => {
           const wsId = wsEntries[0]?.workspace_id || 0;
           summaries.push(generateWorkspaceSummary(wsName, wsId, wsEntries));
         });
-        
+
         // Sort by total hours descending
         summaries.sort((a, b) => b.total_seconds - a.total_seconds);
-        
+
         return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({ 
-              workspace_count: summaries.length,
-              total_hours: secondsToHours(summaries.reduce((t, s) => t + s.total_seconds, 0)),
-              workspaces: summaries 
-            }, null, 2)
-          }]
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  workspace_count: summaries.length,
+                  total_hours: secondsToHours(summaries.reduce((t, s) => t + s.total_seconds, 0)),
+                  workspaces: summaries,
+                },
+                null,
+                2
+              ),
+            },
+          ],
         };
       }
-      
+
       // Management tools
       case 'toggl_list_workspaces': {
         const workspaces = await api.getWorkspaces();
-        
+
         return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({ 
-              count: workspaces.length,
-              workspaces: workspaces.map(ws => ({
-                id: ws.id,
-                name: ws.name,
-                premium: ws.premium,
-                default_currency: ws.default_currency
-              }))
-            }, null, 2)
-          }]
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  count: workspaces.length,
+                  workspaces: workspaces.map((ws) => ({
+                    id: ws.id,
+                    name: ws.name,
+                    premium: ws.premium,
+                    default_currency: ws.default_currency,
+                  })),
+                },
+                null,
+                2
+              ),
+            },
+          ],
         };
       }
-      
+
       case 'toggl_list_projects': {
         const workspaceId = args?.workspace_id || defaultWorkspaceId;
         if (!workspaceId) {
-          throw new Error('Workspace ID required (set TOGGL_DEFAULT_WORKSPACE_ID or provide workspace_id)');
+          throw new Error(
+            'Workspace ID required (set TOGGL_DEFAULT_WORKSPACE_ID or provide workspace_id)'
+          );
         }
-        
+
         const projects = await api.getProjects(workspaceId as number);
-        
+
         return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({ 
-              workspace_id: workspaceId,
-              count: projects.length,
-              projects: projects.map(p => ({
-                id: p.id,
-                name: p.name,
-                active: p.active,
-                billable: p.billable,
-                color: p.color,
-                client_id: p.client_id
-              }))
-            }, null, 2)
-          }]
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  workspace_id: workspaceId,
+                  count: projects.length,
+                  projects: projects.map((p) => ({
+                    id: p.id,
+                    name: p.name,
+                    active: p.active,
+                    billable: p.billable,
+                    color: p.color,
+                    client_id: p.client_id,
+                  })),
+                },
+                null,
+                2
+              ),
+            },
+          ],
         };
       }
-      
+
       case 'toggl_list_clients': {
         const workspaceId = args?.workspace_id || defaultWorkspaceId;
         if (!workspaceId) {
-          throw new Error('Workspace ID required (set TOGGL_DEFAULT_WORKSPACE_ID or provide workspace_id)');
+          throw new Error(
+            'Workspace ID required (set TOGGL_DEFAULT_WORKSPACE_ID or provide workspace_id)'
+          );
         }
-        
+
         const clients = await api.getClients(workspaceId as number);
-        
+
         return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({ 
-              workspace_id: workspaceId,
-              count: clients.length,
-              clients: clients.map(c => ({
-                id: c.id,
-                name: c.name,
-                archived: c.archived
-              }))
-            }, null, 2)
-          }]
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  workspace_id: workspaceId,
+                  count: clients.length,
+                  clients: clients.map((c) => ({
+                    id: c.id,
+                    name: c.name,
+                    archived: c.archived,
+                  })),
+                },
+                null,
+                2
+              ),
+            },
+          ],
         };
       }
-      
+
       // Cache management
       case 'toggl_warm_cache': {
         const workspaceId = (args?.workspace_id as number | undefined) || defaultWorkspaceId;
         await cache.warmCache(workspaceId);
         cacheWarmed = true;
-        
+
         const stats = cache.getStats();
-        
+
         return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({ 
-              success: true,
-              message: 'Cache warmed successfully',
-              stats 
-            }, null, 2)
-          }]
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  success: true,
+                  message: 'Cache warmed successfully',
+                  stats,
+                },
+                null,
+                2
+              ),
+            },
+          ],
         };
       }
-      
+
       case 'toggl_cache_stats': {
         const stats = cache.getStats();
-        const hitRate = stats.hits + stats.misses > 0
-          ? Math.round((stats.hits / (stats.hits + stats.misses)) * 100)
-          : 0;
-        
+        const hitRate =
+          stats.hits + stats.misses > 0
+            ? Math.round((stats.hits / (stats.hits + stats.misses)) * 100)
+            : 0;
+
         return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({ 
-              ...stats,
-              hit_rate: `${hitRate}%`,
-              cache_warmed: cacheWarmed
-            }, null, 2)
-          }]
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  ...stats,
+                  hit_rate: `${hitRate}%`,
+                  cache_warmed: cacheWarmed,
+                },
+                null,
+                2
+              ),
+            },
+          ],
         };
       }
-      
+
       case 'toggl_clear_cache': {
         cache.clearCache();
         cacheWarmed = false;
-        
+
         return {
-          content: [{
-            type: 'text',
-            text: JSON.stringify({ 
-              success: true,
-              message: 'Cache cleared successfully' 
-            })
-          }]
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                success: true,
+                message: 'Cache cleared successfully',
+              }),
+            },
+          ],
         };
       }
-      
+
       default:
         throw new Error(`Unknown tool: ${name}`);
     }
   } catch (error: any) {
     return {
-      content: [{
-        type: 'text',
-        text: JSON.stringify({ 
-          error: true,
-          message: error.message || 'An error occurred',
-          details: error.stack 
-        }, null, 2)
-      }]
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(
+            {
+              error: true,
+              message: error.message || 'An error occurred',
+              details: error.stack,
+            },
+            null,
+            2
+          ),
+        },
+      ],
     };
   }
 });

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -9,128 +9,123 @@ import type {
   TimeEntry,
   TimeEntriesRequest,
   CreateTimeEntryRequest,
-  UpdateTimeEntryRequest
+  UpdateTimeEntryRequest,
 } from './types.js';
 
 export class TogglAPI {
   private baseUrl = 'https://api.track.toggl.com/api/v9';
   private headers: Record<string, string>;
-  
+
   constructor(apiKey: string) {
     // Basic auth: API key as username, 'api_token' as password
     const key = apiKey.trim();
     const auth = Buffer.from(`${key}:api_token`).toString('base64');
     this.headers = {
-      'Authorization': `Basic ${auth}`,
+      Authorization: `Basic ${auth}`,
       'Content-Type': 'application/json',
-      'User-Agent': 'mcp-toggl/1.0.0 (+https://verygoodplugins.com)'
+      'User-Agent': 'mcp-toggl/1.0.0 (+https://verygoodplugins.com)',
     };
   }
-  
+
   // Generic API request method
-  private async request<T>(
-    method: string,
-    endpoint: string,
-    body?: any,
-    retries = 3
-  ): Promise<T> {
+  private async request<T>(method: string, endpoint: string, body?: any, retries = 3): Promise<T> {
     const url = `${this.baseUrl}${endpoint}`;
-    
+
     for (let i = 0; i < retries; i++) {
       try {
         const response = await fetch(url, {
           method,
           headers: this.headers,
-          body: body ? JSON.stringify(body) : undefined
+          body: body ? JSON.stringify(body) : undefined,
         });
-        
+
         // Handle rate limiting
         if (response.status === 429) {
           const retryAfter = response.headers.get('Retry-After');
           const delay = retryAfter ? parseInt(retryAfter) * 1000 : (i + 1) * 2000;
           // Log to stderr so we don't pollute MCP stdio
           console.error(`Rate limited. Retrying after ${delay}ms...`);
-          await new Promise(resolve => setTimeout(resolve, delay));
+          await new Promise((resolve) => setTimeout(resolve, delay));
           continue;
         }
-        
+
         if (!response.ok) {
           const text = await response.text();
           if (response.status === 401 || response.status === 403) {
             // Normalize common auth failure into a clearer message
             throw new Error(
               `Authentication failed (${response.status}). ` +
-              `Verify TOGGL_API_KEY is correct, has no leading/trailing spaces, and is the Toggl Track API token. ` +
-              `Server response: ${text}`
+                `Verify TOGGL_API_KEY is correct, has no leading/trailing spaces, and is the Toggl Track API token. ` +
+                `Server response: ${text}`
             );
           }
           throw new Error(`Toggl API error (${response.status}): ${text}`);
         }
-        
+
         // Handle 204 No Content
         if (response.status === 204) {
           return {} as T;
         }
-        
-        return await response.json() as T;
+
+        return (await response.json()) as T;
       } catch (error) {
         if (i === retries - 1) throw error;
         // Exponential backoff
-        await new Promise(resolve => setTimeout(resolve, (i + 1) * 1000));
+        await new Promise((resolve) => setTimeout(resolve, (i + 1) * 1000));
       }
     }
-    
+
     throw new Error('Max retries reached');
   }
-  
+
   // User methods
   async getMe(): Promise<User> {
     return this.request<User>('GET', '/me');
   }
-  
+
   async getUser(_userId: number): Promise<User> {
     // Note: This might require admin permissions
     return this.request<User>('GET', `/me`);
   }
-  
+
   // Workspace methods
   async getWorkspaces(): Promise<Workspace[]> {
     return this.request<Workspace[]>('GET', '/workspaces');
   }
-  
+
   async getWorkspace(workspaceId: number): Promise<Workspace> {
     return this.request<Workspace>('GET', `/workspaces/${workspaceId}`);
   }
-  
+
   // Project methods
   async getProjects(workspaceId: number): Promise<Project[]> {
     return this.request<Project[]>('GET', `/workspaces/${workspaceId}/projects`);
   }
-  
+
   async getProject(projectId: number): Promise<Project> {
     // First, we need to find which workspace this project belongs to
     // This is a limitation of Toggl API v9 - no direct project endpoint
     const workspaces = await this.getWorkspaces();
     for (const workspace of workspaces) {
       const projects = await this.getProjects(workspace.id);
-      const project = projects.find(p => p.id === projectId);
+      const project = projects.find((p) => p.id === projectId);
       if (project) return project;
     }
     throw new Error(`Project ${projectId} not found`);
   }
-  
+
   // Client methods
   async getClients(workspaceId: number): Promise<Client[]> {
     return this.request<Client[]>('GET', `/workspaces/${workspaceId}/clients`);
   }
-  
+
   async getClient(clientId: number): Promise<Client> {
     // Similar to projects, need to find workspace first
     const workspaces = await this.getWorkspaces();
     for (const workspace of workspaces) {
       try {
         const clients = await this.getClients(workspace.id);
-        const client = clients.find(c => c.id === clientId);
+        const client = clients.find((c) => c.id === clientId);
         if (client) return client;
       } catch (_error) {
         // Workspace might not have clients
@@ -139,29 +134,32 @@ export class TogglAPI {
     }
     throw new Error(`Client ${clientId} not found`);
   }
-  
+
   // Task methods
   async getTasks(workspaceId: number, projectId: number): Promise<Task[]> {
     return this.request<Task[]>('GET', `/workspaces/${workspaceId}/projects/${projectId}/tasks`);
   }
-  
+
   async getTask(workspaceId: number, projectId: number, taskId: number): Promise<Task> {
-    return this.request<Task>('GET', `/workspaces/${workspaceId}/projects/${projectId}/tasks/${taskId}`);
+    return this.request<Task>(
+      'GET',
+      `/workspaces/${workspaceId}/projects/${projectId}/tasks/${taskId}`
+    );
   }
-  
+
   // Tag methods
   async getTags(workspaceId: number): Promise<Tag[]> {
     return this.request<Tag[]>('GET', `/workspaces/${workspaceId}/tags`);
   }
-  
+
   async getTag(workspaceId: number, tagId: number): Promise<Tag> {
     return this.request<Tag>('GET', `/workspaces/${workspaceId}/tags/${tagId}`);
   }
-  
+
   // Time entry methods
   async getTimeEntries(params?: TimeEntriesRequest): Promise<TimeEntry[]> {
     let endpoint = '/me/time_entries';
-    
+
     if (params) {
       const queryParams = new URLSearchParams();
       if (params.start_date) queryParams.append('start_date', params.start_date);
@@ -169,122 +167,139 @@ export class TogglAPI {
       if (params.since) queryParams.append('since', params.since.toString());
       if (params.before) queryParams.append('before', params.before.toString());
       if (params.meta !== undefined) queryParams.append('meta', params.meta.toString());
-      
+
       const query = queryParams.toString();
       if (query) endpoint += `?${query}`;
     }
-    
+
     return this.request<TimeEntry[]>('GET', endpoint);
   }
-  
+
   async getCurrentTimeEntry(): Promise<TimeEntry | null> {
     const result = await this.request<TimeEntry | null>('GET', '/me/time_entries/current');
     return result;
   }
-  
+
   async getTimeEntry(timeEntryId: number): Promise<TimeEntry> {
     return this.request<TimeEntry>('GET', `/me/time_entries/${timeEntryId}`);
   }
-  
-  async createTimeEntry(workspaceId: number, entry: Partial<CreateTimeEntryRequest>): Promise<TimeEntry> {
+
+  async createTimeEntry(
+    workspaceId: number,
+    entry: Partial<CreateTimeEntryRequest>
+  ): Promise<TimeEntry> {
     const payload: CreateTimeEntryRequest = {
       workspace_id: workspaceId,
       created_with: 'mcp-toggl',
       start: entry.start || new Date().toISOString(),
-      ...entry
+      ...entry,
     };
-    
+
     return this.request<TimeEntry>('POST', `/workspaces/${workspaceId}/time_entries`, payload);
   }
-  
-  async updateTimeEntry(workspaceId: number, timeEntryId: number, updates: UpdateTimeEntryRequest): Promise<TimeEntry> {
-    return this.request<TimeEntry>('PUT', `/workspaces/${workspaceId}/time_entries/${timeEntryId}`, updates);
+
+  async updateTimeEntry(
+    workspaceId: number,
+    timeEntryId: number,
+    updates: UpdateTimeEntryRequest
+  ): Promise<TimeEntry> {
+    return this.request<TimeEntry>(
+      'PUT',
+      `/workspaces/${workspaceId}/time_entries/${timeEntryId}`,
+      updates
+    );
   }
-  
+
   async deleteTimeEntry(workspaceId: number, timeEntryId: number): Promise<void> {
     await this.request<void>('DELETE', `/workspaces/${workspaceId}/time_entries/${timeEntryId}`);
   }
-  
-  async startTimer(workspaceId: number, description?: string, projectId?: number, taskId?: number, tags?: string[]): Promise<TimeEntry> {
+
+  async startTimer(
+    workspaceId: number,
+    description?: string,
+    projectId?: number,
+    taskId?: number,
+    tags?: string[]
+  ): Promise<TimeEntry> {
     const entry: Partial<CreateTimeEntryRequest> = {
       description,
       project_id: projectId,
       task_id: taskId,
       tags,
       start: new Date().toISOString(),
-      duration: -1 // Negative duration indicates running timer
+      duration: -1, // Negative duration indicates running timer
     };
-    
+
     return this.createTimeEntry(workspaceId, entry);
   }
-  
+
   async stopTimer(workspaceId: number, timeEntryId: number): Promise<TimeEntry> {
     const now = new Date().toISOString();
     return this.updateTimeEntry(workspaceId, timeEntryId, { stop: now });
   }
-  
+
   // Bulk operations for efficiency
   async getTimeEntriesForDateRange(startDate: Date, endDate: Date): Promise<TimeEntry[]> {
     const params: TimeEntriesRequest = {
       start_date: startDate.toISOString().split('T')[0],
-      end_date: endDate.toISOString().split('T')[0]
+      end_date: endDate.toISOString().split('T')[0],
     };
-    
+
     return this.getTimeEntries(params);
   }
-  
+
   async getTimeEntriesForToday(): Promise<TimeEntry[]> {
     const today = new Date();
     today.setHours(0, 0, 0, 0);
     const tomorrow = new Date(today);
     tomorrow.setDate(tomorrow.getDate() + 1);
-    
+
     return this.getTimeEntriesForDateRange(today, tomorrow);
   }
-  
+
   async getTimeEntriesForWeek(weekOffset = 0): Promise<TimeEntry[]> {
     const today = new Date();
     const dayOfWeek = today.getDay();
     const diff = today.getDate() - dayOfWeek + (dayOfWeek === 0 ? -6 : 1); // Adjust for Sunday
-    
+
     const monday = new Date(today.setDate(diff));
-    monday.setDate(monday.getDate() + (weekOffset * 7));
+    monday.setDate(monday.getDate() + weekOffset * 7);
     monday.setHours(0, 0, 0, 0);
-    
+
     const sunday = new Date(monday);
     sunday.setDate(sunday.getDate() + 6);
     sunday.setHours(23, 59, 59, 999);
-    
+
     return this.getTimeEntriesForDateRange(monday, sunday);
   }
-  
+
   async getTimeEntriesForMonth(monthOffset = 0): Promise<TimeEntry[]> {
     const today = new Date();
     const year = today.getFullYear();
     const month = today.getMonth() + monthOffset;
-    
+
     const firstDay = new Date(year, month, 1);
     const lastDay = new Date(year, month + 1, 0);
-    
+
     return this.getTimeEntriesForDateRange(firstDay, lastDay);
   }
-  
+
   // Reports API endpoints (if needed)
   async getDetailedReport(workspaceId: number, params: any): Promise<any> {
     // This would use the Reports API v3 if needed
     // https://api.track.toggl.com/reports/api/v3/workspace/{workspace_id}/search/time_entries
     const reportsUrl = `https://api.track.toggl.com/reports/api/v3/workspace/${workspaceId}/search/time_entries`;
-    
+
     const response = await fetch(reportsUrl, {
       method: 'POST',
       headers: this.headers,
-      body: JSON.stringify(params)
+      body: JSON.stringify(params),
     });
-    
+
     if (!response.ok) {
       throw new Error(`Reports API error: ${response.status}`);
     }
-    
+
     return response.json();
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,9 +5,9 @@ export interface TogglConfig {
 }
 
 export interface CacheConfig {
-  ttl: number;        // Time-to-live in milliseconds
-  maxSize: number;    // Maximum number of cached entities
-  batchSize: number;  // Number of entries to fetch per request
+  ttl: number; // Time-to-live in milliseconds
+  maxSize: number; // Maximum number of cached entities
+  batchSize: number; // Number of entries to fetch per request
 }
 
 // Core Toggl entities
@@ -113,7 +113,7 @@ export interface TimeEntry {
   billable?: boolean;
   start: string;
   stop?: string;
-  duration: number;  // In seconds, negative if currently running
+  duration: number; // In seconds, negative if currently running
   description?: string;
   tags?: string[];
   tag_ids?: number[];
@@ -198,11 +198,11 @@ export interface WorkspaceSummary {
 
 // API request/response interfaces
 export interface TimeEntriesRequest {
-  start_date?: string;  // ISO 8601 date
-  end_date?: string;    // ISO 8601 date
-  since?: number;       // Unix timestamp
-  before?: number;      // Unix timestamp
-  meta?: boolean;       // Include meta information
+  start_date?: string; // ISO 8601 date
+  end_date?: string; // ISO 8601 date
+  since?: number; // Unix timestamp
+  before?: number; // Unix timestamp
+  meta?: boolean; // Include meta information
 }
 
 export interface CreateTimeEntryRequest {
@@ -213,9 +213,9 @@ export interface CreateTimeEntryRequest {
   tags?: string[];
   tag_ids?: number[];
   billable?: boolean;
-  start: string;  // ISO 8601 datetime
-  stop?: string;  // ISO 8601 datetime
-  duration?: number;  // For entries with only duration
+  start: string; // ISO 8601 datetime
+  stop?: string; // ISO 8601 datetime
+  duration?: number; // For entries with only duration
   created_with: string;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,7 +5,7 @@ import type {
   ProjectSummary,
   WorkspaceSummary,
   ReportEntry,
-  DateRange
+  DateRange,
 } from './types.js';
 
 // Convert seconds to hours with decimal precision
@@ -18,7 +18,7 @@ export function formatDuration(seconds: number): string {
   const hours = Math.floor(seconds / 3600);
   const minutes = Math.floor((seconds % 3600) / 60);
   const secs = seconds % 60;
-  
+
   if (hours > 0) {
     return `${hours}h ${minutes}m`;
   } else if (minutes > 0) {
@@ -35,28 +35,30 @@ export function formatDate(dateStr: string): string {
     weekday: 'short',
     year: 'numeric',
     month: 'short',
-    day: 'numeric'
+    day: 'numeric',
   });
 }
 
 // Get date range for various periods
-export function getDateRange(period: 'today' | 'yesterday' | 'week' | 'lastWeek' | 'month' | 'lastMonth'): DateRange {
+export function getDateRange(
+  period: 'today' | 'yesterday' | 'week' | 'lastWeek' | 'month' | 'lastMonth'
+): DateRange {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
-  
+
   switch (period) {
     case 'today': {
       const tomorrow = new Date(today);
       tomorrow.setDate(tomorrow.getDate() + 1);
       return { start: today, end: tomorrow };
     }
-    
+
     case 'yesterday': {
       const yesterday = new Date(today);
       yesterday.setDate(yesterday.getDate() - 1);
       return { start: yesterday, end: today };
     }
-    
+
     case 'week': {
       const dayOfWeek = today.getDay();
       const diff = today.getDate() - dayOfWeek + (dayOfWeek === 0 ? -6 : 1);
@@ -66,7 +68,7 @@ export function getDateRange(period: 'today' | 'yesterday' | 'week' | 'lastWeek'
       sunday.setHours(23, 59, 59, 999);
       return { start: monday, end: sunday };
     }
-    
+
     case 'lastWeek': {
       const dayOfWeek = today.getDay();
       const diff = today.getDate() - dayOfWeek + (dayOfWeek === 0 ? -6 : 1) - 7;
@@ -76,14 +78,14 @@ export function getDateRange(period: 'today' | 'yesterday' | 'week' | 'lastWeek'
       sunday.setHours(23, 59, 59, 999);
       return { start: monday, end: sunday };
     }
-    
+
     case 'month': {
       const firstDay = new Date(today.getFullYear(), today.getMonth(), 1);
       const lastDay = new Date(today.getFullYear(), today.getMonth() + 1, 0);
       lastDay.setHours(23, 59, 59, 999);
       return { start: firstDay, end: lastDay };
     }
-    
+
     case 'lastMonth': {
       const firstDay = new Date(today.getFullYear(), today.getMonth() - 1, 1);
       const lastDay = new Date(today.getFullYear(), today.getMonth(), 0);
@@ -96,45 +98,49 @@ export function getDateRange(period: 'today' | 'yesterday' | 'week' | 'lastWeek'
 // Group time entries by date
 export function groupEntriesByDate(entries: HydratedTimeEntry[]): Map<string, HydratedTimeEntry[]> {
   const grouped = new Map<string, HydratedTimeEntry[]>();
-  
-  entries.forEach(entry => {
+
+  entries.forEach((entry) => {
     const date = entry.start.split('T')[0];
     if (!grouped.has(date)) {
       grouped.set(date, []);
     }
     grouped.get(date)!.push(entry);
   });
-  
+
   return grouped;
 }
 
 // Group time entries by project
-export function groupEntriesByProject(entries: HydratedTimeEntry[]): Map<string, HydratedTimeEntry[]> {
+export function groupEntriesByProject(
+  entries: HydratedTimeEntry[]
+): Map<string, HydratedTimeEntry[]> {
   const grouped = new Map<string, HydratedTimeEntry[]>();
-  
-  entries.forEach(entry => {
+
+  entries.forEach((entry) => {
     const key = entry.project_name || 'No Project';
     if (!grouped.has(key)) {
       grouped.set(key, []);
     }
     grouped.get(key)!.push(entry);
   });
-  
+
   return grouped;
 }
 
 // Group time entries by workspace
-export function groupEntriesByWorkspace(entries: HydratedTimeEntry[]): Map<string, HydratedTimeEntry[]> {
+export function groupEntriesByWorkspace(
+  entries: HydratedTimeEntry[]
+): Map<string, HydratedTimeEntry[]> {
   const grouped = new Map<string, HydratedTimeEntry[]>();
-  
-  entries.forEach(entry => {
+
+  entries.forEach((entry) => {
     const key = entry.workspace_name;
     if (!grouped.has(key)) {
       grouped.set(key, []);
     }
     grouped.get(key)!.push(entry);
   });
-  
+
   return grouped;
 }
 
@@ -142,19 +148,21 @@ export function groupEntriesByWorkspace(entries: HydratedTimeEntry[]): Map<strin
 export function calculateTotalDuration(entries: HydratedTimeEntry[]): number {
   return entries.reduce((total, entry) => {
     // Handle running timers (negative duration)
-    const duration = entry.duration < 0 
-      ? Math.floor((Date.now() - new Date(entry.start).getTime()) / 1000)
-      : entry.duration;
+    const duration =
+      entry.duration < 0
+        ? Math.floor((Date.now() - new Date(entry.start).getTime()) / 1000)
+        : entry.duration;
     return total + duration;
   }, 0);
 }
 
 // Create a report entry from a hydrated time entry
 export function createReportEntry(entry: HydratedTimeEntry): ReportEntry {
-  const duration = entry.duration < 0
-    ? Math.floor((Date.now() - new Date(entry.start).getTime()) / 1000)
-    : entry.duration;
-    
+  const duration =
+    entry.duration < 0
+      ? Math.floor((Date.now() - new Date(entry.start).getTime()) / 1000)
+      : entry.duration;
+
   return {
     id: entry.id,
     workspace: entry.workspace_name,
@@ -167,7 +175,7 @@ export function createReportEntry(entry: HydratedTimeEntry): ReportEntry {
     duration_hours: secondsToHours(duration),
     duration_seconds: duration,
     tags: entry.tag_names || entry.tags,
-    billable: entry.billable
+    billable: entry.billable,
   };
 }
 
@@ -178,9 +186,9 @@ export function generateProjectSummary(
 ): ProjectSummary {
   const totalSeconds = calculateTotalDuration(entries);
   const billableSeconds = entries
-    .filter(e => e.billable)
+    .filter((e) => e.billable)
     .reduce((total, e) => total + (e.duration < 0 ? 0 : e.duration), 0);
-  
+
   return {
     project_id: entries[0]?.project_id,
     project_name: projectName,
@@ -190,7 +198,7 @@ export function generateProjectSummary(
     total_seconds: totalSeconds,
     billable_hours: secondsToHours(billableSeconds),
     billable_seconds: billableSeconds,
-    entry_count: entries.length
+    entry_count: entries.length,
   };
 }
 
@@ -202,11 +210,11 @@ export function generateWorkspaceSummary(
 ): WorkspaceSummary {
   const totalSeconds = calculateTotalDuration(entries);
   const billableSeconds = entries
-    .filter(e => e.billable)
+    .filter((e) => e.billable)
     .reduce((total, e) => total + (e.duration < 0 ? 0 : e.duration), 0);
-  
-  const projectIds = new Set(entries.map(e => e.project_id).filter(Boolean));
-  
+
+  const projectIds = new Set(entries.map((e) => e.project_id).filter(Boolean));
+
   return {
     workspace_id: workspaceId,
     workspace_name: workspaceName,
@@ -215,7 +223,7 @@ export function generateWorkspaceSummary(
     billable_hours: secondsToHours(billableSeconds),
     billable_seconds: billableSeconds,
     project_count: projectIds.size,
-    entry_count: entries.length
+    entry_count: entries.length,
   };
 }
 
@@ -223,14 +231,14 @@ export function generateWorkspaceSummary(
 export function generateDailyReport(date: string, entries: HydratedTimeEntry[]): DailyReport {
   const totalSeconds = calculateTotalDuration(entries);
   const reportEntries = entries.map(createReportEntry);
-  
+
   // Group by project
   const byProject = groupEntriesByProject(entries);
   const projectSummaries: ProjectSummary[] = [];
   byProject.forEach((projectEntries, projectName) => {
     projectSummaries.push(generateProjectSummary(projectName, projectEntries));
   });
-  
+
   // Group by workspace
   const byWorkspace = groupEntriesByWorkspace(entries);
   const workspaceSummaries: WorkspaceSummary[] = [];
@@ -238,14 +246,14 @@ export function generateDailyReport(date: string, entries: HydratedTimeEntry[]):
     const wsId = wsEntries[0]?.workspace_id || 0;
     workspaceSummaries.push(generateWorkspaceSummary(wsName, wsId, wsEntries));
   });
-  
+
   return {
     date,
     total_hours: secondsToHours(totalSeconds),
     total_seconds: totalSeconds,
     entries: reportEntries,
     by_project: projectSummaries,
-    by_workspace: workspaceSummaries
+    by_workspace: workspaceSummaries,
   };
 }
 
@@ -256,24 +264,24 @@ export function generateWeeklyReport(
   entries: HydratedTimeEntry[]
 ): WeeklyReport {
   const totalSeconds = calculateTotalDuration(entries);
-  
+
   // Group by date for daily breakdown
   const byDate = groupEntriesByDate(entries);
   const dailyBreakdown: DailyReport[] = [];
   byDate.forEach((dateEntries, date) => {
     dailyBreakdown.push(generateDailyReport(date, dateEntries));
   });
-  
+
   // Sort daily reports
   dailyBreakdown.sort((a, b) => a.date.localeCompare(b.date));
-  
+
   // Overall project summaries
   const byProject = groupEntriesByProject(entries);
   const projectSummaries: ProjectSummary[] = [];
   byProject.forEach((projectEntries, projectName) => {
     projectSummaries.push(generateProjectSummary(projectName, projectEntries));
   });
-  
+
   // Overall workspace summaries
   const byWorkspace = groupEntriesByWorkspace(entries);
   const workspaceSummaries: WorkspaceSummary[] = [];
@@ -281,7 +289,7 @@ export function generateWeeklyReport(
     const wsId = wsEntries[0]?.workspace_id || 0;
     workspaceSummaries.push(generateWorkspaceSummary(wsName, wsId, wsEntries));
   });
-  
+
   return {
     week_start: weekStart.toISOString().split('T')[0],
     week_end: weekEnd.toISOString().split('T')[0],
@@ -289,22 +297,22 @@ export function generateWeeklyReport(
     total_seconds: totalSeconds,
     daily_breakdown: dailyBreakdown,
     by_project: projectSummaries,
-    by_workspace: workspaceSummaries
+    by_workspace: workspaceSummaries,
   };
 }
 
 // Format report for display
 export function formatReportForDisplay(report: DailyReport | WeeklyReport): string {
   const lines: string[] = [];
-  
+
   if ('week_start' in report) {
     // Weekly report
     lines.push(`📊 Weekly Report (${report.week_start} to ${report.week_end})`);
     lines.push(`Total: ${report.total_hours} hours`);
     lines.push('');
-    
+
     lines.push('📅 Daily Breakdown:');
-    report.daily_breakdown.forEach(day => {
+    report.daily_breakdown.forEach((day) => {
       lines.push(`  ${day.date}: ${day.total_hours}h`);
     });
   } else {
@@ -312,19 +320,19 @@ export function formatReportForDisplay(report: DailyReport | WeeklyReport): stri
     lines.push(`📊 Daily Report for ${report.date}`);
     lines.push(`Total: ${report.total_hours} hours`);
   }
-  
+
   lines.push('');
   lines.push('🏢 By Workspace:');
-  report.by_workspace.forEach(ws => {
+  report.by_workspace.forEach((ws) => {
     lines.push(`  ${ws.workspace_name}: ${ws.total_hours}h (${ws.project_count} projects)`);
   });
-  
+
   lines.push('');
   lines.push('📁 By Project:');
-  report.by_project.forEach(proj => {
+  report.by_project.forEach((proj) => {
     const client = proj.client_name ? ` (${proj.client_name})` : '';
     lines.push(`  ${proj.project_name}${client}: ${proj.total_hours}h`);
   });
-  
+
   return lines.join('\n');
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ES2022",
+    "module": "Node16",
     "lib": ["ES2022"],
     "outDir": "./dist",
     "rootDir": "./src",
@@ -10,7 +10,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "moduleResolution": "node",
+    "moduleResolution": "Node16",
     "allowSyntheticDefaultImports": true,
     "declaration": true,
     "declarationMap": true,
@@ -21,11 +21,5 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src/**/*"],
-  "exclude": [
-    "node_modules",
-    "dist",
-    "**/*.test.ts",
-    "**/*.spec.ts",
-    "src/test.ts"
-  ]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts", "src/test.ts"]
 }


### PR DESCRIPTION
## Summary
- Upgrade MCP SDK to 1.29.0 and TypeScript to 6.0.3, with Node16 module resolution so Dependabot/TS6 CI stops failing.
- Switch package/license docs to MIT and keep package-lock in sync with zero high-severity audit findings.
- Add MCP tool annotations and apply the repo Prettier baseline so formatting is idempotent.

## Test plan
- npm run format
- git diff --check
- npm run lint
- npm run build
- npm test
- npm audit --audit-level=high
- ../mcp-ecosystem/scripts/audit-server.sh ../mcp-toggl