### PR TITLE
docs(readme): refresh release positioning

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -42,6 +42,9 @@ package-lock.json
 
 # Keep these in the published package
 !dist/
+!docs/
+!docs/images/
+!docs/images/*.svg
 !README.md
 !LICENSE
 !package.json

--- a/README.md
+++ b/README.md
@@ -1,19 +1,82 @@
-# MCP Toggl Server
+# MCP Toggl
 
-A Model Context Protocol (MCP) server for Toggl Track integration, providing time tracking and reporting capabilities with intelligent caching for optimal performance.
+> Talk to your time tracking. Pull reports, start timers, inspect desktop activity, and turn raw Toggl data into useful recaps from Claude or any MCP-compatible client.
 
-## Features
+[![npm](https://img.shields.io/npm/v/@verygoodplugins/mcp-toggl)](https://www.npmjs.com/package/@verygoodplugins/mcp-toggl)
+[![MCP](https://img.shields.io/badge/MCP-server-blueviolet)](https://modelcontextprotocol.io)
+[![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
+[![Toggl API](https://img.shields.io/badge/Toggl-API%20v9-red)](https://developers.track.toggl.com/docs/)
 
-- **Time Tracking**: Start/stop timers, get current and past time entries
-- **Smart Reporting**: Daily/weekly reports with project and workspace breakdowns
-- **Performance Optimized**: Intelligent caching system minimizes API calls
-- **Data Hydration**: Automatically enriches time entries with project/workspace/client names
-- **Flexible Filtering**: Query by date ranges, workspaces, or projects
-- **Automation Ready**: Structured JSON output perfect for Automation Hub workflows
+## See What Your Week Actually Looked Like
 
-## Quick Start (Recommended)
+> You ask: "Give me the recap of my week"
 
-Use via npx without cloning or building locally.
+The MCP server returns hydrated time entries with project, workspace, client, tag, and running-timer context. Your client can turn that into a readable recap:
+
+> 32.7 hours across 31 entries and 7 projects. Monday was a light planning day, Tuesday had the long implementation block, Wednesday stayed focused on one project, and Friday turned into a shipping run. The top project took 27% of the week, with two smaller projects close behind.
+
+![Weekly recap chart](docs/images/weekly-recap.svg)
+
+The server does not hard-code this prose or chart. It exposes structured Toggl data in a shape that makes synthesis easy.
+
+## Catch the Drift
+
+> You ask: "Did I actually work on what I said I worked on for that PR review entry?"
+
+`toggl_get_timeline` can compare a tracked entry boundary with Toggl Track Desktop activity:
+
+> The entry ran 1h 33m. About 67 minutes were in review tools, 5 minutes were scattered across chat apps, and the rest was idle or trimmed timeline space. The entry mostly checks out.
+
+![Drift detection chart](docs/images/drift-detection.svg)
+
+This is useful before invoicing, after long context-switching days, or whenever a vague entry like "admin" starts hiding too much Slack and browser time.
+
+## See Patterns Over Time
+
+> You ask: "Show me last month at a glance"
+
+Daily and weekly report tools make it straightforward for the client to render heatmaps, spot streaks, and surface intensity changes:
+
+![Monthly heatmap](docs/images/monthly-heatmap.svg)
+
+Toggl is still the source of truth. The MCP layer makes the data easier for an agent to inspect, summarize, and visualize.
+
+## Things You Can Ask
+
+```text
+What am I currently tracking?
+How much time did I spend on the website project this month?
+Start a timer for "PR review" on the Platform project
+Show me yesterday's hours as a chart
+What apps did I use most today?
+Generate a daily report for last Friday
+Compare this week to last week by project
+Which day this month had the most billable work?
+```
+
+Chart prompts depend on your MCP client. The server returns the structured data; clients such as Claude decide how to render it.
+
+## What Makes This Useful
+
+**Hydrated responses**: time entries are enriched with `project_name`, `client_name`, `workspace_name`, `tag_names`, and normalized running-timer fields so the client does not need a second lookup for ordinary reporting.
+
+**Smart caching**: workspaces, projects, clients, tasks, and tags are cached after first read. `toggl_cache_stats` shows hits, misses, loaded entities, and hit rate.
+
+**Desktop activity timeline**: `toggl_get_timeline` summarizes app usage from Toggl Track Desktop and can return raw events when you need sequence analysis.
+
+**Privacy controls**: timeline calls support summary-only output with `include_events: false` and title redaction with `redact_titles: true`.
+
+**Period shortcuts**: `today`, `yesterday`, `week`, `lastWeek`, `month`, and `lastMonth` are supported on the tools where those periods make sense.
+
+**Recoverable errors**: workspace resolution errors include `available_workspaces`, and Toggl quota/rate-limit errors include structured retry hints.
+
+## Quick Start
+
+### Prerequisites
+
+- Node.js `^20.19.0` or `>=22.12.0`
+- A Toggl Track account
+- Your Toggl API token from [track.toggl.com/profile](https://track.toggl.com/profile)
 
 ### Claude Desktop
 
@@ -23,198 +86,80 @@ Add this to `~/Library/Application Support/Claude/claude_desktop_config.json`:
 {
   "mcpServers": {
     "mcp-toggl": {
-      "command": "npx @verygoodplugins/mcp-toggl@latest",
+      "command": "npx",
+      "args": ["-y", "@verygoodplugins/mcp-toggl@latest"],
       "env": {
         "TOGGL_API_KEY": "your_api_key_here",
-        "TOGGL_DEFAULT_WORKSPACE_ID": "123456",
-        "TOGGL_CACHE_TTL": "3600000",
-        "TOGGL_CACHE_SIZE": "1000"
+        "TOGGL_DEFAULT_WORKSPACE_ID": "123456"
       }
     }
   }
 }
 ```
 
-### Cursor
+`TOGGL_DEFAULT_WORKSPACE_ID` is optional. If you have exactly one Toggl workspace, the server can resolve it automatically. If you have multiple workspaces and do not set a default, workspace-scoped tools return the available workspace IDs so the client can retry with `workspace_id`.
 
-Add this to your Cursor MCP settings (e.g., `~/.cursor/mcp.json`):
+Restart Claude Desktop, then ask:
 
-```json
-{
-  "mcp": {
-    "servers": {
-      "mcp-toggl": {
-        "command": "npx",
-        "args": ["@verygoodplugins/mcp-toggl@latest"],
-        "env": {
-          "TOGGL_API_KEY": "your_api_key_here",
-          "TOGGL_DEFAULT_WORKSPACE_ID": "123456",
-          "TOGGL_CACHE_TTL": "3600000",
-          "TOGGL_CACHE_SIZE": "1000"
-        }
-      }
-    }
-  }
-}
+```text
+What am I currently tracking?
 ```
 
-## Manual Installation
+### Global Install
 
 ```bash
-npm install
-npm run build
+npm install -g @verygoodplugins/mcp-toggl
+mcp-toggl --help
 ```
 
-## Configuration
+## Tools
 
-1. Get your Toggl API key from: https://track.toggl.com/profile
+### Reports and Insights
 
-2. Create a `.env` file:
+| Tool | What it does |
+| --- | --- |
+| `toggl_daily_report` | Hours by project and workspace for a date. Use `format: "text"` for display text or `"json"` for structured output. |
+| `toggl_weekly_report` | 7-day breakdown with daily totals and project rollups. Use `week_offset: -1` for last week. |
+| `toggl_get_time_entries` | Raw hydrated entries by period, date range, workspace, or project. |
+| `toggl_get_timeline` | Toggl Track Desktop app usage summary with optional raw events. |
 
-```env
-TOGGL_API_KEY=your_api_key_here
+### Timer Control
 
-# Aliases also supported (use one of these only if needed):
-# TOGGL_API_TOKEN=your_api_key_here
-# TOGGL_TOKEN=your_api_key_here
+| Tool | What it does |
+| --- | --- |
+| `toggl_get_current_entry` | Returns the running timer, elapsed seconds, and hydrated project/workspace context. |
+| `toggl_start_timer` | Starts a timer with description, optional project/task, and tags. |
+| `toggl_stop_timer` | Stops the currently running timer. |
 
-# Optional configuration
-TOGGL_DEFAULT_WORKSPACE_ID=123456  # Optional default workspace for multi-workspace accounts
-TOGGL_CACHE_TTL=3600000            # Cache TTL in ms (default: 1 hour)
-TOGGL_CACHE_SIZE=1000              # Max cached entities (default: 1000)
-```
+### Lookups
 
-Workspace-scoped tools use `workspace_id` first, then `TOGGL_DEFAULT_WORKSPACE_ID`.
-If neither is provided and your account has exactly one workspace, that workspace is selected
-automatically. If your account has multiple workspaces, the tool returns an actionable error with
-the available workspace IDs so you can pass `workspace_id` or set the default env var.
+| Tool | What it does |
+| --- | --- |
+| `toggl_check_auth` | Verifies token access and lists available workspaces without exposing the token. |
+| `toggl_list_workspaces` | Lists all accessible workspaces. |
+| `toggl_list_projects` | Lists projects for a workspace using cache-backed reads after first fetch. |
+| `toggl_list_clients` | Lists clients for a workspace using cache-backed reads after first fetch. |
 
-3. Add to your MCP configuration:
+### Cache Management
 
-### Claude Desktop
+| Tool | What it does |
+| --- | --- |
+| `toggl_warm_cache` | Pre-fetches workspace, project, client, and tag data before a heavy reporting session. |
+| `toggl_cache_stats` | Returns hits, misses, hit rate, loaded entity counts, and warm-cache state. |
+| `toggl_clear_cache` | Clears cached data. Useful after creating or renaming Toggl entities. |
 
-Edit `~/Library/Application Support/Claude/claude_desktop_config.json`:
+### Summaries
 
-```json
-{
-  "mcpServers": {
-    "mcp-toggl": {
-      "command": "node",
-      "args": ["/path/to/mcp-toggl/dist/index.js"],
-      "env": {
-        "TOGGL_API_KEY": "your_api_key_here"
-      }
-    }
-  }
-}
-```
+| Tool | What it does |
+| --- | --- |
+| `toggl_project_summary` | Total hours per project for a period or date range. |
+| `toggl_workspace_summary` | Total hours per workspace for a period or date range. |
 
-### Cursor
+## Timeline Privacy
 
-Edit `.mcp.json` in your project:
+Toggl Track Desktop activity can include window titles. Those titles may contain document names, email subjects, chat text, URLs, OAuth pages, or database names.
 
-```json
-{
-  "mcpServers": {
-    "mcp-toggl": {
-      "command": "node",
-      "args": ["./mcp-servers/mcp-toggl/dist/index.js"],
-      "env": {
-        "TOGGL_API_KEY": "your_api_key_here"
-      }
-    }
-  }
-}
-```
-
-## Available Tools
-
-### Authentication
-
-#### `toggl_check_auth`
-
-Verify Toggl API connectivity and confirm your token can access available workspaces without exposing the token.
-
-### Time Tracking
-
-#### `toggl_get_time_entries`
-
-Get time entries with optional filters.
-
-```json
-{
-  "period": "today", // or: yesterday, week, lastWeek, month, lastMonth
-  "workspace_id": 123456,
-  "project_id": 789012
-}
-```
-
-#### `toggl_get_current_entry`
-
-Get the currently running timer.
-
-#### `toggl_start_timer`
-
-Start a new time entry. `workspace_id` is optional only when `TOGGL_DEFAULT_WORKSPACE_ID` is set
-or your Toggl account has a single workspace.
-
-```json
-{
-  "description": "Working on MCP server",
-  "workspace_id": 123456,
-  "project_id": 123456,
-  "tags": ["development", "mcp"]
-}
-```
-
-#### `toggl_stop_timer`
-
-Stop the currently running timer.
-
-### Reporting
-
-#### `toggl_daily_report`
-
-Generate a daily report with project/workspace breakdowns.
-
-```json
-{
-  "date": "2024-09-01",
-  "format": "json" // or "text" for formatted output
-}
-```
-
-#### `toggl_weekly_report`
-
-Generate a weekly report with daily breakdowns.
-
-```json
-{
-  "week_offset": 0, // 0 = this week, -1 = last week
-  "format": "json"
-}
-```
-
-#### `toggl_project_summary`
-
-Get total hours per project for a date range.
-
-```json
-{
-  "period": "month",
-  "workspace_id": 123456
-}
-```
-
-#### `toggl_workspace_summary`
-
-Get total hours per workspace.
-
-#### `toggl_get_timeline`
-
-Get Toggl Desktop activity timeline data with application usage summaries and optional raw events. Requires Toggl Track Desktop timeline sync to be enabled.
-
-Privacy note: raw timeline events can include window titles that may contain document names, email subjects, chat text, URLs, OAuth pages, or database names. For privacy-conscious usage, request summary-only output:
+Summary-only mode returns app totals without raw events:
 
 ```json
 {
@@ -223,7 +168,7 @@ Privacy note: raw timeline events can include window titles that may contain doc
 }
 ```
 
-To return events while hiding window titles:
+Events with redacted titles preserve sequence and duration but remove titles:
 
 ```json
 {
@@ -233,166 +178,58 @@ To return events while hiding window titles:
 }
 ```
 
-### Management
-
-#### `toggl_list_workspaces`
-
-List all available workspaces.
-
-#### `toggl_list_projects`
-
-List projects in a workspace. Uses cached workspace project lists after the first fetch.
+Full event mode is the default:
 
 ```json
 {
-  "workspace_id": 123456
+  "period": "today"
 }
 ```
 
-#### `toggl_list_clients`
+When in doubt, use `include_events: false`.
 
-List clients in a workspace. Uses cached workspace client lists after the first fetch.
+## Configuration Reference
 
-### Cache Management
+| Env var | Required | Default | Notes |
+| --- | --- | --- | --- |
+| `TOGGL_API_KEY` | Yes | - | Preferred env var for your Toggl API token. |
+| `TOGGL_API_TOKEN` | No | - | Supported alias for backwards compatibility. `TOGGL_API_KEY` is preferred. |
+| `TOGGL_TOKEN` | No | - | Supported alias for backwards compatibility. `TOGGL_API_KEY` is preferred. |
+| `TOGGL_DEFAULT_WORKSPACE_ID` | No | - | Used when a tool requires a workspace and none is passed. |
+| `TOGGL_CACHE_TTL` | No | `3600000` | Cache TTL in milliseconds. Default is 1 hour. |
+| `TOGGL_CACHE_SIZE` | No | `1000` | Maximum cached entity budget. |
+| `TOGGL_BATCH_SIZE` | No | `100` | Batch size used by API pagination helpers. |
 
-#### `toggl_warm_cache`
+## Caveats
 
-Pre-fetch workspace/project/client/tag data for better performance. `workspace_id` is optional only
-when `TOGGL_DEFAULT_WORKSPACE_ID` is set or your account has a single workspace.
+**Toggl rate limits and quotas**: Toggl may return rate-limit or quota errors during chatty sessions. The server returns structured retry information when Toggl provides it. Warm the cache before large reporting sessions to avoid repeated project/client/tag fetches.
 
-#### `toggl_cache_stats`
+**Running timer duration**: Toggl uses negative duration values for running entries. Read `running` and `elapsed_seconds` from the hydrated response instead.
 
-View cache performance metrics. Hits and misses include entity lookups and cached workspace-scoped
-project/client/tag list reads.
+**Timeline availability**: `toggl_get_timeline` requires Toggl Track Desktop timeline sync. If it is not enabled or has not uploaded data yet, the tool returns `enabled: false` with setup guidance.
 
-#### `toggl_clear_cache`
+**Timeline totals**: `limit` only limits returned raw events. `summary`, `total_seconds`, and `total_hours` are calculated from all matching events.
 
-Clear all cached data.
-
-## Performance Optimization
-
-The server uses an intelligent caching system to minimize API calls:
-
-1. **First Run**: Fetches workspaces and warms the selected workspace when one can be resolved
-2. **Subsequent Calls**: Uses cached workspace/project/client/tag data for list tools and hydration
-3. **Smart Invalidation**: TTL-based expiry with configurable duration
-4. **Memory Efficient**: LRU eviction keeps memory usage under 10MB
-
-### Typical Performance
-
-- First report: workspace/project/client/tag fetches as needed, plus time entries
-- Subsequent reports: usually 1 API call for time entries, with names hydrated from cache
-- Repeated project/client list calls: served from cache until TTL expiry
-
-## Usage Examples
-
-### Daily Standup Report
-
-```javascript
-// Get today's time entries with full details
-toggl_daily_report({ format: 'text' });
-```
-
-### Weekly Summary for Automation Hub
-
-```javascript
-// Get last week's data as JSON
-toggl_weekly_report({ week_offset: -1 });
-```
-
-### Project Hours Tracking
-
-```javascript
-// Get this month's hours by project
-toggl_project_summary({ period: 'month' });
-```
-
-## Integration with Automation Hub
-
-The server returns structured JSON perfect for Automation Hub workflows:
-
-```javascript
-// Example daily report output
-{
-  "date": "2024-09-01",
-  "total_hours": 8.5,
-  "by_project": [
-    {
-      "project_name": "MCP Development",
-      "client_name": "Internal",
-      "total_hours": 4.5,
-      "billable_hours": 0
-    }
-  ],
-  "by_workspace": [
-    {
-      "workspace_name": "Very Good Plugins",
-      "total_hours": 8.5,
-      "project_count": 3
-    }
-  ]
-}
-```
-
-## Troubleshooting
-
-### API Key Issues
-
-- Ensure your API key is correct (get from https://track.toggl.com/profile)
-- API key goes in the username field, "api_token" as password for basic auth
-- Trim whitespace: copy/paste can include trailing spaces/newlines which cause 401/403
-- Accepted env var names: `TOGGL_API_KEY` (preferred), `TOGGL_API_TOKEN`, or `TOGGL_TOKEN`
-- If you see 401/403, regenerate the token on your Toggl profile and update your MCP config
-
-### Security & Token Lifecycle
-
-- This server uses Basic Auth with a Toggl API token, not OAuth; there is no refresh token to manage.
-- Toggl API tokens do not expire automatically. They only change if you manually regenerate them or if Toggl invalidates them during a security event.
-- If you regenerate your token, the old one stops working immediately. Update the `TOGGL_API_KEY` in your Claude/Cursor config and restart the client.
-- Never commit real secrets to version control. Use placeholders like `your_api_key_here` in docs and examples.
-- Claude Desktop stores the env value in `claude_desktop_config.json` on your machine. Treat that file as sensitive and do not share it.
-
-### Quick Auth Check
-
-You can verify connectivity by calling the `toggl_check_auth` tool, which pings `/me` and lists your available workspaces without exposing your token.
-
-### Rate Limiting
-
-- The server implements bounded automatic retry for short 429 rate-limit windows
-- Longer Toggl quota windows return structured errors with `retry_after_seconds` instead of making the MCP client appear stuck
-- Use `toggl_warm_cache` once per workspace and rely on cached list tools to avoid repeated project/client fetches
-
-### Cache Issues
-
-- Run `toggl_clear_cache` if data seems stale
-- Adjust `TOGGL_CACHE_TTL` for your needs (default: 1 hour)
-
-### Claude Desktop Chart Issues
-
-- For timeline charts, prefer summary-only data: call `toggl_get_timeline` with `include_events: false`
-- If Claude Desktop blanks while rendering a generated chart but the MCP server logs do not show a crash, restart Claude Desktop and retry with smaller summarized inputs
-
-## Development
+## Local Development
 
 ```bash
-# Run in development mode
-npm run dev
-
-# Build for production
+git clone https://github.com/verygoodplugins/mcp-toggl.git
+cd mcp-toggl
+npm install
 npm run build
-
-# Test the server
 npm test
+```
+
+Useful commands:
+
+```bash
+npm run dev
+npm run lint
+npm run format
 ```
 
 ## License
 
-MIT
+MIT.
 
-## Support
-
-For issues or questions, please open an issue on GitHub.
-
----
-
-Built with 🧡 for the open source community by [Very Good Plugins](https://verygoodplugins.com?utm_source=github)
+Built by [Very Good Plugins](https://verygoodplugins.com).

--- a/docs/images/drift-detection.svg
+++ b/docs/images/drift-detection.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 320" role="img" aria-label="Comparison of tracked time versus actual app usage during a 1 hour 33 minute PR review session: 67 minutes on focus tools, 5 minutes on chat, 21 minutes unaccounted">
+<title>Tracked vs reality — May 1 PR review session</title>
+<desc>Two horizontal bars. Top shows the single tracked entry: 1 hour 33 minutes on PR review for Automation Hub. Bottom shows actual app activity in that same window: focus tools (Cursor, Chrome, Codex, Claude, iTerm, GitHub Desktop) covered 67 minutes, chat apps (Slack, WhatsApp, Discord) covered 5 minutes, and 21 minutes were unaccounted for due to idle time or events not in the timeline snapshot.</desc>
+<style>
+.title { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; font-size: 16px; font-weight: 500; fill: #2C2C2A; }
+.subtitle { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; font-size: 12px; fill: #5F5E5A; }
+.row-label { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; font-size: 13px; font-weight: 500; fill: #2C2C2A; }
+.row-sub { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; font-size: 11px; fill: #5F5E5A; }
+.seg-label { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; font-size: 11px; font-weight: 500; fill: #FFFFFF; }
+.seg-label-dark { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; font-size: 11px; font-weight: 500; fill: #2C2C2A; }
+.callout { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; font-size: 11px; fill: #993C1D; font-weight: 500; }
+.legend-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; font-size: 11px; fill: #2C2C2A; }
+.axis { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; font-size: 10px; fill: #888780; }
+@media (prefers-color-scheme: dark) {
+  .title { fill: #F1EFE8; }
+  .subtitle { fill: #B4B2A9; }
+  .row-label { fill: #F1EFE8; }
+  .row-sub { fill: #B4B2A9; }
+  .seg-label-dark { fill: #F1EFE8; }
+  .callout { fill: #F0997B; }
+  .legend-text { fill: #F1EFE8; }
+  .axis { fill: #888780; }
+}
+</style>
+
+<text x="20" y="28" class="title">Tracked vs reality — &quot;PR review&quot; entry on May 1</text>
+<text x="20" y="48" class="subtitle">01:22 → 02:55 UTC · 1h 33m tracked on Automation Hub</text>
+
+<text x="20" y="92" class="row-label">Tracked</text>
+<text x="20" y="108" class="row-sub">1 entry</text>
+
+<rect x="80" y="78" width="690" height="36" fill="#378ADD" rx="3" />
+<text x="92" y="101" class="seg-label">PR review · Automation Hub</text>
+<text x="758" y="101" class="seg-label" text-anchor="end">1h 33m</text>
+
+<text x="20" y="162" class="row-label">Reality</text>
+<text x="20" y="178" class="row-sub">9 apps</text>
+
+<g>
+<rect x="80" y="148" width="160.4" height="36" fill="#1D9E75" rx="3" />
+<text x="160.2" y="171" class="seg-label" text-anchor="middle">Cursor 21m</text>
+
+<rect x="241.4" y="148" width="157.0" height="36" fill="#0F6E56" rx="3" />
+<text x="319.9" y="171" class="seg-label" text-anchor="middle">Chrome 21m</text>
+
+<rect x="399.4" y="148" width="113.0" height="36" fill="#1D9E75" rx="3" />
+<text x="455.9" y="171" class="seg-label" text-anchor="middle">Codex 15m</text>
+
+<rect x="513.4" y="148" width="29.9" height="36" fill="#0F6E56" rx="3" />
+
+<rect x="544.3" y="148" width="20.7" height="36" fill="#1D9E75" rx="3" />
+
+<rect x="566.0" y="148" width="18.8" height="36" fill="#0F6E56" rx="3" />
+
+<rect x="585.8" y="148" width="38.5" height="36" fill="#D85A30" rx="3" />
+<text x="605.0" y="171" class="seg-label" text-anchor="middle">5m</text>
+
+<rect x="625.3" y="148" width="152.7" height="36" fill="#B4B2A9" rx="3" />
+<text x="701.6" y="171" class="seg-label-dark" text-anchor="middle">21m unaccounted</text>
+</g>
+
+<line x1="585.8" y1="184" x2="585.8" y2="208" stroke="#993C1D" stroke-width="1" stroke-dasharray="2 2" />
+<line x1="624.3" y1="184" x2="624.3" y2="208" stroke="#993C1D" stroke-width="1" stroke-dasharray="2 2" />
+<text x="605.0" y="222" class="callout" text-anchor="middle">drift: chat apps</text>
+
+<line x1="80" y1="248" x2="770" y2="248" stroke="#888780" stroke-width="0.5" />
+<text x="80" y="264" class="axis">01:22</text>
+<text x="425" y="264" class="axis" text-anchor="middle">02:08</text>
+<text x="770" y="264" class="axis" text-anchor="end">02:55</text>
+
+<g transform="translate(20, 290)">
+<rect x="0" y="0" width="10" height="10" fill="#1D9E75" rx="2" />
+<text x="16" y="9" class="legend-text">Code/review tools</text>
+<rect x="142" y="0" width="10" height="10" fill="#0F6E56" rx="2" />
+<text x="158" y="9" class="legend-text">Browser/PR view</text>
+<rect x="280" y="0" width="10" height="10" fill="#D85A30" rx="2" />
+<text x="296" y="9" class="legend-text">Chat (Slack, WhatsApp, Discord)</text>
+<rect x="496" y="0" width="10" height="10" fill="#B4B2A9" rx="2" />
+<text x="512" y="9" class="legend-text">Idle / not in timeline snapshot</text>
+</g>
+</svg>

--- a/docs/images/monthly-heatmap.svg
+++ b/docs/images/monthly-heatmap.svg
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 380" role="img" aria-label="Calendar heatmap of April 2026 plus May 1: 26 active days, 219.6 hours total. Longest day Apr 2 at 18.2 hours. Most consistent stretch Apr 20 to 25 with 6 straight days of 9 to 14 hours.">
+<title>April recap — 219.6 hrs across 26 active days</title>
+<desc>Calendar heatmap showing daily hours tracked across April 2026 and May 1. Color intensity scales from light green (under 4 hours) to dark green (over 16 hours). Empty cells represent days with no entries. Off days: April 7, 11, 14-15, and 26.</desc>
+<style>
+.title { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; font-size: 16px; font-weight: 500; fill: #2C2C2A; }
+.subtitle { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; font-size: 12px; fill: #5F5E5A; }
+.day-label { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; font-size: 11px; fill: #5F5E5A; }
+.month-label { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; font-size: 10px; fill: #888780; }
+.legend-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; font-size: 11px; fill: #5F5E5A; }
+.stat-label { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; font-size: 12px; fill: #5F5E5A; }
+.stat-value { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; font-size: 22px; font-weight: 500; fill: #2C2C2A; }
+.stat-sub { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; font-size: 11px; fill: #888780; }
+.note-label { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; font-size: 12px; fill: #5F5E5A; }
+.note-value { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; font-size: 13px; font-weight: 500; fill: #2C2C2A; }
+@media (prefers-color-scheme: dark) {
+  .title { fill: #F1EFE8; }
+  .subtitle { fill: #B4B2A9; }
+  .day-label { fill: #B4B2A9; }
+  .month-label { fill: #888780; }
+  .legend-text { fill: #B4B2A9; }
+  .stat-label { fill: #B4B2A9; }
+  .stat-value { fill: #F1EFE8; }
+  .stat-sub { fill: #888780; }
+  .note-label { fill: #B4B2A9; }
+  .note-value { fill: #F1EFE8; }
+}
+</style>
+
+<text x="20" y="28" class="title">April recap — 219.6 hrs across 26 active days</text>
+<text x="20" y="48" class="subtitle">Apr 1 → May 1 · daily hours tracked</text>
+
+<text x="60" y="100" class="day-label" text-anchor="end">Mon</text>
+<text x="60" y="136" class="day-label" text-anchor="end">Tue</text>
+<text x="60" y="172" class="day-label" text-anchor="end">Wed</text>
+<text x="60" y="208" class="day-label" text-anchor="end">Thu</text>
+<text x="60" y="244" class="day-label" text-anchor="end">Fri</text>
+<text x="60" y="280" class="day-label" text-anchor="end">Sat</text>
+<text x="60" y="316" class="day-label" text-anchor="end">Sun</text>
+
+<rect x="70" y="80" width="32" height="32" fill="#F1EFE8" rx="4" opacity="0.4" />
+<rect x="70" y="116" width="32" height="32" fill="#F1EFE8" rx="4" opacity="0.4" />
+<rect x="70" y="152" width="32" height="32" fill="#5DCAA5" rx="4" />
+<rect x="70" y="188" width="32" height="32" fill="#085041" rx="4" />
+<rect x="70" y="224" width="32" height="32" fill="#9FE1CB" rx="4" />
+<rect x="70" y="260" width="32" height="32" fill="#9FE1CB" rx="4" />
+<rect x="70" y="296" width="32" height="32" fill="#9FE1CB" rx="4" />
+
+<rect x="106" y="80" width="32" height="32" fill="#5DCAA5" rx="4" />
+<rect x="106" y="116" width="32" height="32" fill="#E8E5DA" rx="4" />
+<rect x="106" y="152" width="32" height="32" fill="#9FE1CB" rx="4" />
+<rect x="106" y="188" width="32" height="32" fill="#085041" rx="4" />
+<rect x="106" y="224" width="32" height="32" fill="#1D9E75" rx="4" />
+<rect x="106" y="260" width="32" height="32" fill="#E8E5DA" rx="4" />
+<rect x="106" y="296" width="32" height="32" fill="#9FE1CB" rx="4" />
+
+<rect x="142" y="80" width="32" height="32" fill="#1D9E75" rx="4" />
+<rect x="142" y="116" width="32" height="32" fill="#E8E5DA" rx="4" />
+<rect x="142" y="152" width="32" height="32" fill="#E8E5DA" rx="4" />
+<rect x="142" y="188" width="32" height="32" fill="#0F6E56" rx="4" />
+<rect x="142" y="224" width="32" height="32" fill="#5DCAA5" rx="4" />
+<rect x="142" y="260" width="32" height="32" fill="#1D9E75" rx="4" />
+<rect x="142" y="296" width="32" height="32" fill="#1D9E75" rx="4" />
+
+<rect x="178" y="80" width="32" height="32" fill="#1D9E75" rx="4" />
+<rect x="178" y="116" width="32" height="32" fill="#0F6E56" rx="4" />
+<rect x="178" y="152" width="32" height="32" fill="#1D9E75" rx="4" />
+<rect x="178" y="188" width="32" height="32" fill="#0F6E56" rx="4" />
+<rect x="178" y="224" width="32" height="32" fill="#0F6E56" rx="4" />
+<rect x="178" y="260" width="32" height="32" fill="#1D9E75" rx="4" />
+<rect x="178" y="296" width="32" height="32" fill="#E8E5DA" rx="4" />
+
+<rect x="214" y="80" width="32" height="32" fill="#5DCAA5" rx="4" />
+<rect x="214" y="116" width="32" height="32" fill="#0F6E56" rx="4" />
+<rect x="214" y="152" width="32" height="32" fill="#5DCAA5" rx="4" />
+<rect x="214" y="188" width="32" height="32" fill="#5DCAA5" rx="4" />
+<rect x="214" y="224" width="32" height="32" fill="#9FE1CB" rx="4" />
+<rect x="214" y="260" width="32" height="32" fill="#F1EFE8" rx="4" opacity="0.4" />
+<rect x="214" y="296" width="32" height="32" fill="#F1EFE8" rx="4" opacity="0.4" />
+
+<text x="86" y="64" class="month-label" text-anchor="middle">Mar 30</text>
+<text x="194" y="64" class="month-label" text-anchor="middle">Apr 13</text>
+<text x="230" y="64" class="month-label" text-anchor="middle">Apr 27</text>
+
+<g transform="translate(70, 348)">
+<text x="0" y="0" class="legend-text">Less</text>
+<rect x="32" y="-9" width="11" height="11" fill="#E8E5DA" rx="2" />
+<rect x="48" y="-9" width="11" height="11" fill="#9FE1CB" rx="2" />
+<rect x="64" y="-9" width="11" height="11" fill="#5DCAA5" rx="2" />
+<rect x="80" y="-9" width="11" height="11" fill="#1D9E75" rx="2" />
+<rect x="96" y="-9" width="11" height="11" fill="#0F6E56" rx="2" />
+<rect x="112" y="-9" width="11" height="11" fill="#085041" rx="2" />
+<text x="130" y="0" class="legend-text">More</text>
+<text x="170" y="0" class="legend-text" fill="#888780">0h · &lt;4h · 4-8h · 8-12h · 12-16h · 16h+</text>
+</g>
+
+<g transform="translate(310, 80)">
+<text x="0" y="14" class="stat-label">Total tracked</text>
+<text x="0" y="42" class="stat-value">219.6</text>
+<text x="74" y="42" class="stat-sub">hrs</text>
+
+<text x="0" y="84" class="stat-label">Active days</text>
+<text x="0" y="112" class="stat-value">26</text>
+<text x="46" y="112" class="stat-sub">of 31 (84%)</text>
+
+<text x="0" y="154" class="stat-label">Avg active day</text>
+<text x="0" y="182" class="stat-value">8.4</text>
+<text x="58" y="182" class="stat-sub">hrs</text>
+</g>
+
+<g transform="translate(530, 80)">
+<text x="0" y="14" class="note-label">Longest day</text>
+<text x="0" y="34" class="note-value">Apr 2 — 18.2 hrs</text>
+<text x="0" y="52" class="stat-sub">"AI shit" + late call w/ Spence</text>
+
+<text x="0" y="92" class="note-label">Best stretch</text>
+<text x="0" y="112" class="note-value">Apr 20 → 25 · 6 days</text>
+<text x="0" y="130" class="stat-sub">avg 11.9 hrs/day, no breaks</text>
+
+<text x="0" y="170" class="note-label">Days off</text>
+<text x="0" y="190" class="note-value">5 · Apr 7, 11, 14, 15, 26</text>
+<text x="0" y="208" class="stat-sub">2 weekend pairs, mostly steady</text>
+</g>
+</svg>

--- a/docs/images/weekly-recap.svg
+++ b/docs/images/weekly-recap.svg
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 440" role="img" aria-label="Stacked bar chart of weekly hours by project, Apr 27 to May 1: Mon 2.5, Tue 15.8, Wed 6.9, Thu 2.2, Fri 5.2; total 32.7 hours across 7 projects">
+<title>Week of Apr 27 — 32.7 hours across 7 projects</title>
+<desc>Daily hours stacked by project. Tuesday peaks at 15.8 hours covering Business Development, AutoMem, Automation Hub, and MCP Servers. Wednesday is 6.9 hours of AI Learning. Friday is 5.2 hours, mostly Toggl MCP shipping work.</desc>
+<style>
+.title { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; font-size: 16px; font-weight: 500; fill: #2C2C2A; }
+.subtitle { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; font-size: 12px; fill: #5F5E5A; }
+.axis { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; font-size: 11px; fill: #5F5E5A; }
+.day-total { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; font-size: 11px; font-weight: 500; fill: #2C2C2A; }
+.legend-text { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; font-size: 11px; fill: #2C2C2A; }
+.grid { stroke: rgba(0,0,0,0.08); stroke-width: 1; }
+@media (prefers-color-scheme: dark) {
+  .title { fill: #F1EFE8; }
+  .subtitle { fill: #B4B2A9; }
+  .axis { fill: #B4B2A9; }
+  .day-total { fill: #F1EFE8; }
+  .legend-text { fill: #F1EFE8; }
+  .grid { stroke: rgba(255,255,255,0.10); }
+}
+</style>
+
+<text x="20" y="28" class="title">Week of Apr 27 — 32.7 hrs across 7 projects</text>
+<text x="20" y="48" class="subtitle">Daily hours stacked by project · 31 entries</text>
+
+<line x1="60" y1="80" x2="770" y2="80" class="grid" />
+<text x="50" y="84" class="axis" text-anchor="end">16h</text>
+<line x1="60" y1="145" x2="770" y2="145" class="grid" />
+<text x="50" y="149" class="axis" text-anchor="end">12h</text>
+<line x1="60" y1="210" x2="770" y2="210" class="grid" />
+<text x="50" y="214" class="axis" text-anchor="end">8h</text>
+<line x1="60" y1="275" x2="770" y2="275" class="grid" />
+<text x="50" y="279" class="axis" text-anchor="end">4h</text>
+<line x1="60" y1="340" x2="770" y2="340" class="grid" />
+<text x="50" y="344" class="axis" text-anchor="end">0h</text>
+
+<g>
+<rect x="96" y="306.7" width="70" height="33.3" fill="#378ADD" />
+<rect x="96" y="300.0" width="70" height="6.7" fill="#1D9E75" />
+<text x="131" y="293" class="day-total" text-anchor="middle">2.5h</text>
+<text x="131" y="360" class="axis" text-anchor="middle">Mon</text>
+<text x="131" y="375" class="axis" text-anchor="middle">Apr 27</text>
+</g>
+
+<g>
+<rect x="238" y="246.1" width="70" height="93.9" fill="#378ADD" />
+<rect x="238" y="159.8" width="70" height="86.3" fill="#7F77DD" />
+<rect x="238" y="113.2" width="70" height="46.6" fill="#1D9E75" />
+<rect x="238" y="82.6" width="70" height="30.6" fill="#EF9F27" />
+<text x="273" y="76" class="day-total" text-anchor="middle">15.8h</text>
+<text x="273" y="360" class="axis" text-anchor="middle">Tue</text>
+<text x="273" y="375" class="axis" text-anchor="middle">Apr 28</text>
+</g>
+
+<g>
+<rect x="380" y="227.4" width="70" height="112.6" fill="#D85A30" />
+<text x="415" y="220" class="day-total" text-anchor="middle">6.9h</text>
+<text x="415" y="360" class="axis" text-anchor="middle">Wed</text>
+<text x="415" y="375" class="axis" text-anchor="middle">Apr 29</text>
+</g>
+
+<g>
+<rect x="522" y="326.2" width="70" height="13.8" fill="#378ADD" />
+<rect x="522" y="307.5" width="70" height="18.7" fill="#D85A30" />
+<rect x="522" y="303.9" width="70" height="3.6" fill="#1D9E75" />
+<text x="557" y="297" class="day-total" text-anchor="middle">2.2h</text>
+<text x="557" y="360" class="axis" text-anchor="middle">Thu</text>
+<text x="557" y="375" class="axis" text-anchor="middle">Apr 30</text>
+</g>
+
+<g>
+<rect x="664" y="338.05" width="70" height="1.95" fill="#378ADD" />
+<rect x="664" y="312.85" width="70" height="25.2" fill="#1D9E75" />
+<rect x="664" y="267.85" width="70" height="45.0" fill="#D4537E" />
+<rect x="664" y="260.55" width="70" height="7.3" fill="#EF9F27" />
+<rect x="664" y="255.35" width="70" height="5.2" fill="#888780" />
+<text x="699" y="248" class="day-total" text-anchor="middle">5.2h</text>
+<text x="699" y="360" class="axis" text-anchor="middle">Fri</text>
+<text x="699" y="375" class="axis" text-anchor="middle">May 1</text>
+</g>
+
+<g transform="translate(20, 405)">
+<rect x="0" y="0" width="10" height="10" fill="#378ADD" />
+<text x="16" y="9" class="legend-text">Business Dev</text>
+<rect x="108" y="0" width="10" height="10" fill="#D85A30" />
+<text x="124" y="9" class="legend-text">AI Learning</text>
+<rect x="208" y="0" width="10" height="10" fill="#7F77DD" />
+<text x="224" y="9" class="legend-text">AutoMem</text>
+<rect x="296" y="0" width="10" height="10" fill="#1D9E75" />
+<text x="312" y="9" class="legend-text">Automation Hub</text>
+<rect x="416" y="0" width="10" height="10" fill="#D4537E" />
+<text x="432" y="9" class="legend-text">Toggl MCP</text>
+<rect x="516" y="0" width="10" height="10" fill="#EF9F27" />
+<text x="532" y="9" class="legend-text">MCP Servers</text>
+<rect x="624" y="0" width="10" height="10" fill="#888780" />
+<text x="640" y="9" class="legend-text">WPF Support</text>
+</g>
+</svg>

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   },
   "files": [
     "dist/",
+    "docs/images/*.svg",
     "README.md",
     "LICENSE"
   ],


### PR DESCRIPTION
## Summary
- Rework the README around the release story: weekly recaps, timeline drift checks, monthly patterns, and concrete prompts.
- Correct install/runtime/config details for the published package and current env vars.
- Move README images to `docs/images/` and publish only the three SVG assets used by the README.
- Drop the oversized GIF/raster assets from the shippable docs set.

## Breaking changes
- None.

## Test plan
- npm test
- npm pack --dry-run --json
- git diff --check -- README.md package.json .npmignore docs