### PR TITLE
ci(release): allow manual npm trusted publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   npm-publish:


### PR DESCRIPTION
## Summary
- grant id-token: write to the manual npm publish workflow so npm trusted publishing can mint provenance credentials

## Breaking changes
- None

## Related
- Follow-up to the v1.1.0 release where GitHub release succeeded but npm remained on 1.0.0