### PR TITLE
fix(cache): bound cached collections and retry delay

### DIFF
--- a/src/cache-manager.ts
+++ b/src/cache-manager.ts
@@ -70,14 +70,13 @@ export class CacheManager {
   }
 
   private cacheBucketLimit(): number {
-    return Math.max(1, Math.floor(this.config.maxSize / 6));
+    return Math.max(1, Math.ceil(this.config.maxSize / 6));
   }
 
   // Generic cache setter
   private setCached<T>(cache: Map<number, CacheEntry<T>>, id: number, data: T): void {
-    // Enforce max cache size with LRU eviction
-    if (cache.size >= this.cacheBucketLimit()) {
-      // Divide by 6 for each cache type
+    // Enforce per-cache bucket size using insertion-order eviction.
+    if (!cache.has(id) && cache.size >= this.cacheBucketLimit()) {
       const firstKey = cache.keys().next().value;
       if (firstKey !== undefined) {
         cache.delete(firstKey);
@@ -98,7 +97,7 @@ export class CacheManager {
       return;
     }
 
-    if (cache.size >= limit) {
+    if (!cache.has(id) && cache.size >= limit) {
       const firstKey = cache.keys().next().value;
       if (firstKey !== undefined) {
         cache.delete(firstKey);

--- a/src/cache-manager.ts
+++ b/src/cache-manager.ts
@@ -69,10 +69,14 @@ export class CacheManager {
     return null;
   }
 
+  private cacheBucketLimit(): number {
+    return Math.max(1, Math.floor(this.config.maxSize / 6));
+  }
+
   // Generic cache setter
   private setCached<T>(cache: Map<number, CacheEntry<T>>, id: number, data: T): void {
     // Enforce max cache size with LRU eviction
-    if (cache.size >= this.config.maxSize / 6) {
+    if (cache.size >= this.cacheBucketLimit()) {
       // Divide by 6 for each cache type
       const firstKey = cache.keys().next().value;
       if (firstKey !== undefined) {
@@ -87,12 +91,36 @@ export class CacheManager {
     });
   }
 
-  private setCachedCollection<T>(data: T[]): CacheEntry<T[]> {
-    return {
+  private setCachedCollection<T>(cache: Map<number, CacheEntry<T[]>>, id: number, data: T[]): void {
+    const limit = this.cacheBucketLimit();
+    if (data.length > limit) {
+      cache.delete(id);
+      return;
+    }
+
+    if (cache.size >= limit) {
+      const firstKey = cache.keys().next().value;
+      if (firstKey !== undefined) {
+        cache.delete(firstKey);
+      }
+    }
+
+    cache.set(id, {
       data,
       timestamp: new Date(),
       ttl: this.config.ttl,
-    };
+    });
+  }
+
+  private setWorkspaceList(workspaces: Workspace[]): void {
+    this.workspaceList =
+      workspaces.length <= this.cacheBucketLimit()
+        ? {
+            data: workspaces,
+            timestamp: new Date(),
+            ttl: this.config.ttl,
+          }
+        : null;
   }
 
   // Workspace methods
@@ -127,7 +155,7 @@ export class CacheManager {
       workspaces.forEach((ws: Workspace) => {
         this.setCached(this.workspaces, ws.id, ws);
       });
-      this.workspaceList = this.setCachedCollection(workspaces);
+      this.setWorkspaceList(workspaces);
       return workspaces;
     } catch (error) {
       console.error('Failed to fetch workspaces:', error);
@@ -171,7 +199,7 @@ export class CacheManager {
       projects.forEach((proj: Project) => {
         this.setCached(this.projects, proj.id, proj);
       });
-      this.projectsByWorkspace.set(workspaceId, this.setCachedCollection(projects));
+      this.setCachedCollection(this.projectsByWorkspace, workspaceId, projects);
       return projects;
     } catch (error) {
       console.error(`Failed to fetch projects for workspace ${workspaceId}:`, error);
@@ -215,7 +243,7 @@ export class CacheManager {
       clients.forEach((client: Client) => {
         this.setCached(this.clients, client.id, client);
       });
-      this.clientsByWorkspace.set(workspaceId, this.setCachedCollection(clients));
+      this.setCachedCollection(this.clientsByWorkspace, workspaceId, clients);
       return clients;
     } catch (error) {
       console.error(`Failed to fetch clients for workspace ${workspaceId}:`, error);
@@ -305,7 +333,7 @@ export class CacheManager {
       tags.forEach((tag: Tag) => {
         this.setCached(this.tags, tag.id, tag);
       });
-      this.tagsByWorkspace.set(workspaceId, this.setCachedCollection(tags));
+      this.setCachedCollection(this.tagsByWorkspace, workspaceId, tags);
       return tags;
     } catch (error) {
       console.error(`Failed to fetch tags for workspace ${workspaceId}:`, error);

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -450,7 +450,7 @@ function parseRetryAfterSeconds(value: string | null): number | undefined {
   if (!value) return undefined;
 
   const deltaSeconds = Number.parseInt(value, 10);
-  if (Number.isFinite(deltaSeconds)) return deltaSeconds;
+  if (Number.isFinite(deltaSeconds)) return Math.max(0, deltaSeconds);
 
   const dateMs = Date.parse(value);
   if (!Number.isFinite(dateMs)) return undefined;

--- a/tests/cache-manager.test.ts
+++ b/tests/cache-manager.test.ts
@@ -41,6 +41,100 @@ function createAPI() {
 }
 
 describe('cache manager', () => {
+  it('refreshes an existing entity without evicting another cached entity', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-01T10:00:00.000Z'));
+
+    const api = {
+      ...createAPI(),
+      getWorkspace: vi.fn(async (id: number) => ({ id, name: `Workspace ${id}` })),
+    };
+    const cache = new CacheManager({
+      ...config,
+      ttl: 1,
+      maxSize: 12,
+    });
+    cache.setAPI(api);
+
+    await cache.getWorkspace(1);
+    await cache.getWorkspace(2);
+
+    vi.setSystemTime(new Date('2026-05-01T10:00:00.002Z'));
+    await cache.getWorkspace(2);
+
+    const workspaces = (
+      cache as unknown as { workspaces: Map<number, unknown> }
+    ).workspaces;
+    expect([...workspaces.keys()]).toEqual([1, 2]);
+  });
+
+  it('does not cache oversized workspace-scoped project, client, or tag collections', async () => {
+    const oversizedProjects: Project[] = [
+      { id: 10, workspace_id: 1, name: 'Project 1' },
+      { id: 11, workspace_id: 1, name: 'Project 2' },
+    ];
+    const oversizedClients: Client[] = [
+      { id: 20, workspace_id: 1, name: 'Client 1' },
+      { id: 21, workspace_id: 1, name: 'Client 2' },
+    ];
+    const oversizedTags: Tag[] = [
+      { id: 30, workspace_id: 1, name: 'tag-1' },
+      { id: 31, workspace_id: 1, name: 'tag-2' },
+    ];
+    const api = {
+      ...createAPI(),
+      getProjects: vi.fn(async () => oversizedProjects),
+      getClients: vi.fn(async () => oversizedClients),
+      getTags: vi.fn(async () => oversizedTags),
+    };
+    const cache = new CacheManager({
+      ...config,
+      maxSize: 6,
+    });
+    cache.setAPI(api);
+
+    await expect(cache.getProjects(1)).resolves.toEqual(oversizedProjects);
+    await expect(cache.getProjects(1)).resolves.toEqual(oversizedProjects);
+    await expect(cache.getClients(1)).resolves.toEqual(oversizedClients);
+    await expect(cache.getClients(1)).resolves.toEqual(oversizedClients);
+    await expect(cache.getTags(1)).resolves.toEqual(oversizedTags);
+    await expect(cache.getTags(1)).resolves.toEqual(oversizedTags);
+
+    expect(api.getProjects).toHaveBeenCalledTimes(2);
+    expect(api.getClients).toHaveBeenCalledTimes(2);
+    expect(api.getTags).toHaveBeenCalledTimes(2);
+  });
+
+  it('evicts per-workspace collection caches only when adding a new workspace', async () => {
+    const api = {
+      ...createAPI(),
+      getProjects: vi.fn(async (workspaceId: number) => [
+        {
+          id: workspaceId * 10,
+          workspace_id: workspaceId,
+          name: `Project ${workspaceId}`,
+        },
+      ]),
+    };
+    const cache = new CacheManager({
+      ...config,
+      maxSize: 12,
+    });
+    cache.setAPI(api);
+
+    await cache.getProjects(1);
+    await cache.getProjects(2);
+    await cache.getProjects(2);
+    await cache.getProjects(3);
+    await cache.getProjects(1);
+
+    expect(api.getProjects).toHaveBeenCalledTimes(4);
+    expect(api.getProjects).toHaveBeenNthCalledWith(1, 1);
+    expect(api.getProjects).toHaveBeenNthCalledWith(2, 2);
+    expect(api.getProjects).toHaveBeenNthCalledWith(3, 3);
+    expect(api.getProjects).toHaveBeenNthCalledWith(4, 1);
+  });
+
   it('serves warmed workspace collections from cache and records hits', async () => {
     const api = createAPI();
     const cache = new CacheManager(config);


### PR DESCRIPTION
## Summary
- Bound cached workspace/project/client/tag collection storage to the configured cache budget instead of allowing oversized collection entries to bypass eviction.
- Clamp numeric Retry-After delta values at zero so stale or negative headers cannot produce negative retry timing.

## Breaking changes
- None.

## Test plan
- npm run build
- npm run lint (passes with existing no-explicit-any warnings)
- npm test