### PR TITLE
feat: add Toggl timeline tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ dist/
 .env.local
 *.log
 .DS_Store
+.cursor/
+AGENTS.md
 .vscode/
 .idea/
 *.swp

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,8 @@ import {
   Tool,
 } from '@modelcontextprotocol/sdk/types.js';
 import { config } from 'dotenv';
-import { TogglAPI } from './toggl-api.js';
+import { TogglAPI, TimelineNotEnabledError } from './toggl-api.js';
+import { buildTimelineResponse } from './timeline.js';
 import { CacheManager } from './cache-manager.js';
 import {
   getDateRange,
@@ -22,12 +23,27 @@ import {
   toLocalYMD,
   parseLocalYMD,
 } from './utils.js';
-import type { CacheConfig, TimeEntry } from './types.js';
+import type { CacheConfig, TimelineEvent, TimeEntry } from './types.js';
 
 function parseInclusiveEndDate(value: string): Date {
   const date = parseLocalYMD(value);
   date.setDate(date.getDate() + 1);
   return date;
+}
+
+function jsonResponse(data: unknown) {
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(data, null, 2),
+      },
+    ],
+  };
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : 'An error occurred';
 }
 
 // Version for CLI output and server metadata
@@ -459,6 +475,56 @@ const tools: Tool[] = [
       type: 'object',
       properties: {},
       required: [],
+    },
+  },
+  {
+    name: 'toggl_get_timeline',
+    description:
+      'Get Toggl Desktop activity timeline showing application usage. PRIVACY NOTE: raw events include window titles that may contain sensitive document names, email subjects, chat text, URLs, OAuth pages, or database names; use include_events: false for privacy-conscious summary-only usage. Requires Toggl Track Desktop timeline sync to be enabled. Response semantics: summary is { [appName: string]: total_seconds }; total_events is the post-filter event count; returned_events is the returned events array length; truncated means only the events array was limited, never the summary. limit does not affect summary calculation. total_seconds is canonical; total_hours is rounded to 4 decimals for display.',
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        period: {
+          type: 'string',
+          enum: ['today', 'yesterday', 'week', 'lastWeek', 'month', 'lastMonth'],
+          description: 'Predefined period (alternative to start_date/end_date)',
+        },
+        start_date: {
+          type: 'string',
+          description: 'Start date (YYYY-MM-DD format, inclusive, local timezone)',
+        },
+        end_date: {
+          type: 'string',
+          description: 'End date (YYYY-MM-DD format, inclusive, local timezone)',
+        },
+        app: {
+          type: 'string',
+          description: 'Filter by application name, case-insensitive partial match',
+        },
+        include_events: {
+          type: 'boolean',
+          description: 'Include raw events array (default: true). Set false for summary only.',
+        },
+        redact_titles: {
+          type: 'boolean',
+          default: false,
+          description:
+            'When true, returned events keep app name, timestamps, duration, idle state, and desktop_id, but set title to null.',
+        },
+        limit: {
+          type: 'number',
+          minimum: 1,
+          maximum: 1000,
+          default: 50,
+          description:
+            'Maximum events to return in events array (default: 50, max: 1000). Does not affect summary calculation.',
+        },
+      },
     },
   },
 ];
@@ -1004,26 +1070,41 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         };
       }
 
+      case 'toggl_get_timeline': {
+        buildTimelineResponse([], args);
+
+        let allEvents: TimelineEvent[];
+        try {
+          allEvents = await api.getTimeline();
+        } catch (error) {
+          if (error instanceof TimelineNotEnabledError) {
+            return jsonResponse({
+              enabled: false,
+              total_events: 0,
+              returned_events: 0,
+              truncated: false,
+              total_seconds: 0,
+              total_hours: 0,
+              summary: {},
+              events: [],
+              message:
+                'Toggl Desktop timeline is not enabled yet. Open the Toggl Track Desktop app for Mac, enable timeline/activity tracking and sync, then retry this tool after the app has uploaded activity data.',
+            });
+          }
+          throw error;
+        }
+
+        return jsonResponse(buildTimelineResponse(allEvents, args));
+      }
+
       default:
         throw new Error(`Unknown tool: ${name}`);
     }
-  } catch (error: any) {
-    return {
-      content: [
-        {
-          type: 'text',
-          text: JSON.stringify(
-            {
-              error: true,
-              message: error.message || 'An error occurred',
-              details: error.stack,
-            },
-            null,
-            2
-          ),
-        },
-      ],
-    };
+  } catch (error: unknown) {
+    return jsonResponse({
+      error: true,
+      message: errorMessage(error),
+    });
   }
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import {
   generateWorkspaceSummary,
   toLocalYMD,
   parseLocalYMD,
+  localDateRangeFromArgs,
 } from './utils.js';
 import type { CacheConfig, TimelineEvent, TimeEntry } from './types.js';
 
@@ -1071,7 +1072,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'toggl_get_timeline': {
-        buildTimelineResponse([], args);
+        localDateRangeFromArgs(args);
 
         let allEvents: TimelineEvent[];
         try {

--- a/src/timeline.ts
+++ b/src/timeline.ts
@@ -1,0 +1,87 @@
+import type { EnrichedTimelineEvent, TimelineEvent } from './types.js';
+import { localDateRangeFromArgs } from './utils.js';
+
+interface TimelineArgs extends Record<string, unknown> {
+  app?: unknown;
+  include_events?: unknown;
+  limit?: unknown;
+  redact_titles?: unknown;
+  period?: unknown;
+  start_date?: unknown;
+  end_date?: unknown;
+}
+
+export interface TimelineResponse {
+  enabled: true;
+  total_events: number;
+  returned_events: number;
+  truncated: boolean;
+  total_seconds: number;
+  total_hours: number;
+  summary: Record<string, number>;
+  events?: EnrichedTimelineEvent[];
+}
+
+export function timelineSecondsToHours(seconds: number): number {
+  return Math.round((seconds / 3600) * 10000) / 10000;
+}
+
+export function buildTimelineResponse(
+  allEvents: TimelineEvent[],
+  args: TimelineArgs | undefined,
+  nowSeconds = Math.floor(Date.now() / 1000)
+): TimelineResponse {
+  const range = localDateRangeFromArgs(args);
+  const startTs = range?.start ? range.start.getTime() / 1000 : null;
+  const endTs = range?.end ? range.end.getTime() / 1000 : null;
+  const appFilter = typeof args?.app === 'string' ? args.app.toLowerCase() : null;
+  const includeEvents = args?.include_events !== false;
+  const redactTitles = args?.redact_titles === true;
+  const rawLimit = typeof args?.limit === 'number' ? args.limit : 50;
+  const limit = Math.max(1, Math.min(Math.floor(rawLimit), 1000));
+
+  const appSummary = new Map<string, number>();
+  const events: EnrichedTimelineEvent[] = [];
+  let totalEvents = 0;
+  let totalSeconds = 0;
+
+  for (const event of allEvents) {
+    const eventEnd = event.end_time ?? nowSeconds;
+
+    if (startTs !== null && eventEnd <= startTs) continue;
+    if (endTs !== null && event.start_time >= endTs) continue;
+
+    const filename = event.filename ?? 'Unknown';
+    if (appFilter && !filename.toLowerCase().includes(appFilter)) continue;
+
+    const clippedStart = startTs !== null ? Math.max(event.start_time, startTs) : event.start_time;
+    const clippedEnd = endTs !== null ? Math.min(eventEnd, endTs) : eventEnd;
+    const duration = Math.max(0, Math.floor(clippedEnd - clippedStart));
+
+    totalEvents++;
+    totalSeconds += duration;
+    appSummary.set(filename, (appSummary.get(filename) ?? 0) + duration);
+
+    if (includeEvents && events.length < limit) {
+      events.push({
+        ...event,
+        filename,
+        title: redactTitles ? null : event.title,
+        start: new Date(event.start_time * 1000).toISOString(),
+        end: new Date(eventEnd * 1000).toISOString(),
+        duration_seconds: duration,
+      });
+    }
+  }
+
+  return {
+    enabled: true,
+    total_events: totalEvents,
+    returned_events: events.length,
+    truncated: includeEvents && totalEvents > events.length,
+    total_seconds: totalSeconds,
+    total_hours: timelineSecondsToHours(totalSeconds),
+    summary: Object.fromEntries([...appSummary.entries()].sort(([, a], [, b]) => b - a)),
+    ...(includeEvents ? { events } : {}),
+  };
+}

--- a/src/timeline.ts
+++ b/src/timeline.ts
@@ -67,8 +67,8 @@ export function buildTimelineResponse(
         ...event,
         filename,
         title: redactTitles ? null : event.title,
-        start: new Date(event.start_time * 1000).toISOString(),
-        end: new Date(eventEnd * 1000).toISOString(),
+        start: new Date(clippedStart * 1000).toISOString(),
+        end: new Date(clippedEnd * 1000).toISOString(),
         duration_seconds: duration,
       });
     }

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -11,10 +11,19 @@ import type {
   TimeEntriesRequest,
   CreateTimeEntryRequest,
   UpdateTimeEntryRequest,
+  TimelineEvent,
 } from './types.js';
+
+export class TimelineNotEnabledError extends Error {
+  constructor() {
+    super('Timeline is not enabled');
+    this.name = 'TimelineNotEnabledError';
+  }
+}
 
 export class TogglAPI {
   private baseUrl = 'https://api.track.toggl.com/api/v9';
+  private timelineBaseUrl = 'https://track.toggl.com/api/v9';
   private headers: Record<string, string>;
 
   constructor(apiKey: string) {
@@ -305,4 +314,86 @@ export class TogglAPI {
 
     return response.json();
   }
+
+  async getTimeline(): Promise<TimelineEvent[]> {
+    const url = `${this.timelineBaseUrl}/timeline`;
+    const maxRetries = 3;
+
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      try {
+        const response = await fetch(url, {
+          method: 'GET',
+          headers: this.headers,
+        });
+
+        if (response.status === 429) {
+          const retryAfter = response.headers.get('Retry-After');
+          const delay = retryAfter ? parseInt(retryAfter, 10) * 1000 : (attempt + 1) * 2000;
+          console.error(`Timeline rate limited. Retrying after ${delay}ms...`);
+          await new Promise((resolve) => setTimeout(resolve, delay));
+          continue;
+        }
+
+        const text = await response.text();
+
+        if (!response.ok) {
+          if (response.status === 400 && parseTimelineError(text) === 'Timeline is not enabled') {
+            throw new TimelineNotEnabledError();
+          }
+
+          const isAuth = response.status === 401 || response.status === 403;
+          const message = isAuth
+            ? `Timeline authentication failed (${response.status}). Verify TOGGL_API_KEY is correct. Server response: ${text}`
+            : `Timeline API error (${response.status}): ${text}`;
+          const err = new Error(message);
+          if (response.status >= 400 && response.status < 500) {
+            Object.assign(err, { noRetry: true });
+          }
+          throw err;
+        }
+
+        const data = JSON.parse(text) as unknown;
+        if (!Array.isArray(data)) {
+          throw new Error('Timeline API returned invalid response format');
+        }
+
+        return data.filter(isTimelineEvent);
+      } catch (error: any) {
+        if (
+          error instanceof TimelineNotEnabledError ||
+          error?.noRetry ||
+          attempt === maxRetries - 1
+        ) {
+          throw error;
+        }
+        await new Promise((resolve) => setTimeout(resolve, (attempt + 1) * 1000));
+      }
+    }
+
+    throw new Error('Max retries reached for timeline');
+  }
+}
+
+function parseTimelineError(text: string): string {
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    return typeof parsed === 'string' ? parsed : text;
+  } catch (_error) {
+    return text;
+  }
+}
+
+function isTimelineEvent(value: unknown): value is TimelineEvent {
+  if (typeof value !== 'object' || value === null) return false;
+  const event = value as Record<string, unknown>;
+
+  return (
+    typeof event.id === 'number' &&
+    typeof event.start_time === 'number' &&
+    (typeof event.end_time === 'number' || event.end_time === null) &&
+    typeof event.desktop_id === 'string' &&
+    typeof event.idle === 'boolean' &&
+    (typeof event.filename === 'string' || event.filename === null) &&
+    (typeof event.title === 'string' || event.title === null)
+  );
 }

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -328,7 +328,18 @@ export class TogglAPI {
 
         if (response.status === 429) {
           const retryAfter = response.headers.get('Retry-After');
-          const delay = retryAfter ? parseInt(retryAfter, 10) * 1000 : (attempt + 1) * 2000;
+          let delay: number;
+          if (retryAfter) {
+            const deltaSeconds = parseInt(retryAfter, 10);
+            if (Number.isFinite(deltaSeconds)) {
+              delay = deltaSeconds * 1000;
+            } else {
+              const dateMs = Date.parse(retryAfter);
+              delay = Number.isFinite(dateMs) ? Math.max(0, dateMs - Date.now()) : (attempt + 1) * 2000;
+            }
+          } else {
+            delay = (attempt + 1) * 2000;
+          }
           console.error(`Timeline rate limited. Retrying after ${delay}ms...`);
           await new Promise((resolve) => setTimeout(resolve, delay));
           continue;

--- a/src/types.ts
+++ b/src/types.ts
@@ -231,6 +231,23 @@ export interface UpdateTimeEntryRequest {
   duration?: number;
 }
 
+export interface TimelineEvent {
+  id: number;
+  start_time: number; // Unix timestamp in seconds
+  end_time: number | null; // Unix timestamp in seconds, null if active
+  desktop_id: string;
+  idle: boolean;
+  filename: string | null; // Application name
+  title: string | null; // Window title, may contain sensitive data
+}
+
+export interface EnrichedTimelineEvent extends TimelineEvent {
+  filename: string;
+  start: string;
+  end: string;
+  duration_seconds: number;
+}
+
 // Cache interfaces
 export interface CacheEntry<T> {
   data: T;
@@ -270,6 +287,8 @@ export interface DateRange {
   start: Date;
   end: Date;
 }
+
+export type DatePeriod = 'today' | 'yesterday' | 'week' | 'lastWeek' | 'month' | 'lastMonth';
 
 export interface GroupedEntries {
   [key: string]: HydratedTimeEntry[];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,7 @@ import type {
   WorkspaceSummary,
   ReportEntry,
   DateRange,
+  DatePeriod,
 } from './types.js';
 
 // Convert seconds to hours with decimal precision
@@ -49,14 +50,76 @@ export function toLocalYMD(date: Date): string {
 
 // Parse a YYYY-MM-DD string into a Date at local midnight.
 export function parseLocalYMD(value: string): Date {
-  const [year, month, day] = value.split('-').map(Number);
-  return new Date(year, (month ?? 1) - 1, day ?? 1, 0, 0, 0, 0);
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) {
+    throw new Error(`Invalid date format: ${value}. Expected YYYY-MM-DD.`);
+  }
+
+  const [, yearStr, monthStr, dayStr] = match;
+  const year = Number(yearStr);
+  const month = Number(monthStr);
+  const day = Number(dayStr);
+  const date = new Date(year, month - 1, day, 0, 0, 0, 0);
+
+  if (date.getFullYear() !== year || date.getMonth() !== month - 1 || date.getDate() !== day) {
+    throw new Error(`Invalid calendar date: ${value}`);
+  }
+
+  return date;
+}
+
+export function isDatePeriod(value: unknown): value is DatePeriod {
+  return (
+    value === 'today' ||
+    value === 'yesterday' ||
+    value === 'week' ||
+    value === 'lastWeek' ||
+    value === 'month' ||
+    value === 'lastMonth'
+  );
+}
+
+export function localDateRangeFromArgs(
+  args: Record<string, unknown> | undefined
+): { start: Date | null; end: Date | null } | null {
+  if (args?.period !== undefined) {
+    if (!isDatePeriod(args.period)) {
+      throw new Error(
+        `Invalid period: ${String(args.period)}. Must be one of: today, yesterday, week, lastWeek, month, lastMonth`
+      );
+    }
+    return getDateRange(args.period);
+  }
+
+  const startValue = args?.start_date;
+  const endValue = args?.end_date;
+
+  if (startValue === undefined && endValue === undefined) {
+    return null;
+  }
+
+  if (startValue !== undefined && typeof startValue !== 'string') {
+    throw new Error('start_date must be a YYYY-MM-DD string');
+  }
+  if (endValue !== undefined && typeof endValue !== 'string') {
+    throw new Error('end_date must be a YYYY-MM-DD string');
+  }
+
+  const start = startValue ? parseLocalYMD(startValue) : null;
+  const end = endValue ? parseLocalYMD(endValue) : null;
+  if (end) {
+    end.setDate(end.getDate() + 1);
+  }
+
+  if (start && end && start >= end) {
+    throw new Error('start_date must be before or equal to end_date');
+  }
+
+  return { start, end };
 }
 
 // Get date range for various periods
-export function getDateRange(
-  period: 'today' | 'yesterday' | 'week' | 'lastWeek' | 'month' | 'lastMonth'
-): DateRange {
+export function getDateRange(period: DatePeriod): DateRange {
   const today = new Date();
   today.setHours(0, 0, 0, 0);
 

--- a/tests/stdio-smoke.test.ts
+++ b/tests/stdio-smoke.test.ts
@@ -2,6 +2,8 @@ import { execFile } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { promisify } from 'node:util';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { describe, expect, it } from 'vitest';
 
 const execFileAsync = promisify(execFile);
@@ -40,5 +42,55 @@ describe.skipIf(!existsSync(entryPoint))('stdio smoke checks', () => {
     expect(result?.code).toBe(1);
     expect(result?.stdout).toBe('');
     expect(result?.stderr).toContain('Missing required environment variable');
+  });
+
+  it('exposes timeline schema bounds and sanitized tool errors', async () => {
+    const client = new Client({ name: 'mcp-toggl-test', version: '1.0.0' });
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [entryPoint],
+      env: {
+        ...process.env,
+        TOGGL_API_KEY: 'dummy-token',
+        TOGGL_API_TOKEN: '',
+        TOGGL_TOKEN: '',
+      },
+    });
+
+    await client.connect(transport);
+
+    try {
+      const tools = await client.listTools();
+      const timelineTool = tools.tools.find((tool) => tool.name === 'toggl_get_timeline');
+      const properties = timelineTool?.inputSchema.properties as
+        | Record<string, Record<string, unknown>>
+        | undefined;
+
+      expect(properties?.limit).toMatchObject({
+        minimum: 1,
+        maximum: 1000,
+        default: 50,
+      });
+      expect(properties?.redact_titles).toMatchObject({
+        type: 'boolean',
+        default: false,
+      });
+
+      const result = await client.callTool({
+        name: 'toggl_get_timeline',
+        arguments: { start_date: '2026-02-30' },
+      });
+      const payload = JSON.parse(result.content?.[0]?.text ?? '{}') as Record<string, unknown>;
+      const serialized = JSON.stringify(payload);
+
+      expect(payload.error).toBe(true);
+      expect(payload.message).toContain('Invalid calendar date');
+      expect(payload).not.toHaveProperty('details');
+      expect(serialized).not.toContain('/Users/');
+      expect(serialized).not.toContain('dist/index.js');
+      expect(serialized).not.toContain('at ');
+    } finally {
+      await client.close();
+    }
   });
 });

--- a/tests/timeline.test.ts
+++ b/tests/timeline.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { buildTimelineResponse } from '../src/timeline.js';
+import type { TimelineEvent } from '../src/types.js';
+
+function event(id: number, filename: string, title = `Sensitive ${id}`): TimelineEvent {
+  return {
+    id,
+    start_time: 1_700_000_000 + id * 100,
+    end_time: 1_700_000_060 + id * 100,
+    desktop_id: 'desktop-1',
+    idle: false,
+    filename,
+    title,
+  };
+}
+
+describe('timeline response shaping', () => {
+  it('clamps limit below 1 to one returned event', () => {
+    const response = buildTimelineResponse([event(1, 'Cursor'), event(2, 'Slack')], { limit: 0 });
+
+    expect(response.total_events).toBe(2);
+    expect(response.returned_events).toBe(1);
+    expect(response.truncated).toBe(true);
+    expect(response.events).toHaveLength(1);
+  });
+
+  it('clamps limit above 1000 to 1000 returned events', () => {
+    const events = Array.from({ length: 1005 }, (_, index) => event(index + 1, 'Cursor'));
+    const response = buildTimelineResponse(events, { limit: 5000 });
+
+    expect(response.total_events).toBe(1005);
+    expect(response.returned_events).toBe(1000);
+    expect(response.truncated).toBe(true);
+    expect(response.events).toHaveLength(1000);
+    expect(response.summary).toEqual({ Cursor: 1005 * 60 });
+  });
+
+  it('omits events when include_events is false but still computes summary', () => {
+    const response = buildTimelineResponse(
+      [event(1, 'Cursor'), event(2, 'Slack'), event(3, 'Slack')],
+      { include_events: false }
+    );
+
+    expect(response.total_events).toBe(3);
+    expect(response.returned_events).toBe(0);
+    expect(response.truncated).toBe(false);
+    expect(response.summary).toEqual({ Slack: 120, Cursor: 60 });
+    expect(response).not.toHaveProperty('events');
+  });
+
+  it('filters apps using a case-insensitive partial match', () => {
+    const response = buildTimelineResponse(
+      [event(1, 'Google Chrome'), event(2, 'Cursor'), event(3, 'Chrome Canary')],
+      { app: 'chrome' }
+    );
+
+    expect(response.total_events).toBe(2);
+    expect(response.summary).toEqual({ 'Google Chrome': 60, 'Chrome Canary': 60 });
+  });
+
+  it('redacts titles while preserving non-sensitive event fields and summary', () => {
+    const response = buildTimelineResponse([event(1, 'Mail', 'Inbox - private@example.com')], {
+      redact_titles: true,
+    });
+
+    expect(response.summary).toEqual({ Mail: 60 });
+    expect(response.events?.[0]).toMatchObject({
+      id: 1,
+      desktop_id: 'desktop-1',
+      filename: 'Mail',
+      title: null,
+      idle: false,
+      duration_seconds: 60,
+    });
+    expect(response.events?.[0]?.start).toBeDefined();
+    expect(response.events?.[0]?.end).toBeDefined();
+  });
+
+  it('uses four-decimal total_hours precision for timeline display', () => {
+    const response = buildTimelineResponse([event(1, 'Cursor')], {});
+
+    expect(response.total_seconds).toBe(60);
+    expect(response.total_hours).toBe(0.0167);
+  });
+});

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -5,6 +5,8 @@ import {
   generateWeeklyReport,
   formatDuration,
   getDateRange,
+  isDatePeriod,
+  localDateRangeFromArgs,
   parseLocalYMD,
   secondsToHours,
   toLocalYMD,
@@ -44,6 +46,27 @@ describe('local date ranges', () => {
     expect(parsed.getHours()).toBe(0);
   });
 
+  it('rejects malformed and impossible local dates', () => {
+    expect(() => parseLocalYMD('2026-4-19')).toThrow('Invalid date format');
+    expect(() => parseLocalYMD('2026-02-30')).toThrow('Invalid calendar date');
+  });
+
+  it('validates supported period names', () => {
+    expect(isDatePeriod('today')).toBe(true);
+    expect(isDatePeriod('lastMonth')).toBe(true);
+    expect(isDatePeriod('quarter')).toBe(false);
+  });
+
+  it('resolves inclusive end dates to exclusive local boundaries', () => {
+    const range = localDateRangeFromArgs({
+      start_date: '2026-04-19',
+      end_date: '2026-04-20',
+    });
+
+    expect(range?.start && toLocalYMD(range.start)).toBe('2026-04-19');
+    expect(range?.end && toLocalYMD(range.end)).toBe('2026-04-21');
+  });
+
   it('uses exclusive local period ends for Toggl date filters', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-04-19T11:00:00Z'));
@@ -70,11 +93,9 @@ describe('local date ranges', () => {
       tags: [],
     } as HydratedTimeEntry;
 
-    const report = generateWeeklyReport(
-      parseLocalYMD('2026-04-13'),
-      parseLocalYMD('2026-04-19'),
-      [entry]
-    );
+    const report = generateWeeklyReport(parseLocalYMD('2026-04-13'), parseLocalYMD('2026-04-19'), [
+      entry,
+    ]);
 
     expect(report.daily_breakdown).toHaveLength(1);
     expect(report.daily_breakdown[0]?.date).toBe('2026-04-19');


### PR DESCRIPTION
## Summary
- Add `toggl_get_timeline` for Toggl Desktop activity timeline data using the undocumented `track.toggl.com/api/v9/timeline` endpoint.
- Return a structured disabled-state response when Toggl reports `Timeline is not enabled`.
- Add schema bounds/docs for `limit`, summary/output semantics, and a `redact_titles` privacy option for raw event output.
- Sanitize MCP error responses so stack traces and local filesystem paths are not returned to clients.
- Ignore local `.cursor/` and `AGENTS.md` files instead of committing stale/local agent configuration.

## Validation
- `npm run build`
- `npm run lint` (passes with existing `any` warnings)
- `npm test` (18 passing)
- Direct API smoke: `/api/v9/me` returned 200; timeline endpoint currently returns `Timeline is not enabled`
- MCP smoke: timeline tool is listed, disabled timeline response is structured, invalid date errors do not expose paths/stacks

## Notes
- `total_seconds` is the canonical timeline duration value; timeline `total_hours` is display-only and rounded to 4 decimals.
- `limit` only caps the returned `events` array; `summary`, `total_events`, and `total_seconds` are computed from all matching events.