### PR TITLE
ci(release): fix npm publish auth path

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,7 +5,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   npm-publish:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,25 @@
+name: npm Publish
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  npm-publish:
+    runs-on: ubuntu-latest
+    environment: npm
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+      - run: npm publish --provenance --access public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.1.0](https://github.com/verygoodplugins/mcp-toggl/compare/v1.0.0...v1.1.0) (2026-05-01)
+## [1.1.0](https://github.com/verygoodplugins/mcp-toggl/compare/v1.0.0...mcp-toggl-v1.1.0) (2026-05-01)
 
 
 ### Features


### PR DESCRIPTION
## Summary
- Fix the 1.1.0 changelog compare link to match the actual release tag (`mcp-toggl-v1.1.0`).
- Make npm publishing explicitly use an `NPM_TOKEN` secret when token publishing is used.
- Add a manual npm publish workflow so the already-created 1.1.0 release can be republished after npm auth is configured.
- Updated the existing GitHub release notes for `mcp-toggl-v1.1.0` directly to correct the compare link.

## Breaking changes
- None.

## Follow-up required
- Configure either repo/environment secret `NPM_TOKEN` with publish access to `@verygoodplugins/mcp-toggl`, or configure npm Trusted Publisher for `verygoodplugins/mcp-toggl` using workflow filename `npm-publish.yml` and environment `npm`.
- Then run the `npm Publish` workflow manually from `main` to publish `1.1.0`.

## Test plan
- npm test
- git diff --check
- Parsed `.github/workflows/release-please.yml` and `.github/workflows/npm-publish.yml` with PyYAML