### PR TITLE
fix(release): address Claude Desktop feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Model Context Protocol (MCP) server for Toggl Track integration, providing tim
 ## Features
 
 - **Time Tracking**: Start/stop timers, get current and past time entries
-- **Smart Reporting**: Daily/weekly reports with project and workspace breakdowns  
+- **Smart Reporting**: Daily/weekly reports with project and workspace breakdowns
 - **Performance Optimized**: Intelligent caching system minimizes API calls
 - **Data Hydration**: Automatically enriches time entries with project/workspace/client names
 - **Flexible Filtering**: Query by date ranges, workspaces, or projects
@@ -16,7 +16,9 @@ A Model Context Protocol (MCP) server for Toggl Track integration, providing tim
 Use via npx without cloning or building locally.
 
 ### Claude Desktop
+
 Add this to `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
 ```json
 {
   "mcpServers": {
@@ -34,7 +36,9 @@ Add this to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 ```
 
 ### Cursor
+
 Add this to your Cursor MCP settings (e.g., `~/.cursor/mcp.json`):
+
 ```json
 {
   "mcp": {
@@ -66,6 +70,7 @@ npm run build
 1. Get your Toggl API key from: https://track.toggl.com/profile
 
 2. Create a `.env` file:
+
 ```env
 TOGGL_API_KEY=your_api_key_here
 
@@ -74,15 +79,22 @@ TOGGL_API_KEY=your_api_key_here
 # TOGGL_TOKEN=your_api_key_here
 
 # Optional configuration
-TOGGL_DEFAULT_WORKSPACE_ID=123456  # Your default workspace
+TOGGL_DEFAULT_WORKSPACE_ID=123456  # Optional default workspace for multi-workspace accounts
 TOGGL_CACHE_TTL=3600000            # Cache TTL in ms (default: 1 hour)
 TOGGL_CACHE_SIZE=1000              # Max cached entities (default: 1000)
 ```
 
+Workspace-scoped tools use `workspace_id` first, then `TOGGL_DEFAULT_WORKSPACE_ID`.
+If neither is provided and your account has exactly one workspace, that workspace is selected
+automatically. If your account has multiple workspaces, the tool returns an actionable error with
+the available workspace IDs so you can pass `workspace_id` or set the default env var.
+
 3. Add to your MCP configuration:
 
 ### Claude Desktop
+
 Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
+
 ```json
 {
   "mcpServers": {
@@ -98,7 +110,9 @@ Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
 ```
 
 ### Cursor
+
 Edit `.mcp.json` in your project:
+
 ```json
 {
   "mcpServers": {
@@ -118,58 +132,73 @@ Edit `.mcp.json` in your project:
 ### Authentication
 
 #### `toggl_check_auth`
+
 Verify Toggl API connectivity and confirm your token can access available workspaces without exposing the token.
 
 ### Time Tracking
 
 #### `toggl_get_time_entries`
+
 Get time entries with optional filters.
+
 ```json
 {
-  "period": "today",  // or: yesterday, week, lastWeek, month, lastMonth
+  "period": "today", // or: yesterday, week, lastWeek, month, lastMonth
   "workspace_id": 123456,
   "project_id": 789012
 }
 ```
 
 #### `toggl_get_current_entry`
+
 Get the currently running timer.
 
 #### `toggl_start_timer`
-Start a new time entry.
+
+Start a new time entry. `workspace_id` is optional only when `TOGGL_DEFAULT_WORKSPACE_ID` is set
+or your Toggl account has a single workspace.
+
 ```json
 {
   "description": "Working on MCP server",
+  "workspace_id": 123456,
   "project_id": 123456,
   "tags": ["development", "mcp"]
 }
 ```
 
 #### `toggl_stop_timer`
+
 Stop the currently running timer.
 
 ### Reporting
 
 #### `toggl_daily_report`
+
 Generate a daily report with project/workspace breakdowns.
+
 ```json
 {
   "date": "2024-09-01",
-  "format": "json"  // or "text" for formatted output
+  "format": "json" // or "text" for formatted output
 }
 ```
 
 #### `toggl_weekly_report`
+
 Generate a weekly report with daily breakdowns.
+
 ```json
 {
-  "week_offset": 0,  // 0 = this week, -1 = last week
+  "week_offset": 0, // 0 = this week, -1 = last week
   "format": "json"
 }
 ```
 
 #### `toggl_project_summary`
+
 Get total hours per project for a date range.
+
 ```json
 {
   "period": "month",
@@ -178,12 +207,15 @@ Get total hours per project for a date range.
 ```
 
 #### `toggl_workspace_summary`
+
 Get total hours per workspace.
 
 #### `toggl_get_timeline`
+
 Get Toggl Desktop activity timeline data with application usage summaries and optional raw events. Requires Toggl Track Desktop timeline sync to be enabled.
 
 Privacy note: raw timeline events can include window titles that may contain document names, email subjects, chat text, URLs, OAuth pages, or database names. For privacy-conscious usage, request summary-only output:
+
 ```json
 {
   "period": "today",
@@ -192,6 +224,7 @@ Privacy note: raw timeline events can include window titles that may contain doc
 ```
 
 To return events while hiding window titles:
+
 ```json
 {
   "period": "today",
@@ -203,10 +236,13 @@ To return events while hiding window titles:
 ### Management
 
 #### `toggl_list_workspaces`
+
 List all available workspaces.
 
 #### `toggl_list_projects`
-List projects in a workspace.
+
+List projects in a workspace. Uses cached workspace project lists after the first fetch.
+
 ```json
 {
   "workspace_id": 123456
@@ -214,51 +250,61 @@ List projects in a workspace.
 ```
 
 #### `toggl_list_clients`
-List clients in a workspace.
+
+List clients in a workspace. Uses cached workspace client lists after the first fetch.
 
 ### Cache Management
 
 #### `toggl_warm_cache`
-Pre-fetch workspace/project/client data for better performance.
+
+Pre-fetch workspace/project/client/tag data for better performance. `workspace_id` is optional only
+when `TOGGL_DEFAULT_WORKSPACE_ID` is set or your account has a single workspace.
 
 #### `toggl_cache_stats`
-View cache performance metrics.
+
+View cache performance metrics. Hits and misses include entity lookups and cached workspace-scoped
+project/client/tag list reads.
 
 #### `toggl_clear_cache`
+
 Clear all cached data.
 
 ## Performance Optimization
 
 The server uses an intelligent caching system to minimize API calls:
 
-1. **First Run**: Warms cache by fetching workspaces, projects, and clients
-2. **Subsequent Calls**: Uses cached names for hydration (95%+ cache hit rate)
+1. **First Run**: Fetches workspaces and warms the selected workspace when one can be resolved
+2. **Subsequent Calls**: Uses cached workspace/project/client/tag data for list tools and hydration
 3. **Smart Invalidation**: TTL-based expiry with configurable duration
 4. **Memory Efficient**: LRU eviction keeps memory usage under 10MB
 
 ### Typical Performance
-- First report: 2-3 API calls (warm cache + get entries)
-- Subsequent reports: 1 API call (just time entries)
-- Cache hit rate: >95% for typical usage
+
+- First report: workspace/project/client/tag fetches as needed, plus time entries
+- Subsequent reports: usually 1 API call for time entries, with names hydrated from cache
+- Repeated project/client list calls: served from cache until TTL expiry
 
 ## Usage Examples
 
 ### Daily Standup Report
+
 ```javascript
 // Get today's time entries with full details
-toggl_daily_report({ "format": "text" })
+toggl_daily_report({ format: 'text' });
 ```
 
 ### Weekly Summary for Automation Hub
+
 ```javascript
 // Get last week's data as JSON
-toggl_weekly_report({ "week_offset": -1 })
+toggl_weekly_report({ week_offset: -1 });
 ```
 
 ### Project Hours Tracking
+
 ```javascript
 // Get this month's hours by project
-toggl_project_summary({ "period": "month" })
+toggl_project_summary({ period: 'month' });
 ```
 
 ## Integration with Automation Hub
@@ -291,6 +337,7 @@ The server returns structured JSON perfect for Automation Hub workflows:
 ## Troubleshooting
 
 ### API Key Issues
+
 - Ensure your API key is correct (get from https://track.toggl.com/profile)
 - API key goes in the username field, "api_token" as password for basic auth
 - Trim whitespace: copy/paste can include trailing spaces/newlines which cause 401/403
@@ -298,6 +345,7 @@ The server returns structured JSON perfect for Automation Hub workflows:
 - If you see 401/403, regenerate the token on your Toggl profile and update your MCP config
 
 ### Security & Token Lifecycle
+
 - This server uses Basic Auth with a Toggl API token, not OAuth; there is no refresh token to manage.
 - Toggl API tokens do not expire automatically. They only change if you manually regenerate them or if Toggl invalidates them during a security event.
 - If you regenerate your token, the old one stops working immediately. Update the `TOGGL_API_KEY` in your Claude/Cursor config and restart the client.
@@ -305,15 +353,24 @@ The server returns structured JSON perfect for Automation Hub workflows:
 - Claude Desktop stores the env value in `claude_desktop_config.json` on your machine. Treat that file as sensitive and do not share it.
 
 ### Quick Auth Check
+
 You can verify connectivity by calling the `toggl_check_auth` tool, which pings `/me` and lists your available workspaces without exposing your token.
 
 ### Rate Limiting
-- The server implements automatic retry with exponential backoff
-- Respects Toggl's rate limits (max 1 request per second)
+
+- The server implements bounded automatic retry for short 429 rate-limit windows
+- Longer Toggl quota windows return structured errors with `retry_after_seconds` instead of making the MCP client appear stuck
+- Use `toggl_warm_cache` once per workspace and rely on cached list tools to avoid repeated project/client fetches
 
 ### Cache Issues
+
 - Run `toggl_clear_cache` if data seems stale
 - Adjust `TOGGL_CACHE_TTL` for your needs (default: 1 hour)
+
+### Claude Desktop Chart Issues
+
+- For timeline charts, prefer summary-only data: call `toggl_get_timeline` with `include_events: false`
+- If Claude Desktop blanks while rendering a generated chart but the MCP server logs do not show a crash, restart Claude Desktop and retry with smaller summarized inputs
 
 ## Development
 

--- a/server.json
+++ b/server.json
@@ -68,7 +68,7 @@
     },
     {
       "name": "toggl_warm_cache",
-      "description": "Pre-fetch workspace, project, and client data"
+      "description": "Pre-fetch workspace, project, client, and tag data"
     },
     {
       "name": "toggl_cache_stats",

--- a/src/cache-manager.ts
+++ b/src/cache-manager.ts
@@ -19,6 +19,10 @@ export class CacheManager {
   private tasks: Map<number, CacheEntry<Task>> = new Map();
   private users: Map<number, CacheEntry<User>> = new Map();
   private tags: Map<number, CacheEntry<Tag>> = new Map();
+  private workspaceList: CacheEntry<Workspace[]> | null = null;
+  private projectsByWorkspace: Map<number, CacheEntry<Project[]>> = new Map();
+  private clientsByWorkspace: Map<number, CacheEntry<Client[]>> = new Map();
+  private tagsByWorkspace: Map<number, CacheEntry<Tag[]>> = new Map();
 
   // Track cache performance
   private stats = {
@@ -39,7 +43,7 @@ export class CacheManager {
   }
 
   // Check if cache entry is still valid
-  private isValid<T>(entry?: CacheEntry<T>): boolean {
+  private isValid<T>(entry?: CacheEntry<T> | null): boolean {
     if (!entry) return false;
     const age = Date.now() - entry.timestamp.getTime();
     return age < entry.ttl;
@@ -48,6 +52,15 @@ export class CacheManager {
   // Generic cache getter
   private getCached<T>(cache: Map<number, CacheEntry<T>>, id: number): T | null {
     const entry = cache.get(id);
+    if (this.isValid(entry)) {
+      this.stats.hits++;
+      return entry!.data;
+    }
+    this.stats.misses++;
+    return null;
+  }
+
+  private getCachedCollection<T>(entry: CacheEntry<T[]> | null | undefined): T[] | null {
     if (this.isValid(entry)) {
       this.stats.hits++;
       return entry!.data;
@@ -74,6 +87,14 @@ export class CacheManager {
     });
   }
 
+  private setCachedCollection<T>(data: T[]): CacheEntry<T[]> {
+    return {
+      data,
+      timestamp: new Date(),
+      ttl: this.config.ttl,
+    };
+  }
+
   // Workspace methods
   async getWorkspace(id: number | undefined): Promise<Workspace | null> {
     if (!id) return null;
@@ -95,6 +116,9 @@ export class CacheManager {
   }
 
   async getWorkspaces(): Promise<Workspace[]> {
+    const cached = this.getCachedCollection(this.workspaceList);
+    if (cached) return cached;
+
     if (!this.api) return [];
 
     try {
@@ -103,6 +127,7 @@ export class CacheManager {
       workspaces.forEach((ws: Workspace) => {
         this.setCached(this.workspaces, ws.id, ws);
       });
+      this.workspaceList = this.setCachedCollection(workspaces);
       return workspaces;
     } catch (error) {
       console.error('Failed to fetch workspaces:', error);
@@ -111,11 +136,16 @@ export class CacheManager {
   }
 
   // Project methods
-  async getProject(id: number): Promise<Project | null> {
+  async getProject(id: number, workspaceId?: number): Promise<Project | null> {
     const cached = this.getCached(this.projects, id);
     if (cached) return cached;
 
     if (!this.api) return null;
+
+    if (workspaceId) {
+      const projects = await this.getProjects(workspaceId);
+      return projects.find((project) => project.id === id) || null;
+    }
 
     try {
       const project = await this.api.getProject(id);
@@ -130,6 +160,9 @@ export class CacheManager {
   }
 
   async getProjects(workspaceId: number): Promise<Project[]> {
+    const cached = this.getCachedCollection(this.projectsByWorkspace.get(workspaceId));
+    if (cached) return cached;
+
     if (!this.api) return [];
 
     try {
@@ -138,6 +171,7 @@ export class CacheManager {
       projects.forEach((proj: Project) => {
         this.setCached(this.projects, proj.id, proj);
       });
+      this.projectsByWorkspace.set(workspaceId, this.setCachedCollection(projects));
       return projects;
     } catch (error) {
       console.error(`Failed to fetch projects for workspace ${workspaceId}:`, error);
@@ -146,11 +180,16 @@ export class CacheManager {
   }
 
   // Client methods
-  async getClient(id: number): Promise<Client | null> {
+  async getClient(id: number, workspaceId?: number): Promise<Client | null> {
     const cached = this.getCached(this.clients, id);
     if (cached) return cached;
 
     if (!this.api) return null;
+
+    if (workspaceId) {
+      const clients = await this.getClients(workspaceId);
+      return clients.find((client) => client.id === id) || null;
+    }
 
     try {
       const client = await this.api.getClient(id);
@@ -165,6 +204,9 @@ export class CacheManager {
   }
 
   async getClients(workspaceId: number): Promise<Client[]> {
+    const cached = this.getCachedCollection(this.clientsByWorkspace.get(workspaceId));
+    if (cached) return cached;
+
     if (!this.api) return [];
 
     try {
@@ -173,6 +215,7 @@ export class CacheManager {
       clients.forEach((client: Client) => {
         this.setCached(this.clients, client.id, client);
       });
+      this.clientsByWorkspace.set(workspaceId, this.setCachedCollection(clients));
       return clients;
     } catch (error) {
       console.error(`Failed to fetch clients for workspace ${workspaceId}:`, error);
@@ -242,11 +285,8 @@ export class CacheManager {
     if (!this.api) return null;
 
     try {
-      const tag = await this.api.getTag(workspaceId, id);
-      if (tag) {
-        this.setCached(this.tags, id, tag);
-      }
-      return tag;
+      const tags = await this.getTags(workspaceId);
+      return tags.find((tag) => tag.id === id) || null;
     } catch (error) {
       console.error(`Failed to fetch tag ${id}:`, error);
       return null;
@@ -254,6 +294,9 @@ export class CacheManager {
   }
 
   async getTags(workspaceId: number): Promise<Tag[]> {
+    const cached = this.getCachedCollection(this.tagsByWorkspace.get(workspaceId));
+    if (cached) return cached;
+
     if (!this.api) return [];
 
     try {
@@ -262,6 +305,7 @@ export class CacheManager {
       tags.forEach((tag: Tag) => {
         this.setCached(this.tags, tag.id, tag);
       });
+      this.tagsByWorkspace.set(workspaceId, this.setCachedCollection(tags));
       return tags;
     } catch (error) {
       console.error(`Failed to fetch tags for workspace ${workspaceId}:`, error);
@@ -299,37 +343,37 @@ export class CacheManager {
     }
   }
 
+  private normalizeTimeEntry(entry: TimeEntry): HydratedTimeEntry {
+    const running = entry.duration < 0 && !entry.stop;
+    const elapsedSeconds = running
+      ? Math.max(0, Math.floor((Date.now() - new Date(entry.start).getTime()) / 1000))
+      : undefined;
+    const durationSeconds = running ? elapsedSeconds! : Math.max(0, entry.duration);
+    const tags = normalizeStringArray(entry.tags);
+    const tagIds = normalizeNumberArray(entry.tag_ids);
+    const normalized: HydratedTimeEntry = {
+      ...entry,
+      workspace_name: `Workspace ${entry.workspace_id}`,
+      tags,
+      tag_ids: tagIds,
+      tag_names: [...tags],
+      running,
+      duration_seconds: durationSeconds,
+    };
+
+    if (elapsedSeconds !== undefined) {
+      normalized.elapsed_seconds = elapsedSeconds;
+    }
+
+    return normalized;
+  }
+
   // Hydrate time entries with cached names
   async hydrateTimeEntries(entries: TimeEntry[]): Promise<HydratedTimeEntry[]> {
     const hydrated: HydratedTimeEntry[] = [];
 
-    // Collect unique IDs to batch fetch if needed
-    const workspaceIds = new Set<number>();
-    const projectIds = new Set<number>();
-    const taskIds = new Set<{ wid: number; pid: number; tid: number }>();
-
-    entries.forEach((entry) => {
-      workspaceIds.add(entry.workspace_id);
-      if (entry.project_id) projectIds.add(entry.project_id);
-      if (entry.task_id && entry.project_id) {
-        taskIds.add({
-          wid: entry.workspace_id,
-          pid: entry.project_id,
-          tid: entry.task_id,
-        });
-      }
-    });
-
-    // Pre-fetch missing entities
-    const projectsToFetch = Array.from(projectIds).filter((id) => !this.projects.has(id));
-    if (projectsToFetch.length > 0 && this.api) {
-      console.error(`Fetching ${projectsToFetch.length} missing projects...`);
-      await Promise.all(projectsToFetch.map((id) => this.getProject(id)));
-    }
-
-    // Now hydrate each entry
     for (const entry of entries) {
-      const hydEntry: HydratedTimeEntry = { ...entry } as HydratedTimeEntry;
+      const hydEntry = this.normalizeTimeEntry(entry);
 
       // Add workspace name
       const workspace = await this.getWorkspace(entry.workspace_id);
@@ -337,12 +381,12 @@ export class CacheManager {
 
       // Add project name and client info
       if (entry.project_id) {
-        const project = await this.getProject(entry.project_id);
+        const project = await this.getProject(entry.project_id, entry.workspace_id);
         hydEntry.project_name = project?.name || `Project ${entry.project_id}`;
 
         if (project?.client_id) {
           hydEntry.client_id = project.client_id;
-          const client = await this.getClient(project.client_id);
+          const client = await this.getClient(project.client_id, entry.workspace_id);
           hydEntry.client_name = client?.name || `Client ${project.client_id}`;
         }
       }
@@ -360,14 +404,16 @@ export class CacheManager {
       }
 
       // Add tag names
-      if (entry.tag_ids && entry.tag_ids.length > 0) {
-        hydEntry.tag_names = [];
-        for (const tagId of entry.tag_ids) {
+      if (hydEntry.tag_ids.length > 0) {
+        const tagNames = new Set(hydEntry.tag_names);
+        for (const tagId of hydEntry.tag_ids) {
           const tag = await this.getTag(tagId, entry.workspace_id);
           if (tag) {
-            hydEntry.tag_names.push(tag.name);
+            tagNames.add(tag.name);
           }
         }
+        hydEntry.tag_names = Array.from(tagNames);
+        hydEntry.tags = hydEntry.tag_names;
       }
 
       hydrated.push(hydEntry);
@@ -384,6 +430,10 @@ export class CacheManager {
     this.tasks.clear();
     this.users.clear();
     this.tags.clear();
+    this.workspaceList = null;
+    this.projectsByWorkspace.clear();
+    this.clientsByWorkspace.clear();
+    this.tagsByWorkspace.clear();
     this.stats = {
       hits: 0,
       misses: 0,
@@ -424,5 +474,34 @@ export class CacheManager {
     prune(this.tasks);
     prune(this.users);
     prune(this.tags);
+
+    if (!this.isValid(this.workspaceList)) {
+      this.workspaceList = null;
+    }
+    const pruneCollections = <T>(cache: Map<number, CacheEntry<T[]>>) => {
+      const expired: number[] = [];
+      cache.forEach((entry, key) => {
+        if (!this.isValid(entry)) {
+          expired.push(key);
+        }
+      });
+      expired.forEach((key) => cache.delete(key));
+    };
+
+    pruneCollections(this.projectsByWorkspace);
+    pruneCollections(this.clientsByWorkspace);
+    pruneCollections(this.tagsByWorkspace);
   }
+}
+
+function normalizeStringArray(value: string[] | null | undefined): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string')
+    : [];
+}
+
+function normalizeNumberArray(value: number[] | null | undefined): number[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is number => typeof item === 'number')
+    : [];
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,9 +7,10 @@ import {
   Tool,
 } from '@modelcontextprotocol/sdk/types.js';
 import { config } from 'dotenv';
-import { TogglAPI, TimelineNotEnabledError } from './toggl-api.js';
+import { TogglAPI, TimelineNotEnabledError, TogglAPIError } from './toggl-api.js';
 import { buildTimelineResponse } from './timeline.js';
 import { CacheManager } from './cache-manager.js';
+import { WorkspaceResolutionError, parseWorkspaceId, resolveWorkspaceId } from './workspace.js';
 import {
   getDateRange,
   generateDailyReport,
@@ -45,6 +46,32 @@ function jsonResponse(data: unknown) {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : 'An error occurred';
+}
+
+function errorPayload(error: unknown): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    error: true,
+    message: errorMessage(error),
+  };
+
+  if (error instanceof TogglAPIError) {
+    payload.code = error.code;
+    payload.status = error.status;
+    if (error.retry_after_seconds !== undefined) {
+      payload.retry_after_seconds = error.retry_after_seconds;
+    }
+    if (error.tip) {
+      payload.tip = error.tip;
+    }
+  }
+
+  if (error instanceof WorkspaceResolutionError) {
+    payload.code = error.code;
+    payload.tip = error.tip;
+    payload.available_workspaces = error.available_workspaces;
+  }
+
+  return payload;
 }
 
 // Version for CLI output and server metadata
@@ -118,9 +145,7 @@ const cacheConfig: CacheConfig = {
   batchSize: parseInt(process.env.TOGGL_BATCH_SIZE || '100'),
 };
 
-const defaultWorkspaceId = process.env.TOGGL_DEFAULT_WORKSPACE_ID
-  ? parseInt(process.env.TOGGL_DEFAULT_WORKSPACE_ID)
-  : undefined;
+const defaultWorkspaceId = parseWorkspaceId(process.env.TOGGL_DEFAULT_WORKSPACE_ID);
 
 // Initialize API and cache
 const api = new TogglAPI(API_KEY);
@@ -134,12 +159,29 @@ let cacheWarmed = false;
 async function ensureCache(): Promise<void> {
   if (!cacheWarmed) {
     try {
-      await cache.warmCache(defaultWorkspaceId);
+      const workspaces = await cache.getWorkspaces();
+      const singleWorkspaceId = workspaces.length === 1 ? workspaces[0]!.id : undefined;
+      const workspaceIdToWarm = defaultWorkspaceId || singleWorkspaceId;
+      if (workspaceIdToWarm) {
+        await cache.warmCache(workspaceIdToWarm);
+      }
       cacheWarmed = true;
     } catch (error) {
       console.error('Failed to warm cache:', error);
     }
   }
+}
+
+async function resolveWorkspaceForTool(
+  args: Record<string, unknown> | undefined,
+  action: string
+): Promise<number> {
+  return resolveWorkspaceId({
+    explicitWorkspaceId: args?.workspace_id,
+    defaultWorkspaceId,
+    getWorkspaces: () => cache.getWorkspaces(),
+    action,
+  });
 }
 
 // Create MCP server
@@ -240,7 +282,8 @@ const tools: Tool[] = [
         },
         workspace_id: {
           type: 'number',
-          description: 'Workspace ID (uses default if not provided)',
+          description:
+            'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
         },
         project_id: {
           type: 'number',
@@ -407,7 +450,8 @@ const tools: Tool[] = [
       properties: {
         workspace_id: {
           type: 'number',
-          description: 'Workspace ID (uses default if not provided)',
+          description:
+            'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
         },
       },
     },
@@ -425,7 +469,8 @@ const tools: Tool[] = [
       properties: {
         workspace_id: {
           type: 'number',
-          description: 'Workspace ID (uses default if not provided)',
+          description:
+            'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
         },
       },
     },
@@ -434,7 +479,8 @@ const tools: Tool[] = [
   // Cache management
   {
     name: 'toggl_warm_cache',
-    description: 'Pre-fetch and cache workspace, project, and client data for better performance',
+    description:
+      'Pre-fetch and cache workspace, project, client, and tag data for better performance',
     annotations: {
       readOnlyHint: true,
       idempotentHint: true,
@@ -445,7 +491,8 @@ const tools: Tool[] = [
       properties: {
         workspace_id: {
           type: 'number',
-          description: 'Specific workspace to warm cache for',
+          description:
+            'Workspace ID to warm. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
         },
       },
     },
@@ -544,7 +591,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       // Health/authentication
       case 'toggl_check_auth': {
         const me = await api.getMe();
-        const workspaces = await api.getWorkspaces();
+        const workspaces = await cache.getWorkspaces();
         const maskEmail = (e?: string) => {
           if (!e) return undefined as unknown as string;
           const [user, domain] = e.split('@');
@@ -662,15 +709,10 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'toggl_start_timer': {
-        const workspaceId = args?.workspace_id || defaultWorkspaceId;
-        if (!workspaceId) {
-          throw new Error(
-            'Workspace ID required (set TOGGL_DEFAULT_WORKSPACE_ID or provide workspace_id)'
-          );
-        }
+        const workspaceId = await resolveWorkspaceForTool(args, 'starting a timer');
 
         const entry = await api.startTimer(
-          workspaceId as number,
+          workspaceId,
           args?.description as string | undefined,
           args?.project_id as number | undefined,
           args?.task_id as number | undefined,
@@ -912,7 +954,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       // Management tools
       case 'toggl_list_workspaces': {
-        const workspaces = await api.getWorkspaces();
+        const workspaces = await cache.getWorkspaces();
 
         return {
           content: [
@@ -937,14 +979,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'toggl_list_projects': {
-        const workspaceId = args?.workspace_id || defaultWorkspaceId;
-        if (!workspaceId) {
-          throw new Error(
-            'Workspace ID required (set TOGGL_DEFAULT_WORKSPACE_ID or provide workspace_id)'
-          );
-        }
+        const workspaceId = await resolveWorkspaceForTool(args, 'listing projects');
 
-        const projects = await api.getProjects(workspaceId as number);
+        const projects = await cache.getProjects(workspaceId);
 
         return {
           content: [
@@ -972,14 +1009,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       }
 
       case 'toggl_list_clients': {
-        const workspaceId = args?.workspace_id || defaultWorkspaceId;
-        if (!workspaceId) {
-          throw new Error(
-            'Workspace ID required (set TOGGL_DEFAULT_WORKSPACE_ID or provide workspace_id)'
-          );
-        }
+        const workspaceId = await resolveWorkspaceForTool(args, 'listing clients');
 
-        const clients = await api.getClients(workspaceId as number);
+        const clients = await cache.getClients(workspaceId);
 
         return {
           content: [
@@ -1005,7 +1037,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 
       // Cache management
       case 'toggl_warm_cache': {
-        const workspaceId = (args?.workspace_id as number | undefined) || defaultWorkspaceId;
+        const workspaceId = await resolveWorkspaceForTool(args, 'warming the cache');
         await cache.warmCache(workspaceId);
         cacheWarmed = true;
 
@@ -1102,10 +1134,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         throw new Error(`Unknown tool: ${name}`);
     }
   } catch (error: unknown) {
-    return jsonResponse({
-      error: true,
-      message: errorMessage(error),
-    });
+    return jsonResponse(errorPayload(error));
   }
 });
 

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -21,6 +21,37 @@ export class TimelineNotEnabledError extends Error {
   }
 }
 
+export class TogglAPIError extends Error {
+  readonly status: number;
+  readonly code: string;
+  readonly retry_after_seconds?: number;
+  readonly tip?: string;
+  readonly noRetry = true;
+
+  constructor({
+    status,
+    code,
+    message,
+    retryAfterSeconds,
+    tip,
+  }: {
+    status: number;
+    code: string;
+    message: string;
+    retryAfterSeconds?: number;
+    tip?: string;
+  }) {
+    super(message);
+    this.name = 'TogglAPIError';
+    this.status = status;
+    this.code = code;
+    this.retry_after_seconds = retryAfterSeconds;
+    this.tip = tip;
+  }
+}
+
+const MAX_AUTO_RETRY_MS = 30_000;
+
 export class TogglAPI {
   private baseUrl = 'https://api.track.toggl.com/api/v9';
   private timelineBaseUrl = 'https://track.toggl.com/api/v9';
@@ -49,18 +80,39 @@ export class TogglAPI {
           body: body ? JSON.stringify(body) : undefined,
         });
 
-        // Handle rate limiting
+        // Handle rate limiting without sleeping for multi-minute quota resets.
         if (response.status === 429) {
-          const retryAfter = response.headers.get('Retry-After');
-          const delay = retryAfter ? parseInt(retryAfter) * 1000 : (i + 1) * 2000;
-          // Log to stderr so we don't pollute MCP stdio
-          console.error(`Rate limited. Retrying after ${delay}ms...`);
-          await new Promise((resolve) => setTimeout(resolve, delay));
-          continue;
+          const retryAfterSeconds = parseRetryAfterSeconds(response.headers.get('Retry-After'));
+          const delay = retryAfterSeconds !== undefined ? retryAfterSeconds * 1000 : (i + 1) * 2000;
+          if (delay <= MAX_AUTO_RETRY_MS && i < retries - 1) {
+            // Log to stderr so we don't pollute MCP stdio
+            console.error(`Rate limited. Retrying after ${delay}ms...`);
+            await new Promise((resolve) => setTimeout(resolve, delay));
+            continue;
+          }
+
+          throw new TogglAPIError({
+            status: response.status,
+            code: 'RATE_LIMITED',
+            message: 'Toggl API rate limit reached.',
+            retryAfterSeconds,
+            tip: 'Retry after the indicated delay, or use cached/list summary tools to reduce repeated Toggl API calls.',
+          });
         }
 
         if (!response.ok) {
           const text = await response.text();
+          if (response.status === 402) {
+            const retryAfterSeconds = parseQuotaResetSeconds(text);
+            throw new TogglAPIError({
+              status: response.status,
+              code: 'TOGGL_QUOTA_LIMIT',
+              message: `Toggl API quota limit reached.${retryAfterSeconds !== undefined ? ` Quota resets in ${retryAfterSeconds} seconds.` : ''}`,
+              retryAfterSeconds,
+              tip: 'Wait for the Toggl quota window to reset. Cache-backed list tools avoid repeated project/client fetches after they are warmed.',
+            });
+          }
+
           const isAuth = response.status === 401 || response.status === 403;
           const message = isAuth
             ? `Authentication failed (${response.status}). ` +
@@ -327,22 +379,22 @@ export class TogglAPI {
         });
 
         if (response.status === 429) {
-          const retryAfter = response.headers.get('Retry-After');
-          let delay: number;
-          if (retryAfter) {
-            const deltaSeconds = parseInt(retryAfter, 10);
-            if (Number.isFinite(deltaSeconds)) {
-              delay = deltaSeconds * 1000;
-            } else {
-              const dateMs = Date.parse(retryAfter);
-              delay = Number.isFinite(dateMs) ? Math.max(0, dateMs - Date.now()) : (attempt + 1) * 2000;
-            }
-          } else {
-            delay = (attempt + 1) * 2000;
+          const retryAfterSeconds = parseRetryAfterSeconds(response.headers.get('Retry-After'));
+          const delay =
+            retryAfterSeconds !== undefined ? retryAfterSeconds * 1000 : (attempt + 1) * 2000;
+          if (delay <= MAX_AUTO_RETRY_MS && attempt < maxRetries - 1) {
+            console.error(`Timeline rate limited. Retrying after ${delay}ms...`);
+            await new Promise((resolve) => setTimeout(resolve, delay));
+            continue;
           }
-          console.error(`Timeline rate limited. Retrying after ${delay}ms...`);
-          await new Promise((resolve) => setTimeout(resolve, delay));
-          continue;
+
+          throw new TogglAPIError({
+            status: response.status,
+            code: 'RATE_LIMITED',
+            message: 'Toggl timeline API rate limit reached.',
+            retryAfterSeconds,
+            tip: 'Retry after the indicated delay. For Claude Desktop charts, request summary-only timeline output with include_events: false.',
+          });
         }
 
         const text = await response.text();
@@ -392,6 +444,24 @@ function parseTimelineError(text: string): string {
   } catch (_error) {
     return text;
   }
+}
+
+function parseRetryAfterSeconds(value: string | null): number | undefined {
+  if (!value) return undefined;
+
+  const deltaSeconds = Number.parseInt(value, 10);
+  if (Number.isFinite(deltaSeconds)) return deltaSeconds;
+
+  const dateMs = Date.parse(value);
+  if (!Number.isFinite(dateMs)) return undefined;
+  return Math.max(0, Math.ceil((dateMs - Date.now()) / 1000));
+}
+
+function parseQuotaResetSeconds(text: string): number | undefined {
+  const match = /quota will reset in (\d+) seconds/i.exec(text);
+  if (!match) return undefined;
+  const seconds = Number.parseInt(match[1]!, 10);
+  return Number.isFinite(seconds) ? seconds : undefined;
 }
 
 function isTimelineEvent(value: unknown): value is TimelineEvent {

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,9 +114,12 @@ export interface TimeEntry {
   start: string;
   stop?: string;
   duration: number; // In seconds, negative if currently running
+  duration_seconds?: number; // Effective duration in seconds, elapsed for running entries
+  running?: boolean;
+  elapsed_seconds?: number;
   description?: string;
-  tags?: string[];
-  tag_ids?: number[];
+  tags?: string[] | null;
+  tag_ids?: number[] | null;
   duronly?: boolean;
   at?: string;
   server_deleted_at?: string;
@@ -135,7 +138,11 @@ export interface HydratedTimeEntry extends TimeEntry {
   client_name?: string;
   client_id?: number;
   user_name?: string;
-  tag_names?: string[];
+  tags: string[];
+  tag_ids: number[];
+  tag_names: string[];
+  running: boolean;
+  duration_seconds: number;
 }
 
 // Report interfaces

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -219,24 +219,26 @@ export function groupEntriesByWorkspace(
   return grouped;
 }
 
+function effectiveDurationSeconds(entry: HydratedTimeEntry): number {
+  if (entry.duration_seconds !== undefined) return entry.duration_seconds;
+
+  if (entry.duration < 0) {
+    return Math.max(0, Math.floor((Date.now() - new Date(entry.start).getTime()) / 1000));
+  }
+
+  return entry.duration;
+}
+
 // Calculate total duration from entries
 export function calculateTotalDuration(entries: HydratedTimeEntry[]): number {
-  return entries.reduce((total, entry) => {
-    // Handle running timers (negative duration)
-    const duration =
-      entry.duration < 0
-        ? Math.floor((Date.now() - new Date(entry.start).getTime()) / 1000)
-        : entry.duration;
-    return total + duration;
-  }, 0);
+  return entries.reduce((total, entry) => total + effectiveDurationSeconds(entry), 0);
 }
 
 // Create a report entry from a hydrated time entry
 export function createReportEntry(entry: HydratedTimeEntry): ReportEntry {
-  const duration =
-    entry.duration < 0
-      ? Math.floor((Date.now() - new Date(entry.start).getTime()) / 1000)
-      : entry.duration;
+  const duration = effectiveDurationSeconds(entry);
+  const tagNames = entry.tag_names ?? [];
+  const tags = entry.tags ?? [];
 
   return {
     id: entry.id,
@@ -249,7 +251,7 @@ export function createReportEntry(entry: HydratedTimeEntry): ReportEntry {
     stop: entry.stop,
     duration_hours: secondsToHours(duration),
     duration_seconds: duration,
-    tags: entry.tag_names || entry.tags,
+    tags: tagNames.length > 0 ? tagNames : tags,
     billable: entry.billable,
   };
 }
@@ -262,7 +264,7 @@ export function generateProjectSummary(
   const totalSeconds = calculateTotalDuration(entries);
   const billableSeconds = entries
     .filter((e) => e.billable)
-    .reduce((total, e) => total + (e.duration < 0 ? 0 : e.duration), 0);
+    .reduce((total, e) => total + effectiveDurationSeconds(e), 0);
 
   return {
     project_id: entries[0]?.project_id,
@@ -286,7 +288,7 @@ export function generateWorkspaceSummary(
   const totalSeconds = calculateTotalDuration(entries);
   const billableSeconds = entries
     .filter((e) => e.billable)
-    .reduce((total, e) => total + (e.duration < 0 ? 0 : e.duration), 0);
+    .reduce((total, e) => total + effectiveDurationSeconds(e), 0);
 
   const projectIds = new Set(entries.map((e) => e.project_id).filter(Boolean));
 

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1,0 +1,63 @@
+import type { Workspace } from './types.js';
+
+export interface WorkspaceSummary {
+  id: number;
+  name: string;
+}
+
+export class WorkspaceResolutionError extends Error {
+  readonly code = 'WORKSPACE_REQUIRED';
+  readonly tip: string;
+  readonly available_workspaces: WorkspaceSummary[];
+
+  constructor(action: string, workspaces: WorkspaceSummary[]) {
+    const workspaceList = workspaces
+      .map((workspace) => `${workspace.id} (${workspace.name})`)
+      .join(', ');
+    super(
+      workspaces.length > 0
+        ? `Workspace ID required for ${action}. Set TOGGL_DEFAULT_WORKSPACE_ID or provide workspace_id. Available workspaces: ${workspaceList}`
+        : `Workspace ID required for ${action}, but no Toggl workspaces were returned.`
+    );
+    this.name = 'WorkspaceResolutionError';
+    this.available_workspaces = workspaces;
+    this.tip =
+      'Pass workspace_id explicitly, or set TOGGL_DEFAULT_WORKSPACE_ID in your MCP server environment.';
+  }
+}
+
+interface ResolveWorkspaceOptions {
+  explicitWorkspaceId?: unknown;
+  defaultWorkspaceId?: number;
+  getWorkspaces: () => Promise<Workspace[]>;
+  action: string;
+}
+
+export async function resolveWorkspaceId({
+  explicitWorkspaceId,
+  defaultWorkspaceId,
+  getWorkspaces,
+  action,
+}: ResolveWorkspaceOptions): Promise<number> {
+  const explicit = parseWorkspaceId(explicitWorkspaceId);
+  if (explicit !== undefined) return explicit;
+
+  if (defaultWorkspaceId !== undefined) return defaultWorkspaceId;
+
+  const workspaces = await getWorkspaces();
+  if (workspaces.length === 1) return workspaces[0]!.id;
+
+  throw new WorkspaceResolutionError(
+    action,
+    workspaces.map((workspace) => ({
+      id: workspace.id,
+      name: workspace.name,
+    }))
+  );
+}
+
+export function parseWorkspaceId(value: unknown): number | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  const parsed = typeof value === 'number' ? value : Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : undefined;
+}

--- a/tests/cache-manager.test.ts
+++ b/tests/cache-manager.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CacheManager } from '../src/cache-manager.js';
+import type { Client, Project, Tag, TimeEntry, Workspace } from '../src/types.js';
+
+const config = {
+  ttl: 60_000,
+  maxSize: 1_000,
+  batchSize: 100,
+};
+
+const workspace: Workspace = { id: 1, name: 'Workspace' };
+const project: Project = {
+  id: 10,
+  workspace_id: 1,
+  client_id: 20,
+  name: 'Project',
+};
+const client: Client = { id: 20, workspace_id: 1, name: 'Client' };
+const tags: Tag[] = [
+  { id: 30, workspace_id: 1, name: 'automated' },
+  { id: 31, workspace_id: 1, name: 'test' },
+];
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+function createAPI() {
+  return {
+    getWorkspaces: vi.fn(async () => [workspace]),
+    getWorkspace: vi.fn(async () => workspace),
+    getProjects: vi.fn(async () => [project]),
+    getProject: vi.fn(async () => project),
+    getClients: vi.fn(async () => [client]),
+    getClient: vi.fn(async () => client),
+    getTags: vi.fn(async () => tags),
+    getTag: vi.fn(async () => tags[0]),
+    getTask: vi.fn(),
+    getUser: vi.fn(),
+  };
+}
+
+describe('cache manager', () => {
+  it('serves warmed workspace collections from cache and records hits', async () => {
+    const api = createAPI();
+    const cache = new CacheManager(config);
+    cache.setAPI(api);
+
+    await cache.warmCache(1);
+    const statsAfterWarm = cache.getStats();
+
+    expect(api.getProjects).toHaveBeenCalledTimes(1);
+    expect(api.getClients).toHaveBeenCalledTimes(1);
+    expect(api.getTags).toHaveBeenCalledTimes(1);
+    expect(statsAfterWarm.projects).toBe(1);
+    expect(statsAfterWarm.clients).toBe(1);
+    expect(statsAfterWarm.tags).toBe(2);
+
+    await expect(cache.getProjects(1)).resolves.toEqual([project]);
+    await expect(cache.getClients(1)).resolves.toEqual([client]);
+    await expect(cache.getTags(1)).resolves.toEqual(tags);
+
+    expect(api.getProjects).toHaveBeenCalledTimes(1);
+    expect(api.getClients).toHaveBeenCalledTimes(1);
+    expect(api.getTags).toHaveBeenCalledTimes(1);
+    expect(cache.getStats().hits).toBeGreaterThan(statsAfterWarm.hits);
+  });
+
+  it('hydrates tags from the workspace tag collection without the single-tag endpoint', async () => {
+    const api = createAPI();
+    const cache = new CacheManager(config);
+    cache.setAPI(api);
+
+    const entry: TimeEntry = {
+      id: 100,
+      workspace_id: 1,
+      project_id: 10,
+      start: '2026-05-01T10:00:00.000Z',
+      stop: '2026-05-01T10:30:00.000Z',
+      duration: 1800,
+      tags: ['automated', 'test'],
+      tag_ids: [30, 31],
+    };
+
+    const [hydrated] = await cache.hydrateTimeEntries([entry]);
+
+    expect(api.getTag).not.toHaveBeenCalled();
+    expect(api.getTags).toHaveBeenCalledTimes(1);
+    expect(hydrated?.tags).toEqual(['automated', 'test']);
+    expect(hydrated?.tag_ids).toEqual([30, 31]);
+    expect(hydrated?.tag_names).toEqual(['automated', 'test']);
+  });
+
+  it('normalizes null tag fields and adds running duration metadata', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-01T10:01:00.000Z'));
+
+    const api = createAPI();
+    const cache = new CacheManager(config);
+    cache.setAPI(api);
+
+    const entry: TimeEntry = {
+      id: 101,
+      workspace_id: 1,
+      start: '2026-05-01T10:00:00.000Z',
+      duration: -1_777_600_000,
+      tags: null,
+      tag_ids: null,
+    };
+
+    const [hydrated] = await cache.hydrateTimeEntries([entry]);
+
+    expect(hydrated).toMatchObject({
+      tags: [],
+      tag_ids: [],
+      tag_names: [],
+      running: true,
+      elapsed_seconds: 60,
+      duration_seconds: 60,
+      duration: -1_777_600_000,
+    });
+  });
+});

--- a/tests/toggl-api.test.ts
+++ b/tests/toggl-api.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { TogglAPI, TogglAPIError } from '../src/toggl-api.js';
+
+const { fetchMock } = vi.hoisted(() => ({
+  fetchMock: vi.fn(),
+}));
+
+vi.mock('node-fetch', () => ({
+  default: fetchMock,
+}));
+
+function response({
+  status,
+  text = '',
+  json,
+  retryAfter,
+}: {
+  status: number;
+  text?: string;
+  json?: unknown;
+  retryAfter?: string;
+}) {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: {
+      get: vi.fn((name: string) => (name.toLowerCase() === 'retry-after' ? retryAfter : null)),
+    },
+    text: vi.fn(async () => text),
+    json: vi.fn(async () => json),
+  };
+}
+
+describe('toggl api errors', () => {
+  afterEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it('parses Toggl quota reset seconds from 402 responses', async () => {
+    fetchMock.mockResolvedValue(
+      response({
+        status: 402,
+        text: 'You have hit your hourly limit for API calls. The quota will reset in 133 seconds.',
+      })
+    );
+
+    const api = new TogglAPI('token');
+    await expect(api.getWorkspaces()).rejects.toMatchObject({
+      code: 'TOGGL_QUOTA_LIMIT',
+      status: 402,
+      retry_after_seconds: 133,
+    });
+    await expect(api.getWorkspaces()).rejects.toBeInstanceOf(TogglAPIError);
+  });
+
+  it('returns structured rate limit errors instead of sleeping for long retry windows', async () => {
+    fetchMock.mockResolvedValue(response({ status: 429, retryAfter: '60' }));
+
+    const api = new TogglAPI('token');
+    await expect(api.getWorkspaces()).rejects.toMatchObject({
+      code: 'RATE_LIMITED',
+      status: 429,
+      retry_after_seconds: 60,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/workspace.test.ts
+++ b/tests/workspace.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveWorkspaceId, WorkspaceResolutionError } from '../src/workspace.js';
+import type { Workspace } from '../src/types.js';
+
+const workspace = (id: number, name: string): Workspace => ({ id, name });
+
+describe('workspace resolution', () => {
+  it('uses an explicit workspace id first', async () => {
+    const getWorkspaces = vi.fn<() => Promise<Workspace[]>>();
+
+    await expect(
+      resolveWorkspaceId({
+        explicitWorkspaceId: 123,
+        defaultWorkspaceId: 456,
+        getWorkspaces,
+        action: 'testing',
+      })
+    ).resolves.toBe(123);
+    expect(getWorkspaces).not.toHaveBeenCalled();
+  });
+
+  it('uses the configured default workspace when no explicit id is provided', async () => {
+    const getWorkspaces = vi.fn<() => Promise<Workspace[]>>();
+
+    await expect(
+      resolveWorkspaceId({
+        defaultWorkspaceId: 456,
+        getWorkspaces,
+        action: 'testing',
+      })
+    ).resolves.toBe(456);
+    expect(getWorkspaces).not.toHaveBeenCalled();
+  });
+
+  it('auto-selects the only available workspace', async () => {
+    const getWorkspaces = vi.fn(async () => [workspace(789, 'Solo')]);
+
+    await expect(
+      resolveWorkspaceId({
+        getWorkspaces,
+        action: 'testing',
+      })
+    ).resolves.toBe(789);
+  });
+
+  it('fails clearly when multiple workspaces require a choice', async () => {
+    const getWorkspaces = vi.fn(async () => [workspace(1, 'First'), workspace(2, 'Second')]);
+
+    await expect(
+      resolveWorkspaceId({
+        getWorkspaces,
+        action: 'listing projects',
+      })
+    ).rejects.toMatchObject({
+      code: 'WORKSPACE_REQUIRED',
+      available_workspaces: [
+        { id: 1, name: 'First' },
+        { id: 2, name: 'Second' },
+      ],
+    });
+
+    await expect(
+      resolveWorkspaceId({
+        getWorkspaces,
+        action: 'listing projects',
+      })
+    ).rejects.toBeInstanceOf(WorkspaceResolutionError);
+  });
+});


### PR DESCRIPTION
## Summary

- Add deterministic workspace resolution: explicit workspace, default env var, or only available workspace; multi-workspace accounts now get a clear actionable error.
- Route workspace/project/client/tag reads through cache-backed collection caches with meaningful hit/miss stats.
- Normalize hydrated time entries so tag fields are arrays, tag names resolve from bulk workspace tags, and running timers expose derived duration metadata while preserving raw Toggl duration.
- Return structured 402/429 quota metadata instead of hiding long waits, and document Claude Desktop summary-only chart guidance.

## Test plan

- npm run lint
- npm test
- npx tsc --noEmit
- npm audit --audit-level=high
- npm run build
- npm pack --dry-run
- ../mcp-ecosystem/scripts/audit-server.sh ../mcp-toggl
- node ../mcp-ecosystem/scripts/validate-sync.mjs mcp-toggl .