### PR TITLE
feat(toggl): add self-hostable HTTP transport

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+coverage
+.git
+.github
+.env
+*.log

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,92 @@
+name: Docker Build
+
+on:
+  push:
+    branches: [main]
+    tags: ["mcp-toggl-v*"]
+    paths:
+      - "Dockerfile"
+      - ".dockerignore"
+      - "package.json"
+      - "package-lock.json"
+      - "src/**"
+      - "tsconfig.json"
+      - ".github/workflows/docker-build.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "Dockerfile"
+      - ".dockerignore"
+      - "package.json"
+      - "package-lock.json"
+      - "src/**"
+      - "tsconfig.json"
+      - ".github/workflows/docker-build.yml"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Custom tag for the image (optional)"
+        required: false
+        default: ""
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/mcp-toggl
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        if: startsWith(github.ref, 'refs/tags/mcp-toggl-v') || github.event_name == 'workflow_dispatch'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=sha,prefix=sha-,suffix=,format=short
+            type=match,pattern=mcp-toggl-(v.*),group=1
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=stable,enable=${{ startsWith(github.ref, 'refs/tags/mcp-toggl-v') }}
+            type=raw,value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
+
+      - name: Build and optionally push Docker image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: ${{ startsWith(github.ref, 'refs/tags/mcp-toggl-v') || github.event_name == 'workflow_dispatch' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: ${{ (startsWith(github.ref, 'refs/tags/mcp-toggl-v') || github.event_name == 'workflow_dispatch') && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+
+      - name: Generate artifact attestation
+        if: startsWith(github.ref, 'refs/tags/mcp-toggl-v') || github.event_name == 'workflow_dispatch'
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          subject-digest: ${{ steps.push.outputs.digest }}
+          push-to-registry: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+ENV TRANSPORT=http
+ENV PORT=3000
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build && npm prune --omit=dev
+
+ENV NODE_ENV=production
+
+EXPOSE 3000
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD wget -qO- "http://127.0.0.1:${PORT}/health" >/dev/null || exit 1
+
+CMD ["node", "dist/index.js"]

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Original window titles are opt-in:
 ```
 
 `redact_titles` is still accepted for older clients, but `title_mode` is the preferred API.
+This is an intentional privacy-first behavior change from older releases: clients that need original window titles must pass `title_mode: "raw"` or `redact_titles: false`.
 
 When in doubt, use `include_events: false`.
 
@@ -195,6 +196,7 @@ When in doubt, use `include_events: false`.
 mcp-toggl can run as a local stdio server or as a per-user Streamable HTTP server. For the full platform-agnostic guide, see [VGP MCP self-hosting](https://github.com/verygoodplugins/mcp-ecosystem/blob/main/docs/SELF_HOSTING.md).
 
 Use a server-side Toggl token. Do not put your Toggl API token in the connector URL.
+Remote HTTP deployments also require an MCP bearer token so the public `/mcp` endpoint cannot be used as a proxy for your Toggl account.
 
 ### Docker
 
@@ -202,6 +204,7 @@ Use a server-side Toggl token. Do not put your Toggl API token in the connector 
 docker run --rm \
   -p 3000:3000 \
   -e TOGGL_API_TOKEN=xxx \
+  -e MCP_HTTP_AUTH_TOKEN=change-this-random-secret \
   ghcr.io/verygoodplugins/mcp-toggl:stable
 ```
 
@@ -216,30 +219,35 @@ Claude Desktop custom connector URL:
 https://your-deployment.example.com/mcp
 ```
 
+Configure the connector to send `Authorization: Bearer <MCP_HTTP_AUTH_TOKEN>`.
+
 ### Railway
 
 [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/mcp-toggl?referralCode=VuFE6g&utm_medium=integration&utm_source=github&utm_campaign=generic)
 
-Set `TOGGL_API_TOKEN` in Railway variables. Leave `TRANSPORT=http`; Railway will provide `PORT`.
+Set `TOGGL_API_TOKEN` and `MCP_HTTP_AUTH_TOKEN` in Railway variables. Leave `TRANSPORT=http`; Railway will provide `PORT`.
 
 ### Other Hosts
 
-Fly, Render, Coolify, and a bare VPS all use the same image and env vars. The only required deployment secret is `TOGGL_API_TOKEN`; `TOGGL_DEFAULT_WORKSPACE_ID` is optional for accounts with multiple workspaces.
+Fly, Render, Coolify, and a bare VPS all use the same image and env vars. Required deployment secrets are `TOGGL_API_TOKEN` and `MCP_HTTP_AUTH_TOKEN`; `TOGGL_DEFAULT_WORKSPACE_ID` is optional for accounts with multiple workspaces.
 
 ## Configuration Reference
 
-| Env var                      | Required | Default   | Notes                                                                                   |
-| ---------------------------- | -------- | --------- | --------------------------------------------------------------------------------------- |
-| `TOGGL_API_KEY`              | Yes      | -         | Toggl API token for local stdio installs. Either this or `TOGGL_API_TOKEN` is required. |
-| `TOGGL_API_TOKEN`            | Yes      | -         | Toggl API token for Docker/PaaS installs. Either this or `TOGGL_API_KEY` is required.   |
-| `TOGGL_TOKEN`                | No       | -         | Legacy alias. Prefer `TOGGL_API_KEY` or `TOGGL_API_TOKEN`.                              |
-| `TOGGL_DEFAULT_WORKSPACE_ID` | No       | -         | Used when a tool requires a workspace and none is passed.                               |
-| `TOGGL_CACHE_TTL`            | No       | `3600000` | Cache TTL in milliseconds. Default is 1 hour.                                           |
-| `TOGGL_CACHE_SIZE`           | No       | `1000`    | Maximum cached entity budget.                                                           |
-| `TOGGL_BATCH_SIZE`           | No       | `100`     | Batch size used by API pagination helpers.                                              |
-| `TRANSPORT`                  | No       | `stdio`   | Use `http` for Streamable HTTP self-hosting.                                            |
-| `PORT`                       | No       | `3000`    | HTTP port when `TRANSPORT=http`.                                                        |
-| `HOST`                       | No       | `0.0.0.0` | HTTP bind host when `TRANSPORT=http`.                                                   |
+| Env var                            | Required         | Default   | Notes                                                                                   |
+| ---------------------------------- | ---------------- | --------- | --------------------------------------------------------------------------------------- |
+| `TOGGL_API_KEY`                    | One token env    | -         | Toggl API token for local stdio installs.                                               |
+| `TOGGL_API_TOKEN`                  | One token env    | -         | Toggl API token for Docker/PaaS installs.                                               |
+| `TOGGL_TOKEN`                      | No               | -         | Legacy alias. Prefer `TOGGL_API_KEY` or `TOGGL_API_TOKEN`.                              |
+| `TOGGL_DEFAULT_WORKSPACE_ID`       | No               | -         | Used when a tool requires a workspace and none is passed.                               |
+| `TOGGL_CACHE_TTL`                  | No               | `3600000` | Cache TTL in milliseconds. Default is 1 hour.                                           |
+| `TOGGL_CACHE_SIZE`                 | No               | `1000`    | Maximum cached entity budget.                                                           |
+| `TOGGL_BATCH_SIZE`                 | No               | `100`     | Batch size used by API pagination helpers.                                              |
+| `TRANSPORT`                        | No               | `stdio`   | Use `http` for Streamable HTTP self-hosting.                                            |
+| `MCP_HTTP_AUTH_TOKEN`              | HTTP deployments | -         | Bearer token required for `/mcp` unless loopback unauthenticated mode is explicitly set. |
+| `MCP_HTTP_CORS_ORIGIN`             | No               | -         | Optional browser CORS origin. No CORS response headers are sent by default.             |
+| `MCP_HTTP_ALLOW_UNAUTHENTICATED`   | No               | `false`   | Set to `true` only for loopback-only HTTP development without auth.                     |
+| `PORT`                             | No               | `3000`    | HTTP port when `TRANSPORT=http`.                                                        |
+| `HOST`                             | No               | `0.0.0.0` | HTTP bind host when `TRANSPORT=http`.                                                   |
 
 ## Caveats
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Chart prompts depend on your MCP client. The server returns the structured data;
 
 **Desktop activity timeline**: `toggl_get_timeline` summarizes app usage from Toggl Track Desktop and can return raw events when you need sequence analysis.
 
-**Privacy controls**: timeline calls support summary-only output with `include_events: false` and title redaction with `redact_titles: true`.
+**Privacy controls**: timeline window titles are redacted by default. Use `include_events: false` for summary-only output, or opt into original titles with `title_mode: "raw"` when you explicitly need them.
 
 **Period shortcuts**: `today`, `yesterday`, `week`, `lastWeek`, `month`, and `lastMonth` are supported on the tools where those periods make sense.
 
@@ -116,48 +116,56 @@ mcp-toggl --help
 
 ### Reports and Insights
 
-| Tool | What it does |
-| --- | --- |
-| `toggl_daily_report` | Hours by project and workspace for a date. Use `format: "text"` for display text or `"json"` for structured output. |
-| `toggl_weekly_report` | 7-day breakdown with daily totals and project rollups. Use `week_offset: -1` for last week. |
-| `toggl_get_time_entries` | Raw hydrated entries by period, date range, workspace, or project. |
-| `toggl_get_timeline` | Toggl Track Desktop app usage summary with optional raw events. |
+| Tool                     | What it does                                                                                                        |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------- |
+| `toggl_daily_report`     | Hours by project and workspace for a date. Use `format: "text"` for display text or `"json"` for structured output. |
+| `toggl_weekly_report`    | 7-day breakdown with daily totals and project rollups. Use `week_offset: -1` for last week.                         |
+| `toggl_get_time_entries` | Raw hydrated entries by period, date range, workspace, or project.                                                  |
+| `toggl_get_timeline`     | Toggl Track Desktop app usage summary with optional raw events.                                                     |
 
 ### Timer Control
 
-| Tool | What it does |
-| --- | --- |
+| Tool                      | What it does                                                                        |
+| ------------------------- | ----------------------------------------------------------------------------------- |
 | `toggl_get_current_entry` | Returns the running timer, elapsed seconds, and hydrated project/workspace context. |
-| `toggl_start_timer` | Starts a timer with description, optional project/task, and tags. |
-| `toggl_stop_timer` | Stops the currently running timer. |
+| `toggl_start_timer`       | Starts a timer with description, optional project/task, and tags.                   |
+| `toggl_stop_timer`        | Stops the currently running timer.                                                  |
 
 ### Lookups
 
-| Tool | What it does |
-| --- | --- |
-| `toggl_check_auth` | Verifies token access and lists available workspaces without exposing the token. |
-| `toggl_list_workspaces` | Lists all accessible workspaces. |
-| `toggl_list_projects` | Lists projects for a workspace using cache-backed reads after first fetch. |
-| `toggl_list_clients` | Lists clients for a workspace using cache-backed reads after first fetch. |
+| Tool                    | What it does                                                                     |
+| ----------------------- | -------------------------------------------------------------------------------- |
+| `toggl_check_auth`      | Verifies token access and lists available workspaces without exposing the token. |
+| `toggl_list_workspaces` | Lists all accessible workspaces.                                                 |
+| `toggl_list_projects`   | Lists projects for a workspace using cache-backed reads after first fetch.       |
+| `toggl_list_clients`    | Lists clients for a workspace using cache-backed reads after first fetch.        |
 
 ### Cache Management
 
-| Tool | What it does |
-| --- | --- |
-| `toggl_warm_cache` | Pre-fetches workspace, project, client, and tag data before a heavy reporting session. |
-| `toggl_cache_stats` | Returns hits, misses, hit rate, loaded entity counts, and warm-cache state. |
-| `toggl_clear_cache` | Clears cached data. Useful after creating or renaming Toggl entities. |
+| Tool                | What it does                                                                           |
+| ------------------- | -------------------------------------------------------------------------------------- |
+| `toggl_warm_cache`  | Pre-fetches workspace, project, client, and tag data before a heavy reporting session. |
+| `toggl_cache_stats` | Returns hits, misses, hit rate, loaded entity counts, and warm-cache state.            |
+| `toggl_clear_cache` | Clears cached data. Useful after creating or renaming Toggl entities.                  |
 
 ### Summaries
 
-| Tool | What it does |
-| --- | --- |
-| `toggl_project_summary` | Total hours per project for a period or date range. |
+| Tool                      | What it does                                          |
+| ------------------------- | ----------------------------------------------------- |
+| `toggl_project_summary`   | Total hours per project for a period or date range.   |
 | `toggl_workspace_summary` | Total hours per workspace for a period or date range. |
 
 ## Timeline Privacy
 
 Toggl Track Desktop activity can include window titles. Those titles may contain document names, email subjects, chat text, URLs, OAuth pages, or database names.
+
+By default, `toggl_get_timeline` returns raw event sequence and timing with titles removed:
+
+```json
+{
+  "period": "today"
+}
+```
 
 Summary-only mode returns app totals without raw events:
 
@@ -168,37 +176,70 @@ Summary-only mode returns app totals without raw events:
 }
 ```
 
-Events with redacted titles preserve sequence and duration but remove titles:
+Original window titles are opt-in:
 
 ```json
 {
   "period": "today",
-  "redact_titles": true,
+  "title_mode": "raw",
   "limit": 50
 }
 ```
 
-Full event mode is the default:
-
-```json
-{
-  "period": "today"
-}
-```
+`redact_titles` is still accepted for older clients, but `title_mode` is the preferred API.
 
 When in doubt, use `include_events: false`.
 
+## Self-Hosting
+
+mcp-toggl can run as a local stdio server or as a per-user Streamable HTTP server. For the full platform-agnostic guide, see [VGP MCP self-hosting](https://github.com/verygoodplugins/mcp-ecosystem/blob/main/docs/SELF_HOSTING.md).
+
+Use a server-side Toggl token. Do not put your Toggl API token in the connector URL.
+
+### Docker
+
+```bash
+docker run --rm \
+  -p 3000:3000 \
+  -e TOGGL_API_TOKEN=xxx \
+  ghcr.io/verygoodplugins/mcp-toggl:stable
+```
+
+The container defaults to `TRANSPORT=http` and exposes:
+
+- `POST /mcp` for Streamable HTTP MCP clients
+- `GET /health` for platform health checks
+
+Claude Desktop custom connector URL:
+
+```text
+https://your-deployment.example.com/mcp
+```
+
+### Railway
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/mcp-toggl?referralCode=VuFE6g&utm_medium=integration&utm_source=github&utm_campaign=generic)
+
+Set `TOGGL_API_TOKEN` in Railway variables. Leave `TRANSPORT=http`; Railway will provide `PORT`.
+
+### Other Hosts
+
+Fly, Render, Coolify, and a bare VPS all use the same image and env vars. The only required deployment secret is `TOGGL_API_TOKEN`; `TOGGL_DEFAULT_WORKSPACE_ID` is optional for accounts with multiple workspaces.
+
 ## Configuration Reference
 
-| Env var | Required | Default | Notes |
-| --- | --- | --- | --- |
-| `TOGGL_API_KEY` | Yes | - | Preferred env var for your Toggl API token. |
-| `TOGGL_API_TOKEN` | No | - | Supported alias for backwards compatibility. `TOGGL_API_KEY` is preferred. |
-| `TOGGL_TOKEN` | No | - | Supported alias for backwards compatibility. `TOGGL_API_KEY` is preferred. |
-| `TOGGL_DEFAULT_WORKSPACE_ID` | No | - | Used when a tool requires a workspace and none is passed. |
-| `TOGGL_CACHE_TTL` | No | `3600000` | Cache TTL in milliseconds. Default is 1 hour. |
-| `TOGGL_CACHE_SIZE` | No | `1000` | Maximum cached entity budget. |
-| `TOGGL_BATCH_SIZE` | No | `100` | Batch size used by API pagination helpers. |
+| Env var                      | Required | Default   | Notes                                                                                   |
+| ---------------------------- | -------- | --------- | --------------------------------------------------------------------------------------- |
+| `TOGGL_API_KEY`              | Yes      | -         | Toggl API token for local stdio installs. Either this or `TOGGL_API_TOKEN` is required. |
+| `TOGGL_API_TOKEN`            | Yes      | -         | Toggl API token for Docker/PaaS installs. Either this or `TOGGL_API_KEY` is required.   |
+| `TOGGL_TOKEN`                | No       | -         | Legacy alias. Prefer `TOGGL_API_KEY` or `TOGGL_API_TOKEN`.                              |
+| `TOGGL_DEFAULT_WORKSPACE_ID` | No       | -         | Used when a tool requires a workspace and none is passed.                               |
+| `TOGGL_CACHE_TTL`            | No       | `3600000` | Cache TTL in milliseconds. Default is 1 hour.                                           |
+| `TOGGL_CACHE_SIZE`           | No       | `1000`    | Maximum cached entity budget.                                                           |
+| `TOGGL_BATCH_SIZE`           | No       | `100`     | Batch size used by API pagination helpers.                                              |
+| `TRANSPORT`                  | No       | `stdio`   | Use `http` for Streamable HTTP self-hosting.                                            |
+| `PORT`                       | No       | `3000`    | HTTP port when `TRANSPORT=http`.                                                        |
+| `HOST`                       | No       | `0.0.0.0` | HTTP bind host when `TRANSPORT=http`.                                                   |
 
 ## Caveats
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Chart prompts depend on your MCP client. The server returns the structured data;
 
 **Recoverable errors**: workspace resolution errors include `available_workspaces`, and Toggl quota/rate-limit errors include structured retry hints.
 
+**Team reporting**: report tools support `uid` plus `workspace_id` to pull a workspace member's entries through the Toggl Reports API v3. Use `toggl_list_workspace_users` to find privacy-safe member identifiers.
+
 ## Quick Start
 
 ### Prerequisites
@@ -116,12 +118,12 @@ mcp-toggl --help
 
 ### Reports and Insights
 
-| Tool                     | What it does                                                                                                        |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------- |
-| `toggl_daily_report`     | Hours by project and workspace for a date. Use `format: "text"` for display text or `"json"` for structured output. |
-| `toggl_weekly_report`    | 7-day breakdown with daily totals and project rollups. Use `week_offset: -1` for last week.                         |
-| `toggl_get_time_entries` | Raw hydrated entries by period, date range, workspace, or project.                                                  |
-| `toggl_get_timeline`     | Toggl Track Desktop app usage summary with optional raw events.                                                     |
+| Tool                     | What it does                                                                                                                                  |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `toggl_daily_report`     | Hours by project and workspace for a date. Use `format: "text"` for display text or `"json"` for structured output. Supports `uid` filtering. |
+| `toggl_weekly_report`    | 7-day breakdown with daily totals and project rollups. Use `week_offset: -1` for last week. Supports `uid` filtering.                         |
+| `toggl_get_time_entries` | Raw hydrated entries by period, date range, workspace, or project.                                                                            |
+| `toggl_get_timeline`     | Toggl Track Desktop app usage summary with optional raw events.                                                                               |
 
 ### Timer Control
 
@@ -133,12 +135,13 @@ mcp-toggl --help
 
 ### Lookups
 
-| Tool                    | What it does                                                                     |
-| ----------------------- | -------------------------------------------------------------------------------- |
-| `toggl_check_auth`      | Verifies token access and lists available workspaces without exposing the token. |
-| `toggl_list_workspaces` | Lists all accessible workspaces.                                                 |
-| `toggl_list_projects`   | Lists projects for a workspace using cache-backed reads after first fetch.       |
-| `toggl_list_clients`    | Lists clients for a workspace using cache-backed reads after first fetch.        |
+| Tool                         | What it does                                                                                                             |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `toggl_check_auth`           | Verifies token access and lists available workspaces without exposing the token.                                         |
+| `toggl_list_workspaces`      | Lists all accessible workspaces.                                                                                         |
+| `toggl_list_projects`        | Lists projects for a workspace using cache-backed reads after first fetch.                                               |
+| `toggl_list_clients`         | Lists clients for a workspace using cache-backed reads after first fetch.                                                |
+| `toggl_list_workspace_users` | Lists workspace members as `uid`, `name`, and `active` only. Use a member's `uid` to filter reports by that team member. |
 
 ### Cache Management
 
@@ -150,10 +153,10 @@ mcp-toggl --help
 
 ### Summaries
 
-| Tool                      | What it does                                          |
-| ------------------------- | ----------------------------------------------------- |
-| `toggl_project_summary`   | Total hours per project for a period or date range.   |
-| `toggl_workspace_summary` | Total hours per workspace for a period or date range. |
+| Tool                      | What it does                                                                    |
+| ------------------------- | ------------------------------------------------------------------------------- |
+| `toggl_project_summary`   | Total hours per project for a period or date range. Supports `uid` filtering.   |
+| `toggl_workspace_summary` | Total hours per workspace for a period or date range. Supports `uid` filtering. |
 
 ## Timeline Privacy
 
@@ -233,21 +236,21 @@ Fly, Render, Coolify, and a bare VPS all use the same image and env vars. Requir
 
 ## Configuration Reference
 
-| Env var                            | Required         | Default   | Notes                                                                                   |
-| ---------------------------------- | ---------------- | --------- | --------------------------------------------------------------------------------------- |
-| `TOGGL_API_KEY`                    | One token env    | -         | Toggl API token for local stdio installs.                                               |
-| `TOGGL_API_TOKEN`                  | One token env    | -         | Toggl API token for Docker/PaaS installs.                                               |
-| `TOGGL_TOKEN`                      | No               | -         | Legacy alias. Prefer `TOGGL_API_KEY` or `TOGGL_API_TOKEN`.                              |
-| `TOGGL_DEFAULT_WORKSPACE_ID`       | No               | -         | Used when a tool requires a workspace and none is passed.                               |
-| `TOGGL_CACHE_TTL`                  | No               | `3600000` | Cache TTL in milliseconds. Default is 1 hour.                                           |
-| `TOGGL_CACHE_SIZE`                 | No               | `1000`    | Maximum cached entity budget.                                                           |
-| `TOGGL_BATCH_SIZE`                 | No               | `100`     | Batch size used by API pagination helpers.                                              |
-| `TRANSPORT`                        | No               | `stdio`   | Use `http` for Streamable HTTP self-hosting.                                            |
-| `MCP_HTTP_AUTH_TOKEN`              | HTTP deployments | -         | Bearer token required for `/mcp` unless loopback unauthenticated mode is explicitly set. |
-| `MCP_HTTP_CORS_ORIGIN`             | No               | -         | Optional browser CORS origin. No CORS response headers are sent by default.             |
-| `MCP_HTTP_ALLOW_UNAUTHENTICATED`   | No               | `false`   | Set to `true` only for loopback-only HTTP development without auth.                     |
-| `PORT`                             | No               | `3000`    | HTTP port when `TRANSPORT=http`.                                                        |
-| `HOST`                             | No               | `0.0.0.0` | HTTP bind host when `TRANSPORT=http`.                                                   |
+| Env var                          | Required         | Default   | Notes                                                                                    |
+| -------------------------------- | ---------------- | --------- | ---------------------------------------------------------------------------------------- |
+| `TOGGL_API_KEY`                  | One token env    | -         | Toggl API token for local stdio installs.                                                |
+| `TOGGL_API_TOKEN`                | One token env    | -         | Toggl API token for Docker/PaaS installs.                                                |
+| `TOGGL_TOKEN`                    | No               | -         | Legacy alias. Prefer `TOGGL_API_KEY` or `TOGGL_API_TOKEN`.                               |
+| `TOGGL_DEFAULT_WORKSPACE_ID`     | No               | -         | Used when a tool requires a workspace and none is passed.                                |
+| `TOGGL_CACHE_TTL`                | No               | `3600000` | Cache TTL in milliseconds. Default is 1 hour.                                            |
+| `TOGGL_CACHE_SIZE`               | No               | `1000`    | Maximum cached entity budget.                                                            |
+| `TOGGL_BATCH_SIZE`               | No               | `100`     | Batch size used by API pagination helpers.                                               |
+| `TRANSPORT`                      | No               | `stdio`   | Use `http` for Streamable HTTP self-hosting.                                             |
+| `MCP_HTTP_AUTH_TOKEN`            | HTTP deployments | -         | Bearer token required for `/mcp` unless loopback unauthenticated mode is explicitly set. |
+| `MCP_HTTP_CORS_ORIGIN`           | No               | -         | Optional browser CORS origin. No CORS response headers are sent by default.              |
+| `MCP_HTTP_ALLOW_UNAUTHENTICATED` | No               | `false`   | Set to `true` only for loopback-only HTTP development without auth.                      |
+| `PORT`                           | No               | `3000`    | HTTP port when `TRANSPORT=http`.                                                         |
+| `HOST`                           | No               | `0.0.0.0` | HTTP bind host when `TRANSPORT=http`.                                                    |
 
 ## Caveats
 

--- a/server.json
+++ b/server.json
@@ -69,6 +69,10 @@
       "description": "List clients in a workspace"
     },
     {
+      "name": "toggl_list_workspace_users",
+      "description": "List workspace members (uid, name, active) for per-user report filtering"
+    },
+    {
       "name": "toggl_warm_cache",
       "description": "Pre-fetch workspace, project, client, and tag data"
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
+import { createServer as createHttpServer } from 'node:http';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { fileURLToPath } from 'node:url';
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
@@ -48,30 +52,61 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : 'An error occurred';
 }
 
-function errorPayload(error: unknown): Record<string, unknown> {
-  const payload: Record<string, unknown> = {
-    error: true,
-    message: errorMessage(error),
-  };
+function isUserInputError(error: unknown): error is Error {
+  if (!(error instanceof Error)) return false;
 
+  return [
+    'Invalid date format:',
+    'Invalid calendar date:',
+    'Invalid period:',
+    'start_date must',
+    'end_date must',
+    'title_mode must',
+  ].some((prefix) => error.message.startsWith(prefix));
+}
+
+function errorPayload(error: unknown): Record<string, unknown> {
   if (error instanceof TogglAPIError) {
+    const payload: Record<string, unknown> = {
+      error: true,
+      message: error.message,
+      code: error.code,
+      status: error.status,
+    };
     payload.code = error.code;
-    payload.status = error.status;
     if (error.retry_after_seconds !== undefined) {
       payload.retry_after_seconds = error.retry_after_seconds;
     }
     if (error.tip) {
       payload.tip = error.tip;
     }
+    return payload;
   }
 
   if (error instanceof WorkspaceResolutionError) {
-    payload.code = error.code;
-    payload.tip = error.tip;
-    payload.available_workspaces = error.available_workspaces;
+    return {
+      error: true,
+      message: error.message,
+      code: error.code,
+      tip: error.tip,
+      available_workspaces: error.available_workspaces,
+    };
   }
 
-  return payload;
+  if (isUserInputError(error)) {
+    return {
+      error: true,
+      code: 'INVALID_ARGUMENT',
+      message: errorMessage(error),
+    };
+  }
+
+  console.error('Unhandled tool error:', error);
+  return {
+    error: true,
+    code: 'INTERNAL_ERROR',
+    message: 'Internal server error. Check server logs for details.',
+  };
 }
 
 // Version for CLI output and server metadata
@@ -89,10 +124,12 @@ if (argv.includes('--help') || argv.includes('-h')) {
       `Usage:\n` +
       `  npx @verygoodplugins/mcp-toggl@latest [--help] [--version]\n\n` +
       `Environment:\n` +
-      `  TOGGL_API_KEY                Required Toggl API token\n` +
+      `  TOGGL_API_KEY                Required Toggl API token (or TOGGL_API_TOKEN)\n` +
       `  TOGGL_DEFAULT_WORKSPACE_ID   Optional default workspace id\n` +
       `  TOGGL_CACHE_TTL              Cache TTL in ms (default: 3600000)\n` +
       `  TOGGL_CACHE_SIZE             Max cached entities (default: 1000)\n\n` +
+      `  TRANSPORT                    stdio or http (default: stdio)\n` +
+      `  PORT                         HTTP port when TRANSPORT=http (default: 3000)\n\n` +
       `Claude Desktop (claude_desktop_config.json):\n` +
       `  {\n` +
       `    "mcpServers": {\n` +
@@ -129,13 +166,13 @@ const RAW_API_KEY =
 const API_KEY = RAW_API_KEY?.trim();
 
 if (!API_KEY) {
-  console.error('Missing required environment variable: TOGGL_API_KEY');
-  console.error('Also accepted: TOGGL_API_TOKEN or TOGGL_TOKEN');
+  console.error('Missing required environment variable: TOGGL_API_KEY or TOGGL_API_TOKEN');
+  console.error('Also accepted: TOGGL_TOKEN');
   process.exit(1);
 }
 
-if (process.env.TOGGL_API_TOKEN || process.env.TOGGL_TOKEN) {
-  console.warn('Using TOGGL_API_TOKEN/TOGGL_TOKEN. Prefer TOGGL_API_KEY going forward.');
+if (!process.env.TOGGL_API_KEY && !process.env.TOGGL_API_TOKEN && process.env.TOGGL_TOKEN) {
+  console.warn('Using TOGGL_TOKEN. Prefer TOGGL_API_KEY or TOGGL_API_TOKEN going forward.');
 }
 
 // Initialize configuration
@@ -183,19 +220,6 @@ async function resolveWorkspaceForTool(
     action,
   });
 }
-
-// Create MCP server
-const server = new Server(
-  {
-    name: 'mcp-toggl',
-    version: VERSION,
-  },
-  {
-    capabilities: {
-      tools: {},
-    },
-  }
-);
 
 // Define tool schemas
 const tools: Tool[] = [
@@ -528,7 +552,7 @@ const tools: Tool[] = [
   {
     name: 'toggl_get_timeline',
     description:
-      'Get Toggl Desktop activity timeline showing application usage. PRIVACY NOTE: raw events include window titles that may contain sensitive document names, email subjects, chat text, URLs, OAuth pages, or database names; use include_events: false for privacy-conscious summary-only usage. Requires Toggl Track Desktop timeline sync to be enabled. Response semantics: summary is { [appName: string]: total_seconds }; total_events is the post-filter event count; returned_events is the returned events array length; truncated means only the events array was limited, never the summary. limit does not affect summary calculation. total_seconds is canonical; total_hours is rounded to 4 decimals for display.',
+      'Get Toggl Desktop activity timeline showing application usage. PRIVACY NOTE: window titles are redacted by default because they may contain document names, email subjects, chat text, URLs, OAuth pages, or database names; set title_mode: "raw" only when you explicitly need original titles. Requires Toggl Track Desktop timeline sync to be enabled. Response semantics: summary is { [appName: string]: total_seconds }; total_events is the post-filter event count; returned_events is the returned events array length; truncated means only the events array was limited, never the summary. limit does not affect summary calculation. total_seconds is canonical; total_hours is rounded to 4 decimals for display.',
     annotations: {
       readOnlyHint: true,
       idempotentHint: true,
@@ -558,11 +582,19 @@ const tools: Tool[] = [
           type: 'boolean',
           description: 'Include raw events array (default: true). Set false for summary only.',
         },
+        title_mode: {
+          type: 'string',
+          enum: ['redacted', 'raw'],
+          default: 'redacted',
+          description:
+            'Window title privacy mode. Default redacted removes event titles; raw returns original window titles and should only be used when you explicitly need them.',
+        },
         redact_titles: {
           type: 'boolean',
-          default: false,
+          default: true,
+          deprecated: true,
           description:
-            'When true, returned events keep app name, timestamps, duration, idle state, and desktop_id, but set title to null.',
+            'Deprecated compatibility flag. When title_mode is omitted, true redacts titles and false returns raw titles.',
         },
         limit: {
           type: 'number',
@@ -577,575 +609,727 @@ const tools: Tool[] = [
   },
 ];
 
-// Handle tool listing
-server.setRequestHandler(ListToolsRequestSchema, async () => {
-  return { tools };
-});
+export function createTogglServer(): Server {
+  const server = new Server(
+    {
+      name: 'mcp-toggl',
+      version: VERSION,
+    },
+    {
+      capabilities: {
+        tools: {},
+      },
+    }
+  );
 
-// Handle tool calls
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
-  const { name, arguments: args } = request.params;
+  // Handle tool listing
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    return { tools };
+  });
+
+  // Handle tool calls
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+
+    try {
+      switch (name) {
+        // Health/authentication
+        case 'toggl_check_auth': {
+          const me = await api.getMe();
+          const workspaces = await cache.getWorkspaces();
+          const maskEmail = (e?: string) => {
+            if (!e) return undefined as unknown as string;
+            const [user, domain] = e.split('@');
+            if (!domain) return '***';
+            const u = user.length <= 2 ? '*'.repeat(user.length) : `${user[0]}***${user.slice(-1)}`;
+            return `${u}@${domain}`;
+          };
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(
+                  {
+                    authenticated: true,
+                    user: {
+                      id: (me as any).id,
+                      email: maskEmail((me as any).email),
+                      fullname: (me as any).fullname,
+                    },
+                    workspaces: workspaces.map((w) => ({ id: w.id, name: w.name })),
+                  },
+                  null,
+                  2
+                ),
+              },
+            ],
+          };
+        }
+
+        // Time tracking tools
+        case 'toggl_get_time_entries': {
+          await ensureCache();
+
+          let entries: TimeEntry[];
+
+          if (args?.period) {
+            const range = getDateRange(args.period as any);
+            entries = await api.getTimeEntriesForDateRange(range.start, range.end);
+          } else if (args?.start_date || args?.end_date) {
+            const start = args?.start_date ? parseLocalYMD(args.start_date as string) : new Date();
+            start.setHours(0, 0, 0, 0);
+            const end = args?.end_date
+              ? parseInclusiveEndDate(args.end_date as string)
+              : new Date();
+            if (!args?.end_date) {
+              end.setHours(0, 0, 0, 0);
+              end.setDate(end.getDate() + 1);
+            }
+            entries = await api.getTimeEntriesForDateRange(start, end);
+          } else {
+            entries = await api.getTimeEntriesForToday();
+          }
+
+          // Filter by workspace/project if specified
+          if (args?.workspace_id) {
+            entries = entries.filter((e) => e.workspace_id === args.workspace_id);
+          }
+          if (args?.project_id) {
+            entries = entries.filter((e) => e.project_id === args.project_id);
+          }
+
+          // Hydrate with names
+          const hydrated = await cache.hydrateTimeEntries(entries);
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(
+                  {
+                    count: hydrated.length,
+                    entries: hydrated,
+                  },
+                  null,
+                  2
+                ),
+              },
+            ],
+          };
+        }
+
+        case 'toggl_get_current_entry': {
+          const entry = await api.getCurrentTimeEntry();
+
+          if (!entry) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify({
+                    running: false,
+                    message: 'No timer currently running',
+                  }),
+                },
+              ],
+            };
+          }
+
+          await ensureCache();
+          const hydrated = await cache.hydrateTimeEntries([entry]);
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(
+                  {
+                    running: true,
+                    entry: hydrated[0],
+                  },
+                  null,
+                  2
+                ),
+              },
+            ],
+          };
+        }
+
+        case 'toggl_start_timer': {
+          const workspaceId = await resolveWorkspaceForTool(args, 'starting a timer');
+
+          const entry = await api.startTimer(
+            workspaceId,
+            args?.description as string | undefined,
+            args?.project_id as number | undefined,
+            args?.task_id as number | undefined,
+            args?.tags as string[] | undefined
+          );
+
+          await ensureCache();
+          const hydrated = await cache.hydrateTimeEntries([entry]);
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(
+                  {
+                    success: true,
+                    message: 'Timer started',
+                    entry: hydrated[0],
+                  },
+                  null,
+                  2
+                ),
+              },
+            ],
+          };
+        }
+
+        case 'toggl_stop_timer': {
+          const current = await api.getCurrentTimeEntry();
+
+          if (!current) {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify({
+                    success: false,
+                    message: 'No timer currently running',
+                  }),
+                },
+              ],
+            };
+          }
+
+          const stopped = await api.stopTimer(current.workspace_id, current.id);
+
+          await ensureCache();
+          const hydrated = await cache.hydrateTimeEntries([stopped]);
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(
+                  {
+                    success: true,
+                    message: 'Timer stopped',
+                    entry: hydrated[0],
+                  },
+                  null,
+                  2
+                ),
+              },
+            ],
+          };
+        }
+
+        // Reporting tools
+        case 'toggl_daily_report': {
+          await ensureCache();
+
+          const date = args?.date ? parseLocalYMD(args.date as string) : new Date();
+          date.setHours(0, 0, 0, 0);
+          const nextDay = new Date(date);
+          nextDay.setDate(nextDay.getDate() + 1);
+
+          const entries = await api.getTimeEntriesForDateRange(date, nextDay);
+          const hydrated = await cache.hydrateTimeEntries(entries);
+
+          const report = generateDailyReport(toLocalYMD(date), hydrated);
+
+          if (args?.format === 'text') {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: formatReportForDisplay(report),
+                },
+              ],
+            };
+          }
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(report, null, 2),
+              },
+            ],
+          };
+        }
+
+        case 'toggl_weekly_report': {
+          await ensureCache();
+
+          const weekOffset = (args?.week_offset as number) || 0;
+          const entries = await api.getTimeEntriesForWeek(weekOffset);
+          const hydrated = await cache.hydrateTimeEntries(entries);
+
+          // Calculate week boundaries in local time.
+          const today = new Date();
+          today.setHours(0, 0, 0, 0);
+          const dayOfWeek = today.getDay();
+          const diff = today.getDate() - dayOfWeek + (dayOfWeek === 0 ? -6 : 1);
+          const monday = new Date(today);
+          monday.setDate(diff + weekOffset * 7);
+          const sunday = new Date(monday);
+          sunday.setDate(sunday.getDate() + 6);
+
+          const report = generateWeeklyReport(monday, sunday, hydrated);
+
+          if (args?.format === 'text') {
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: formatReportForDisplay(report),
+                },
+              ],
+            };
+          }
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(report, null, 2),
+              },
+            ],
+          };
+        }
+
+        case 'toggl_project_summary': {
+          await ensureCache();
+
+          let entries: TimeEntry[];
+
+          if (args?.period) {
+            const range = getDateRange(args.period as any);
+            entries = await api.getTimeEntriesForDateRange(range.start, range.end);
+          } else if (args?.start_date && args?.end_date) {
+            const start = parseLocalYMD(args.start_date as string);
+            const end = parseInclusiveEndDate(args.end_date as string);
+            entries = await api.getTimeEntriesForDateRange(start, end);
+          } else {
+            // Default to current week
+            entries = await api.getTimeEntriesForWeek(0);
+          }
+
+          if (args?.workspace_id) {
+            entries = entries.filter((e) => e.workspace_id === args.workspace_id);
+          }
+
+          const hydrated = await cache.hydrateTimeEntries(entries);
+          const byProject = groupEntriesByProject(hydrated);
+
+          const summaries: any[] = [];
+          byProject.forEach((projectEntries, projectName) => {
+            summaries.push(generateProjectSummary(projectName, projectEntries));
+          });
+
+          // Sort by total hours descending
+          summaries.sort((a, b) => b.total_seconds - a.total_seconds);
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(
+                  {
+                    project_count: summaries.length,
+                    total_hours: secondsToHours(summaries.reduce((t, s) => t + s.total_seconds, 0)),
+                    projects: summaries,
+                  },
+                  null,
+                  2
+                ),
+              },
+            ],
+          };
+        }
+
+        case 'toggl_workspace_summary': {
+          await ensureCache();
+
+          let entries: TimeEntry[];
+
+          if (args?.period) {
+            const range = getDateRange(args.period as any);
+            entries = await api.getTimeEntriesForDateRange(range.start, range.end);
+          } else if (args?.start_date && args?.end_date) {
+            const start = parseLocalYMD(args.start_date as string);
+            const end = parseInclusiveEndDate(args.end_date as string);
+            entries = await api.getTimeEntriesForDateRange(start, end);
+          } else {
+            // Default to current week
+            entries = await api.getTimeEntriesForWeek(0);
+          }
+
+          const hydrated = await cache.hydrateTimeEntries(entries);
+          const byWorkspace = groupEntriesByWorkspace(hydrated);
+
+          const summaries: any[] = [];
+          byWorkspace.forEach((wsEntries, wsName) => {
+            const wsId = wsEntries[0]?.workspace_id || 0;
+            summaries.push(generateWorkspaceSummary(wsName, wsId, wsEntries));
+          });
+
+          // Sort by total hours descending
+          summaries.sort((a, b) => b.total_seconds - a.total_seconds);
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(
+                  {
+                    workspace_count: summaries.length,
+                    total_hours: secondsToHours(summaries.reduce((t, s) => t + s.total_seconds, 0)),
+                    workspaces: summaries,
+                  },
+                  null,
+                  2
+                ),
+              },
+            ],
+          };
+        }
+
+        // Management tools
+        case 'toggl_list_workspaces': {
+          const workspaces = await cache.getWorkspaces();
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(
+                  {
+                    count: workspaces.length,
+                    workspaces: workspaces.map((ws) => ({
+                      id: ws.id,
+                      name: ws.name,
+                      premium: ws.premium,
+                      default_currency: ws.default_currency,
+                    })),
+                  },
+                  null,
+                  2
+                ),
+              },
+            ],
+          };
+        }
+
+        case 'toggl_list_projects': {
+          const workspaceId = await resolveWorkspaceForTool(args, 'listing projects');
+
+          const projects = await cache.getProjects(workspaceId);
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(
+                  {
+                    workspace_id: workspaceId,
+                    count: projects.length,
+                    projects: projects.map((p) => ({
+                      id: p.id,
+                      name: p.name,
+                      active: p.active,
+                      billable: p.billable,
+                      color: p.color,
+                      client_id: p.client_id,
+                    })),
+                  },
+                  null,
+                  2
+                ),
+              },
+            ],
+          };
+        }
+
+        case 'toggl_list_clients': {
+          const workspaceId = await resolveWorkspaceForTool(args, 'listing clients');
+
+          const clients = await cache.getClients(workspaceId);
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(
+                  {
+                    workspace_id: workspaceId,
+                    count: clients.length,
+                    clients: clients.map((c) => ({
+                      id: c.id,
+                      name: c.name,
+                      archived: c.archived,
+                    })),
+                  },
+                  null,
+                  2
+                ),
+              },
+            ],
+          };
+        }
+
+        // Cache management
+        case 'toggl_warm_cache': {
+          const workspaceId = await resolveWorkspaceForTool(args, 'warming the cache');
+          await cache.warmCache(workspaceId);
+          cacheWarmed = true;
+
+          const stats = cache.getStats();
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(
+                  {
+                    success: true,
+                    message: 'Cache warmed successfully',
+                    stats,
+                  },
+                  null,
+                  2
+                ),
+              },
+            ],
+          };
+        }
+
+        case 'toggl_cache_stats': {
+          const stats = cache.getStats();
+          const hitRate =
+            stats.hits + stats.misses > 0
+              ? Math.round((stats.hits / (stats.hits + stats.misses)) * 100)
+              : 0;
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(
+                  {
+                    ...stats,
+                    hit_rate: `${hitRate}%`,
+                    cache_warmed: cacheWarmed,
+                  },
+                  null,
+                  2
+                ),
+              },
+            ],
+          };
+        }
+
+        case 'toggl_clear_cache': {
+          cache.clearCache();
+          cacheWarmed = false;
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  success: true,
+                  message: 'Cache cleared successfully',
+                }),
+              },
+            ],
+          };
+        }
+
+        case 'toggl_get_timeline': {
+          localDateRangeFromArgs(args);
+          if (
+            args?.title_mode !== undefined &&
+            args.title_mode !== 'redacted' &&
+            args.title_mode !== 'raw'
+          ) {
+            throw new Error('title_mode must be "redacted" or "raw"');
+          }
+
+          let allEvents: TimelineEvent[];
+          try {
+            allEvents = await api.getTimeline();
+          } catch (error) {
+            if (error instanceof TimelineNotEnabledError) {
+              return jsonResponse({
+                enabled: false,
+                total_events: 0,
+                returned_events: 0,
+                truncated: false,
+                total_seconds: 0,
+                total_hours: 0,
+                summary: {},
+                events: [],
+                message:
+                  'Toggl Desktop timeline is not enabled yet. Open the Toggl Track Desktop app for Mac, enable timeline/activity tracking and sync, then retry this tool after the app has uploaded activity data.',
+              });
+            }
+            throw error;
+          }
+
+          return jsonResponse(buildTimelineResponse(allEvents, args));
+        }
+
+        default:
+          throw new Error(`Unknown tool: ${name}`);
+      }
+    } catch (error: unknown) {
+      return jsonResponse(errorPayload(error));
+    }
+  });
+
+  return server;
+}
+
+function writeJson(res: ServerResponse, statusCode: number, body: Record<string, unknown>): void {
+  res.writeHead(statusCode, {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Content-Type, Accept, MCP-Protocol-Version, Mcp-Session-Id',
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Content-Type': 'application/json',
+  });
+  res.end(JSON.stringify(body));
+}
+
+async function handleMcpHttpRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204, {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Headers': 'Content-Type, Accept, MCP-Protocol-Version, Mcp-Session-Id',
+      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    });
+    res.end();
+    return;
+  }
+
+  if (req.method !== 'POST') {
+    writeJson(res, 405, {
+      jsonrpc: '2.0',
+      error: {
+        code: -32000,
+        message: 'Method not allowed.',
+      },
+      id: null,
+    });
+    return;
+  }
+
+  const server = createTogglServer();
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+  });
 
   try {
-    switch (name) {
-      // Health/authentication
-      case 'toggl_check_auth': {
-        const me = await api.getMe();
-        const workspaces = await cache.getWorkspaces();
-        const maskEmail = (e?: string) => {
-          if (!e) return undefined as unknown as string;
-          const [user, domain] = e.split('@');
-          if (!domain) return '***';
-          const u = user.length <= 2 ? '*'.repeat(user.length) : `${user[0]}***${user.slice(-1)}`;
-          return `${u}@${domain}`;
-        };
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(
-                {
-                  authenticated: true,
-                  user: {
-                    id: (me as any).id,
-                    email: maskEmail((me as any).email),
-                    fullname: (me as any).fullname,
-                  },
-                  workspaces: workspaces.map((w) => ({ id: w.id, name: w.name })),
-                },
-                null,
-                2
-              ),
-            },
-          ],
-        };
-      }
-
-      // Time tracking tools
-      case 'toggl_get_time_entries': {
-        await ensureCache();
-
-        let entries: TimeEntry[];
-
-        if (args?.period) {
-          const range = getDateRange(args.period as any);
-          entries = await api.getTimeEntriesForDateRange(range.start, range.end);
-        } else if (args?.start_date || args?.end_date) {
-          const start = args?.start_date ? parseLocalYMD(args.start_date as string) : new Date();
-          start.setHours(0, 0, 0, 0);
-          const end = args?.end_date ? parseInclusiveEndDate(args.end_date as string) : new Date();
-          if (!args?.end_date) {
-            end.setHours(0, 0, 0, 0);
-            end.setDate(end.getDate() + 1);
-          }
-          entries = await api.getTimeEntriesForDateRange(start, end);
-        } else {
-          entries = await api.getTimeEntriesForToday();
-        }
-
-        // Filter by workspace/project if specified
-        if (args?.workspace_id) {
-          entries = entries.filter((e) => e.workspace_id === args.workspace_id);
-        }
-        if (args?.project_id) {
-          entries = entries.filter((e) => e.project_id === args.project_id);
-        }
-
-        // Hydrate with names
-        const hydrated = await cache.hydrateTimeEntries(entries);
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(
-                {
-                  count: hydrated.length,
-                  entries: hydrated,
-                },
-                null,
-                2
-              ),
-            },
-          ],
-        };
-      }
-
-      case 'toggl_get_current_entry': {
-        const entry = await api.getCurrentTimeEntry();
-
-        if (!entry) {
-          return {
-            content: [
-              {
-                type: 'text',
-                text: JSON.stringify({
-                  running: false,
-                  message: 'No timer currently running',
-                }),
-              },
-            ],
-          };
-        }
-
-        await ensureCache();
-        const hydrated = await cache.hydrateTimeEntries([entry]);
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(
-                {
-                  running: true,
-                  entry: hydrated[0],
-                },
-                null,
-                2
-              ),
-            },
-          ],
-        };
-      }
-
-      case 'toggl_start_timer': {
-        const workspaceId = await resolveWorkspaceForTool(args, 'starting a timer');
-
-        const entry = await api.startTimer(
-          workspaceId,
-          args?.description as string | undefined,
-          args?.project_id as number | undefined,
-          args?.task_id as number | undefined,
-          args?.tags as string[] | undefined
-        );
-
-        await ensureCache();
-        const hydrated = await cache.hydrateTimeEntries([entry]);
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(
-                {
-                  success: true,
-                  message: 'Timer started',
-                  entry: hydrated[0],
-                },
-                null,
-                2
-              ),
-            },
-          ],
-        };
-      }
-
-      case 'toggl_stop_timer': {
-        const current = await api.getCurrentTimeEntry();
-
-        if (!current) {
-          return {
-            content: [
-              {
-                type: 'text',
-                text: JSON.stringify({
-                  success: false,
-                  message: 'No timer currently running',
-                }),
-              },
-            ],
-          };
-        }
-
-        const stopped = await api.stopTimer(current.workspace_id, current.id);
-
-        await ensureCache();
-        const hydrated = await cache.hydrateTimeEntries([stopped]);
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(
-                {
-                  success: true,
-                  message: 'Timer stopped',
-                  entry: hydrated[0],
-                },
-                null,
-                2
-              ),
-            },
-          ],
-        };
-      }
-
-      // Reporting tools
-      case 'toggl_daily_report': {
-        await ensureCache();
-
-        const date = args?.date ? parseLocalYMD(args.date as string) : new Date();
-        date.setHours(0, 0, 0, 0);
-        const nextDay = new Date(date);
-        nextDay.setDate(nextDay.getDate() + 1);
-
-        const entries = await api.getTimeEntriesForDateRange(date, nextDay);
-        const hydrated = await cache.hydrateTimeEntries(entries);
-
-        const report = generateDailyReport(toLocalYMD(date), hydrated);
-
-        if (args?.format === 'text') {
-          return {
-            content: [
-              {
-                type: 'text',
-                text: formatReportForDisplay(report),
-              },
-            ],
-          };
-        }
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(report, null, 2),
-            },
-          ],
-        };
-      }
-
-      case 'toggl_weekly_report': {
-        await ensureCache();
-
-        const weekOffset = (args?.week_offset as number) || 0;
-        const entries = await api.getTimeEntriesForWeek(weekOffset);
-        const hydrated = await cache.hydrateTimeEntries(entries);
-
-        // Calculate week boundaries in local time.
-        const today = new Date();
-        today.setHours(0, 0, 0, 0);
-        const dayOfWeek = today.getDay();
-        const diff = today.getDate() - dayOfWeek + (dayOfWeek === 0 ? -6 : 1);
-        const monday = new Date(today);
-        monday.setDate(diff + weekOffset * 7);
-        const sunday = new Date(monday);
-        sunday.setDate(sunday.getDate() + 6);
-
-        const report = generateWeeklyReport(monday, sunday, hydrated);
-
-        if (args?.format === 'text') {
-          return {
-            content: [
-              {
-                type: 'text',
-                text: formatReportForDisplay(report),
-              },
-            ],
-          };
-        }
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(report, null, 2),
-            },
-          ],
-        };
-      }
-
-      case 'toggl_project_summary': {
-        await ensureCache();
-
-        let entries: TimeEntry[];
-
-        if (args?.period) {
-          const range = getDateRange(args.period as any);
-          entries = await api.getTimeEntriesForDateRange(range.start, range.end);
-        } else if (args?.start_date && args?.end_date) {
-          const start = parseLocalYMD(args.start_date as string);
-          const end = parseInclusiveEndDate(args.end_date as string);
-          entries = await api.getTimeEntriesForDateRange(start, end);
-        } else {
-          // Default to current week
-          entries = await api.getTimeEntriesForWeek(0);
-        }
-
-        if (args?.workspace_id) {
-          entries = entries.filter((e) => e.workspace_id === args.workspace_id);
-        }
-
-        const hydrated = await cache.hydrateTimeEntries(entries);
-        const byProject = groupEntriesByProject(hydrated);
-
-        const summaries: any[] = [];
-        byProject.forEach((projectEntries, projectName) => {
-          summaries.push(generateProjectSummary(projectName, projectEntries));
-        });
-
-        // Sort by total hours descending
-        summaries.sort((a, b) => b.total_seconds - a.total_seconds);
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(
-                {
-                  project_count: summaries.length,
-                  total_hours: secondsToHours(summaries.reduce((t, s) => t + s.total_seconds, 0)),
-                  projects: summaries,
-                },
-                null,
-                2
-              ),
-            },
-          ],
-        };
-      }
-
-      case 'toggl_workspace_summary': {
-        await ensureCache();
-
-        let entries: TimeEntry[];
-
-        if (args?.period) {
-          const range = getDateRange(args.period as any);
-          entries = await api.getTimeEntriesForDateRange(range.start, range.end);
-        } else if (args?.start_date && args?.end_date) {
-          const start = parseLocalYMD(args.start_date as string);
-          const end = parseInclusiveEndDate(args.end_date as string);
-          entries = await api.getTimeEntriesForDateRange(start, end);
-        } else {
-          // Default to current week
-          entries = await api.getTimeEntriesForWeek(0);
-        }
-
-        const hydrated = await cache.hydrateTimeEntries(entries);
-        const byWorkspace = groupEntriesByWorkspace(hydrated);
-
-        const summaries: any[] = [];
-        byWorkspace.forEach((wsEntries, wsName) => {
-          const wsId = wsEntries[0]?.workspace_id || 0;
-          summaries.push(generateWorkspaceSummary(wsName, wsId, wsEntries));
-        });
-
-        // Sort by total hours descending
-        summaries.sort((a, b) => b.total_seconds - a.total_seconds);
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(
-                {
-                  workspace_count: summaries.length,
-                  total_hours: secondsToHours(summaries.reduce((t, s) => t + s.total_seconds, 0)),
-                  workspaces: summaries,
-                },
-                null,
-                2
-              ),
-            },
-          ],
-        };
-      }
-
-      // Management tools
-      case 'toggl_list_workspaces': {
-        const workspaces = await cache.getWorkspaces();
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(
-                {
-                  count: workspaces.length,
-                  workspaces: workspaces.map((ws) => ({
-                    id: ws.id,
-                    name: ws.name,
-                    premium: ws.premium,
-                    default_currency: ws.default_currency,
-                  })),
-                },
-                null,
-                2
-              ),
-            },
-          ],
-        };
-      }
-
-      case 'toggl_list_projects': {
-        const workspaceId = await resolveWorkspaceForTool(args, 'listing projects');
-
-        const projects = await cache.getProjects(workspaceId);
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(
-                {
-                  workspace_id: workspaceId,
-                  count: projects.length,
-                  projects: projects.map((p) => ({
-                    id: p.id,
-                    name: p.name,
-                    active: p.active,
-                    billable: p.billable,
-                    color: p.color,
-                    client_id: p.client_id,
-                  })),
-                },
-                null,
-                2
-              ),
-            },
-          ],
-        };
-      }
-
-      case 'toggl_list_clients': {
-        const workspaceId = await resolveWorkspaceForTool(args, 'listing clients');
-
-        const clients = await cache.getClients(workspaceId);
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(
-                {
-                  workspace_id: workspaceId,
-                  count: clients.length,
-                  clients: clients.map((c) => ({
-                    id: c.id,
-                    name: c.name,
-                    archived: c.archived,
-                  })),
-                },
-                null,
-                2
-              ),
-            },
-          ],
-        };
-      }
-
-      // Cache management
-      case 'toggl_warm_cache': {
-        const workspaceId = await resolveWorkspaceForTool(args, 'warming the cache');
-        await cache.warmCache(workspaceId);
-        cacheWarmed = true;
-
-        const stats = cache.getStats();
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(
-                {
-                  success: true,
-                  message: 'Cache warmed successfully',
-                  stats,
-                },
-                null,
-                2
-              ),
-            },
-          ],
-        };
-      }
-
-      case 'toggl_cache_stats': {
-        const stats = cache.getStats();
-        const hitRate =
-          stats.hits + stats.misses > 0
-            ? Math.round((stats.hits / (stats.hits + stats.misses)) * 100)
-            : 0;
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify(
-                {
-                  ...stats,
-                  hit_rate: `${hitRate}%`,
-                  cache_warmed: cacheWarmed,
-                },
-                null,
-                2
-              ),
-            },
-          ],
-        };
-      }
-
-      case 'toggl_clear_cache': {
-        cache.clearCache();
-        cacheWarmed = false;
-
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify({
-                success: true,
-                message: 'Cache cleared successfully',
-              }),
-            },
-          ],
-        };
-      }
-
-      case 'toggl_get_timeline': {
-        localDateRangeFromArgs(args);
-
-        let allEvents: TimelineEvent[];
-        try {
-          allEvents = await api.getTimeline();
-        } catch (error) {
-          if (error instanceof TimelineNotEnabledError) {
-            return jsonResponse({
-              enabled: false,
-              total_events: 0,
-              returned_events: 0,
-              truncated: false,
-              total_seconds: 0,
-              total_hours: 0,
-              summary: {},
-              events: [],
-              message:
-                'Toggl Desktop timeline is not enabled yet. Open the Toggl Track Desktop app for Mac, enable timeline/activity tracking and sync, then retry this tool after the app has uploaded activity data.',
-            });
-          }
-          throw error;
-        }
-
-        return jsonResponse(buildTimelineResponse(allEvents, args));
-      }
-
-      default:
-        throw new Error(`Unknown tool: ${name}`);
+    await server.connect(transport);
+    await transport.handleRequest(req, res);
+    res.on('close', () => {
+      void transport.close();
+      void server.close();
+    });
+  } catch (error) {
+    console.error('HTTP MCP request failed:', error);
+    await transport.close();
+    await server.close();
+    if (!res.headersSent) {
+      writeJson(res, 500, {
+        jsonrpc: '2.0',
+        error: {
+          code: -32603,
+          message: 'Internal server error.',
+        },
+        id: null,
+      });
     }
-  } catch (error: unknown) {
-    return jsonResponse(errorPayload(error));
   }
-});
+}
+
+function parsePort(value: string | undefined): number {
+  const port = Number.parseInt(value || '3000', 10);
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new Error('PORT must be an integer between 1 and 65535');
+  }
+  return port;
+}
+
+async function startHttpServer(): Promise<void> {
+  const port = parsePort(process.env.PORT);
+  const host = process.env.HOST || '0.0.0.0';
+
+  const httpServer = createHttpServer((req, res) => {
+    const url = new URL(req.url || '/', `http://${req.headers.host || 'localhost'}`);
+
+    if (url.pathname === '/health' && req.method === 'GET') {
+      writeJson(res, 200, {
+        ok: true,
+        name: 'mcp-toggl',
+        version: VERSION,
+        transport: 'http',
+      });
+      return;
+    }
+
+    if (url.pathname === '/mcp') {
+      void handleMcpHttpRequest(req, res);
+      return;
+    }
+
+    writeJson(res, 404, { error: 'Not found' });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    httpServer.once('error', reject);
+    httpServer.listen(port, host, () => {
+      httpServer.off('error', reject);
+      resolve();
+    });
+  });
+
+  const shutdown = () => {
+    httpServer.close(() => process.exit(0));
+  };
+  process.once('SIGINT', shutdown);
+  process.once('SIGTERM', shutdown);
+
+  console.error(`Toggl MCP server running over Streamable HTTP at http://${host}:${port}/mcp`);
+}
 
 // Start the server
 async function main() {
-  const transport = new StdioServerTransport();
-  await server.connect(transport);
-  console.error('Toggl MCP server running');
+  const transport = (process.env.TRANSPORT || 'stdio').trim().toLowerCase();
+
+  if (transport === 'http') {
+    await startHttpServer();
+    return;
+  }
+
+  if (transport !== 'stdio') {
+    console.error('Invalid TRANSPORT value. Expected "stdio" or "http".');
+    process.exit(1);
+  }
+
+  const server = createTogglServer();
+  const stdioTransport = new StdioServerTransport();
+  await server.connect(stdioTransport);
+  console.error('Toggl MCP server running over stdio');
 }
 
-main().catch((error) => {
-  console.error('Server error:', error);
-  process.exit(1);
-});
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main().catch((error) => {
+    console.error('Server error:', error);
+    process.exit(1);
+  });
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,6 +129,7 @@ if (argv.includes('--help') || argv.includes('-h')) {
       `  TOGGL_CACHE_TTL              Cache TTL in ms (default: 3600000)\n` +
       `  TOGGL_CACHE_SIZE             Max cached entities (default: 1000)\n\n` +
       `  TRANSPORT                    stdio or http (default: stdio)\n` +
+      `  MCP_HTTP_AUTH_TOKEN          Required bearer token when TRANSPORT=http\n` +
       `  PORT                         HTTP port when TRANSPORT=http (default: 3000)\n\n` +
       `Claude Desktop (claude_desktop_config.json):\n` +
       `  {\n` +
@@ -1195,24 +1196,66 @@ export function createTogglServer(): Server {
   return server;
 }
 
+function corsHeaders(): Record<string, string> {
+  const origin = (process.env.MCP_HTTP_CORS_ORIGIN || '').trim();
+  if (!origin) return {};
+
+  return {
+    'Access-Control-Allow-Origin': origin,
+    'Access-Control-Allow-Headers':
+      'Authorization, Content-Type, Accept, MCP-Protocol-Version, Mcp-Session-Id',
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+  };
+}
+
 function writeJson(res: ServerResponse, statusCode: number, body: Record<string, unknown>): void {
   res.writeHead(statusCode, {
-    'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Headers': 'Content-Type, Accept, MCP-Protocol-Version, Mcp-Session-Id',
-    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    ...corsHeaders(),
     'Content-Type': 'application/json',
   });
   res.end(JSON.stringify(body));
 }
 
-async function handleMcpHttpRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+function getHeader(req: IncomingMessage, name: string): string | undefined {
+  const value = req.headers[name.toLowerCase()];
+  if (Array.isArray(value)) return value[0];
+  return value;
+}
+
+function isAuthorizedHttpRequest(req: IncomingMessage, authToken: string | undefined): boolean {
+  if (!authToken) return true;
+  return getHeader(req, 'authorization') === `Bearer ${authToken}`;
+}
+
+async function closeServerAndTransport(
+  server: Server,
+  transport: StreamableHTTPServerTransport
+): Promise<void> {
+  await Promise.allSettled([transport.close(), server.close()]);
+}
+
+async function handleMcpHttpRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  authToken: string | undefined
+): Promise<void> {
   if (req.method === 'OPTIONS') {
     res.writeHead(204, {
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Headers': 'Content-Type, Accept, MCP-Protocol-Version, Mcp-Session-Id',
-      'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+      ...corsHeaders(),
     });
     res.end();
+    return;
+  }
+
+  if (!isAuthorizedHttpRequest(req, authToken)) {
+    writeJson(res, 401, {
+      jsonrpc: '2.0',
+      error: {
+        code: -32001,
+        message: 'Unauthorized.',
+      },
+      id: null,
+    });
     return;
   }
 
@@ -1232,18 +1275,21 @@ async function handleMcpHttpRequest(req: IncomingMessage, res: ServerResponse): 
   const transport = new StreamableHTTPServerTransport({
     sessionIdGenerator: undefined,
   });
+  let resourcesClosed = false;
+  const closeResources = async () => {
+    if (resourcesClosed) return;
+    resourcesClosed = true;
+    await closeServerAndTransport(server, transport);
+  };
 
   try {
+    res.once('close', () => {
+      void closeResources();
+    });
     await server.connect(transport);
     await transport.handleRequest(req, res);
-    res.on('close', () => {
-      void transport.close();
-      void server.close();
-    });
   } catch (error) {
     console.error('HTTP MCP request failed:', error);
-    await transport.close();
-    await server.close();
     if (!res.headersSent) {
       writeJson(res, 500, {
         jsonrpc: '2.0',
@@ -1254,20 +1300,47 @@ async function handleMcpHttpRequest(req: IncomingMessage, res: ServerResponse): 
         id: null,
       });
     }
+  } finally {
+    if (res.writableEnded || res.destroyed) {
+      await closeResources();
+    }
   }
 }
 
 function parsePort(value: string | undefined): number {
-  const port = Number.parseInt(value || '3000', 10);
+  const rawValue = (value || '3000').trim();
+  if (!/^\d+$/.test(rawValue)) {
+    throw new Error('PORT must be an integer between 1 and 65535');
+  }
+
+  const port = Number.parseInt(rawValue, 10);
   if (!Number.isInteger(port) || port <= 0 || port > 65535) {
     throw new Error('PORT must be an integer between 1 and 65535');
   }
   return port;
 }
 
+function isLoopbackHost(host: string): boolean {
+  return host === '127.0.0.1' || host === 'localhost' || host === '::1';
+}
+
+function getHttpAuthToken(host: string): string | undefined {
+  const token = (process.env.MCP_HTTP_AUTH_TOKEN || '').trim();
+  if (token) return token;
+
+  if (process.env.MCP_HTTP_ALLOW_UNAUTHENTICATED === 'true' && isLoopbackHost(host)) {
+    return undefined;
+  }
+
+  throw new Error(
+    'MCP_HTTP_AUTH_TOKEN is required when TRANSPORT=http. Set MCP_HTTP_ALLOW_UNAUTHENTICATED=true only for loopback-only development.'
+  );
+}
+
 async function startHttpServer(): Promise<void> {
   const port = parsePort(process.env.PORT);
   const host = process.env.HOST || '0.0.0.0';
+  const authToken = getHttpAuthToken(host);
 
   const httpServer = createHttpServer((req, res) => {
     const url = new URL(req.url || '/', `http://${req.headers.host || 'localhost'}`);
@@ -1283,7 +1356,7 @@ async function startHttpServer(): Promise<void> {
     }
 
     if (url.pathname === '/mcp') {
-      void handleMcpHttpRequest(req, res);
+      void handleMcpHttpRequest(req, res, authToken);
       return;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -222,6 +222,19 @@ async function resolveWorkspaceForTool(
   });
 }
 
+function reportDateRangeFromArgs(args: Record<string, unknown> | undefined): {
+  start: Date;
+  end: Date;
+} {
+  const range = localDateRangeFromArgs(args);
+  if (range?.start && range.end) return { start: range.start, end: range.end };
+  return getDateRange('week');
+}
+
+function readUid(args: Record<string, unknown> | undefined): number | undefined {
+  return typeof args?.uid === 'number' ? args.uid : undefined;
+}
+
 // Define tool schemas
 const tools: Tool[] = [
   // Health/authentication
@@ -362,6 +375,16 @@ const tools: Tool[] = [
           enum: ['json', 'text'],
           description: 'Output format (default: json)',
         },
+        uid: {
+          type: 'number',
+          description:
+            "Toggl user id to report on. When provided, uses Reports API v3 to fetch that workspace member's entries.",
+        },
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID for uid report filtering. If omitted, workspace resolution uses the configured default or sole workspace.',
+        },
       },
     },
   },
@@ -384,6 +407,16 @@ const tools: Tool[] = [
           type: 'string',
           enum: ['json', 'text'],
           description: 'Output format (default: json)',
+        },
+        uid: {
+          type: 'number',
+          description:
+            "Toggl user id to report on. When provided, uses Reports API v3 to fetch that workspace member's entries.",
+        },
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID for uid report filtering. If omitted, workspace resolution uses the configured default or sole workspace.',
         },
       },
     },
@@ -414,7 +447,13 @@ const tools: Tool[] = [
         },
         workspace_id: {
           type: 'number',
-          description: 'Filter by workspace ID',
+          description:
+            'Filter by workspace ID. Also used as the Reports API workspace when uid is provided.',
+        },
+        uid: {
+          type: 'number',
+          description:
+            "Toggl user id to report on. When provided, uses Reports API v3 to fetch that workspace member's entries.",
         },
       },
     },
@@ -442,6 +481,16 @@ const tools: Tool[] = [
         end_date: {
           type: 'string',
           description: 'End date (YYYY-MM-DD format, inclusive, local timezone)',
+        },
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID for uid report filtering. If omitted, workspace resolution uses the configured default or sole workspace.',
+        },
+        uid: {
+          type: 'number',
+          description:
+            "Toggl user id to report on. When provided, uses Reports API v3 to fetch that workspace member's entries.",
         },
       },
     },
@@ -496,6 +545,26 @@ const tools: Tool[] = [
           type: 'number',
           description:
             'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
+        },
+      },
+    },
+  },
+  {
+    name: 'toggl_list_workspace_users',
+    description:
+      'List workspace members as privacy-safe uid, name, and active fields for per-user report filtering.',
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace.',
         },
       },
     },
@@ -837,7 +906,16 @@ export function createTogglServer(): Server {
           const nextDay = new Date(date);
           nextDay.setDate(nextDay.getDate() + 1);
 
-          const entries = await api.getTimeEntriesForDateRange(date, nextDay);
+          const uid = readUid(args);
+          const entries =
+            uid !== undefined
+              ? await api.getTimeEntriesForUserAndDateRange(
+                  await resolveWorkspaceForTool(args, 'generating a daily report'),
+                  uid,
+                  date,
+                  nextDay
+                )
+              : await api.getTimeEntriesForDateRange(date, nextDay);
           const hydrated = await cache.hydrateTimeEntries(entries);
 
           const report = generateDailyReport(toLocalYMD(date), hydrated);
@@ -867,9 +945,6 @@ export function createTogglServer(): Server {
           await ensureCache();
 
           const weekOffset = (args?.week_offset as number) || 0;
-          const entries = await api.getTimeEntriesForWeek(weekOffset);
-          const hydrated = await cache.hydrateTimeEntries(entries);
-
           // Calculate week boundaries in local time.
           const today = new Date();
           today.setHours(0, 0, 0, 0);
@@ -879,6 +954,20 @@ export function createTogglServer(): Server {
           monday.setDate(diff + weekOffset * 7);
           const sunday = new Date(monday);
           sunday.setDate(sunday.getDate() + 6);
+          const nextMonday = new Date(monday);
+          nextMonday.setDate(nextMonday.getDate() + 7);
+
+          const uid = readUid(args);
+          const entries =
+            uid !== undefined
+              ? await api.getTimeEntriesForUserAndDateRange(
+                  await resolveWorkspaceForTool(args, 'generating a weekly report'),
+                  uid,
+                  monday,
+                  nextMonday
+                )
+              : await api.getTimeEntriesForWeek(weekOffset);
+          const hydrated = await cache.hydrateTimeEntries(entries);
 
           const report = generateWeeklyReport(monday, sunday, hydrated);
 
@@ -906,21 +995,19 @@ export function createTogglServer(): Server {
         case 'toggl_project_summary': {
           await ensureCache();
 
-          let entries: TimeEntry[];
+          const range = reportDateRangeFromArgs(args);
+          const uid = readUid(args);
+          let entries =
+            uid !== undefined
+              ? await api.getTimeEntriesForUserAndDateRange(
+                  await resolveWorkspaceForTool(args, 'generating a project summary'),
+                  uid,
+                  range.start,
+                  range.end
+                )
+              : await api.getTimeEntriesForDateRange(range.start, range.end);
 
-          if (args?.period) {
-            const range = getDateRange(args.period as any);
-            entries = await api.getTimeEntriesForDateRange(range.start, range.end);
-          } else if (args?.start_date && args?.end_date) {
-            const start = parseLocalYMD(args.start_date as string);
-            const end = parseInclusiveEndDate(args.end_date as string);
-            entries = await api.getTimeEntriesForDateRange(start, end);
-          } else {
-            // Default to current week
-            entries = await api.getTimeEntriesForWeek(0);
-          }
-
-          if (args?.workspace_id) {
+          if (uid === undefined && args?.workspace_id) {
             entries = entries.filter((e) => e.workspace_id === args.workspace_id);
           }
 
@@ -956,19 +1043,17 @@ export function createTogglServer(): Server {
         case 'toggl_workspace_summary': {
           await ensureCache();
 
-          let entries: TimeEntry[];
-
-          if (args?.period) {
-            const range = getDateRange(args.period as any);
-            entries = await api.getTimeEntriesForDateRange(range.start, range.end);
-          } else if (args?.start_date && args?.end_date) {
-            const start = parseLocalYMD(args.start_date as string);
-            const end = parseInclusiveEndDate(args.end_date as string);
-            entries = await api.getTimeEntriesForDateRange(start, end);
-          } else {
-            // Default to current week
-            entries = await api.getTimeEntriesForWeek(0);
-          }
+          const range = reportDateRangeFromArgs(args);
+          const uid = readUid(args);
+          const entries =
+            uid !== undefined
+              ? await api.getTimeEntriesForUserAndDateRange(
+                  await resolveWorkspaceForTool(args, 'generating a workspace summary'),
+                  uid,
+                  range.start,
+                  range.end
+                )
+              : await api.getTimeEntriesForDateRange(range.start, range.end);
 
           const hydrated = await cache.hydrateTimeEntries(entries);
           const byWorkspace = groupEntriesByWorkspace(hydrated);
@@ -1074,6 +1159,29 @@ export function createTogglServer(): Server {
                       name: c.name,
                       archived: c.archived,
                     })),
+                  },
+                  null,
+                  2
+                ),
+              },
+            ],
+          };
+        }
+
+        case 'toggl_list_workspace_users': {
+          const workspaceId = await resolveWorkspaceForTool(args, 'listing workspace users');
+          const users = await api.getWorkspaceUsers(workspaceId);
+          const summaries = users.map((user) => TogglAPI.toWorkspaceMemberSummary(user));
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(
+                  {
+                    workspace_id: workspaceId,
+                    count: summaries.length,
+                    users: summaries,
                   },
                   null,
                   2

--- a/src/timeline.ts
+++ b/src/timeline.ts
@@ -6,6 +6,7 @@ interface TimelineArgs extends Record<string, unknown> {
   include_events?: unknown;
   limit?: unknown;
   redact_titles?: unknown;
+  title_mode?: unknown;
   period?: unknown;
   start_date?: unknown;
   end_date?: unknown;
@@ -26,6 +27,17 @@ export function timelineSecondsToHours(seconds: number): number {
   return Math.round((seconds / 3600) * 10000) / 10000;
 }
 
+function shouldRedactTitles(args: TimelineArgs | undefined): boolean {
+  if (args?.title_mode !== undefined) {
+    if (args.title_mode === 'raw') return false;
+    if (args.title_mode === 'redacted') return true;
+    throw new Error('title_mode must be "redacted" or "raw"');
+  }
+
+  if (typeof args?.redact_titles === 'boolean') return args.redact_titles;
+  return true;
+}
+
 export function buildTimelineResponse(
   allEvents: TimelineEvent[],
   args: TimelineArgs | undefined,
@@ -36,7 +48,7 @@ export function buildTimelineResponse(
   const endTs = range?.end ? range.end.getTime() / 1000 : null;
   const appFilter = typeof args?.app === 'string' ? args.app.toLowerCase() : null;
   const includeEvents = args?.include_events !== false;
-  const redactTitles = args?.redact_titles === true;
+  const redactTitles = shouldRedactTitles(args);
   const rawLimit = typeof args?.limit === 'number' ? args.limit : 50;
   const limit = Math.max(1, Math.min(Math.floor(rawLimit), 1000));
 

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -113,18 +113,21 @@ export class TogglAPI {
             });
           }
 
-          const isAuth = response.status === 401 || response.status === 403;
-          const message = isAuth
-            ? `Authentication failed (${response.status}). ` +
-              `Verify TOGGL_API_KEY is correct, has no leading/trailing spaces, and is the Toggl Track API token. ` +
-              `Server response: ${text}`
-            : `Toggl API error (${response.status}): ${text}`;
-          const err = new Error(message);
-          // 4xx client errors won't succeed on retry (incl. 401/403); 5xx and network errors do retry.
           if (response.status >= 400 && response.status < 500) {
-            Object.assign(err, { noRetry: true });
+            const isAuth = response.status === 401 || response.status === 403;
+            throw new TogglAPIError({
+              status: response.status,
+              code: isAuth ? 'AUTHENTICATION_FAILED' : 'TOGGL_API_CLIENT_ERROR',
+              message: isAuth
+                ? `Authentication failed (${response.status}). Verify TOGGL_API_KEY is correct, has no leading/trailing spaces, and is the Toggl Track API token.`
+                : `Toggl API rejected the request (${response.status}).`,
+              tip: isAuth
+                ? 'Regenerate or copy your Toggl Track API token from track.toggl.com/profile and restart the MCP server.'
+                : 'Check the tool arguments and Toggl workspace permissions, then retry.',
+            });
           }
-          throw err;
+
+          throw new Error(`Toggl API request failed (${response.status}).`);
         }
 
         // Handle 204 No Content
@@ -404,15 +407,21 @@ export class TogglAPI {
             throw new TimelineNotEnabledError();
           }
 
-          const isAuth = response.status === 401 || response.status === 403;
-          const message = isAuth
-            ? `Timeline authentication failed (${response.status}). Verify TOGGL_API_KEY is correct. Server response: ${text}`
-            : `Timeline API error (${response.status}): ${text}`;
-          const err = new Error(message);
           if (response.status >= 400 && response.status < 500) {
-            Object.assign(err, { noRetry: true });
+            const isAuth = response.status === 401 || response.status === 403;
+            throw new TogglAPIError({
+              status: response.status,
+              code: isAuth ? 'AUTHENTICATION_FAILED' : 'TIMELINE_API_CLIENT_ERROR',
+              message: isAuth
+                ? `Timeline authentication failed (${response.status}). Verify TOGGL_API_KEY is correct.`
+                : `Toggl timeline API rejected the request (${response.status}).`,
+              tip: isAuth
+                ? 'Regenerate or copy your Toggl Track API token from track.toggl.com/profile and restart the MCP server.'
+                : 'Check timeline permissions and request arguments, then retry.',
+            });
           }
-          throw err;
+
+          throw new Error(`Toggl timeline API request failed (${response.status}).`);
         }
 
         const data = JSON.parse(text) as unknown;

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -1,4 +1,4 @@
-import fetch from 'node-fetch';
+import fetch, { type RequestInit, type Response } from 'node-fetch';
 import { toLocalYMD } from './utils.js';
 import type {
   Workspace,
@@ -6,6 +6,8 @@ import type {
   Client,
   Task,
   User,
+  WorkspaceUser,
+  WorkspaceMemberSummary,
   Tag,
   TimeEntry,
   TimeEntriesRequest,
@@ -68,19 +70,12 @@ export class TogglAPI {
     };
   }
 
-  // Generic API request method
-  private async request<T>(method: string, endpoint: string, body?: any, retries = 3): Promise<T> {
-    const url = `${this.baseUrl}${endpoint}`;
-
+  // Shared fetch loop for retryable network, 429, and 5xx responses.
+  private async fetchWithRetry(url: string, init: RequestInit, retries = 3): Promise<Response> {
     for (let i = 0; i < retries; i++) {
       try {
-        const response = await fetch(url, {
-          method,
-          headers: this.headers,
-          body: body ? JSON.stringify(body) : undefined,
-        });
+        const response = await fetch(url, init);
 
-        // Handle rate limiting without sleeping for multi-minute quota resets.
         if (response.status === 429) {
           const retryAfterSeconds = parseRetryAfterSeconds(response.headers.get('Retry-After'));
           const delay = retryAfterSeconds !== undefined ? retryAfterSeconds * 1000 : (i + 1) * 2000;
@@ -100,42 +95,12 @@ export class TogglAPI {
           });
         }
 
-        if (!response.ok) {
-          const text = await response.text();
-          if (response.status === 402) {
-            const retryAfterSeconds = parseQuotaResetSeconds(text);
-            throw new TogglAPIError({
-              status: response.status,
-              code: 'TOGGL_QUOTA_LIMIT',
-              message: `Toggl API quota limit reached.${retryAfterSeconds !== undefined ? ` Quota resets in ${retryAfterSeconds} seconds.` : ''}`,
-              retryAfterSeconds,
-              tip: 'Wait for the Toggl quota window to reset. Cache-backed list tools avoid repeated project/client fetches after they are warmed.',
-            });
-          }
-
-          if (response.status >= 400 && response.status < 500) {
-            const isAuth = response.status === 401 || response.status === 403;
-            throw new TogglAPIError({
-              status: response.status,
-              code: isAuth ? 'AUTHENTICATION_FAILED' : 'TOGGL_API_CLIENT_ERROR',
-              message: isAuth
-                ? `Authentication failed (${response.status}). Verify TOGGL_API_KEY is correct, has no leading/trailing spaces, and is the Toggl Track API token.`
-                : `Toggl API rejected the request (${response.status}).`,
-              tip: isAuth
-                ? 'Regenerate or copy your Toggl Track API token from track.toggl.com/profile and restart the MCP server.'
-                : 'Check the tool arguments and Toggl workspace permissions, then retry.',
-            });
-          }
-
-          throw new Error(`Toggl API request failed (${response.status}).`);
+        if (response.status >= 500 && i < retries - 1) {
+          await new Promise((resolve) => setTimeout(resolve, (i + 1) * 1000));
+          continue;
         }
 
-        // Handle 204 No Content
-        if (response.status === 204) {
-          return {} as T;
-        }
-
-        return (await response.json()) as T;
+        return response;
       } catch (error: any) {
         if (error?.noRetry || i === retries - 1) throw error;
         // Exponential backoff for transient/network errors
@@ -144,6 +109,60 @@ export class TogglAPI {
     }
 
     throw new Error('Max retries reached');
+  }
+
+  // Generic API request method
+  private async request<T>(method: string, endpoint: string, body?: any, retries = 3): Promise<T> {
+    const url = `${this.baseUrl}${endpoint}`;
+    const response = await this.fetchWithRetry(
+      url,
+      {
+        method,
+        headers: this.headers,
+        body: body ? JSON.stringify(body) : undefined,
+      },
+      retries
+    );
+
+    if (!response.ok) {
+      const text = await response.text();
+      if (response.status === 402) {
+        const retryAfterSeconds = parseQuotaResetSeconds(text);
+        throw new TogglAPIError({
+          status: response.status,
+          code: 'TOGGL_QUOTA_LIMIT',
+          message: `Toggl API quota limit reached.${retryAfterSeconds !== undefined ? ` Quota resets in ${retryAfterSeconds} seconds.` : ''}`,
+          retryAfterSeconds,
+          tip: 'Wait for the Toggl quota window to reset. Cache-backed list tools avoid repeated project/client fetches after they are warmed.',
+        });
+      }
+
+      if (response.status >= 400 && response.status < 500) {
+        const isAuth = response.status === 401 || response.status === 403;
+        throw new TogglAPIError({
+          status: response.status,
+          code: isAuth ? 'AUTHENTICATION_FAILED' : 'TOGGL_API_CLIENT_ERROR',
+          message: isAuth
+            ? `Authentication failed (${response.status}). Verify TOGGL_API_KEY is correct, has no leading/trailing spaces, and is the Toggl Track API token.`
+            : `Toggl API rejected the request (${response.status}).`,
+          tip: isAuth
+            ? 'Regenerate or copy your Toggl Track API token from track.toggl.com/profile and restart the MCP server.'
+            : 'Check the tool arguments and Toggl workspace permissions, then retry.',
+        });
+      }
+
+      throw new Error(`Toggl API request failed (${response.status}).`);
+    }
+
+    if (response.status === 204) {
+      return {} as T;
+    }
+
+    try {
+      return (await response.json()) as T;
+    } catch (_error) {
+      return {} as T;
+    }
   }
 
   // User methods
@@ -163,6 +182,171 @@ export class TogglAPI {
 
   async getWorkspace(workspaceId: number): Promise<Workspace> {
     return this.request<Workspace>('GET', `/workspaces/${workspaceId}`);
+  }
+
+  async getWorkspaceUsers(workspaceId: number): Promise<WorkspaceUser[]> {
+    const response = await this.request<WorkspaceUser[] | { items?: WorkspaceUser[] }>(
+      'GET',
+      `/workspaces/${workspaceId}/users`
+    );
+
+    if (Array.isArray(response)) return response;
+    if (Array.isArray(response.items)) return response.items;
+    throw new Error('Toggl workspace users response had an unexpected shape.');
+  }
+
+  static toWorkspaceMemberSummary(raw: WorkspaceUser): WorkspaceMemberSummary {
+    if (typeof raw.id !== 'number') {
+      throw new Error('Toggl workspace user is missing a numeric id.');
+    }
+
+    const active =
+      typeof raw.is_active === 'boolean'
+        ? raw.is_active
+        : typeof raw.inactive === 'boolean'
+          ? !raw.inactive
+          : false;
+
+    return {
+      uid: raw.id,
+      name: raw.fullname,
+      active,
+    };
+  }
+
+  private async reportsRequest<T>(
+    workspaceId: number,
+    endpoint: string,
+    body: Record<string, unknown>,
+    retries = 3
+  ): Promise<{ data: T; nextRowNumber?: number }> {
+    const url = `https://api.track.toggl.com/reports/api/v3/workspace/${workspaceId}${endpoint}`;
+    const response = await this.fetchWithRetry(
+      url,
+      {
+        method: 'POST',
+        headers: this.headers,
+        body: JSON.stringify(body),
+      },
+      retries
+    );
+
+    if (!response.ok) {
+      const text = await response.text();
+      if (response.status === 402) {
+        const retryAfterSeconds = parseQuotaResetSeconds(text);
+        throw new TogglAPIError({
+          status: response.status,
+          code: 'TOGGL_QUOTA_LIMIT',
+          message: `Toggl Reports API quota limit reached.${retryAfterSeconds !== undefined ? ` Quota resets in ${retryAfterSeconds} seconds.` : ''}`,
+          retryAfterSeconds,
+          tip: 'Wait for the Toggl quota window to reset, or use a narrower date range to reduce API usage.',
+        });
+      }
+
+      if (response.status >= 400 && response.status < 500) {
+        const isAuth = response.status === 401 || response.status === 403;
+        throw new TogglAPIError({
+          status: response.status,
+          code: isAuth ? 'AUTHENTICATION_FAILED' : 'REPORTS_API_CLIENT_ERROR',
+          message: isAuth
+            ? `Reports API authentication failed (${response.status}). Verify TOGGL_API_KEY is correct.`
+            : `Toggl Reports API rejected the request (${response.status}).`,
+          tip: isAuth
+            ? 'Regenerate or copy your Toggl Track API token from track.toggl.com/profile and restart the MCP server.'
+            : 'Check report arguments, workspace permissions, and uid access, then retry.',
+        });
+      }
+
+      throw new Error(`Toggl Reports API request failed (${response.status}).`);
+    }
+
+    const nextHeader = response.headers.get('X-Next-Row-Number');
+    const nextRowNumber = nextHeader ? Number.parseInt(nextHeader, 10) : undefined;
+
+    try {
+      return { data: (await response.json()) as T, nextRowNumber };
+    } catch (_error) {
+      return { data: {} as T, nextRowNumber };
+    }
+  }
+
+  async getTimeEntriesForUserAndDateRange(
+    workspaceId: number,
+    userId: number,
+    startDate: Date,
+    endDate: Date
+  ): Promise<TimeEntry[]> {
+    const inclusiveEnd = new Date(endDate);
+    inclusiveEnd.setDate(inclusiveEnd.getDate() - 1);
+
+    type ReportTimeEntry = {
+      id?: number;
+      seconds?: number;
+      start?: string;
+      stop?: string | null;
+    };
+    type ReportRow = {
+      user_id?: number;
+      project_id?: number | null;
+      task_id?: number | null;
+      billable?: boolean;
+      description?: string;
+      tag_ids?: number[] | null;
+      time_entries?: ReportTimeEntry[];
+    } & ReportTimeEntry;
+
+    const allEntries: TimeEntry[] = [];
+    let firstRowNumber = 1;
+
+    while (true) {
+      const { data: rows, nextRowNumber } = await this.reportsRequest<ReportRow[]>(
+        workspaceId,
+        '/search/time_entries',
+        {
+          user_ids: [userId],
+          start_date: toLocalYMD(startDate),
+          end_date: toLocalYMD(inclusiveEnd),
+          first_row_number: firstRowNumber,
+        }
+      );
+
+      const reportRows = Array.isArray(rows) ? rows : [];
+      for (const row of reportRows) {
+        const entries =
+          Array.isArray(row.time_entries) && row.time_entries.length > 0 ? row.time_entries : [row];
+
+        for (const entry of entries) {
+          if (
+            typeof entry.id !== 'number' ||
+            typeof entry.seconds !== 'number' ||
+            typeof entry.start !== 'string'
+          ) {
+            continue;
+          }
+
+          allEntries.push({
+            id: entry.id,
+            workspace_id: workspaceId,
+            project_id: row.project_id ?? undefined,
+            task_id: row.task_id ?? undefined,
+            billable: row.billable,
+            start: entry.start,
+            stop: entry.stop ?? undefined,
+            duration: entry.seconds,
+            description: row.description,
+            tag_ids: row.tag_ids ?? [],
+            tags: [],
+            user_id: row.user_id ?? userId,
+          });
+        }
+      }
+
+      if (!nextRowNumber || nextRowNumber <= firstRowNumber || reportRows.length === 0) break;
+      firstRowNumber = nextRowNumber;
+    }
+
+    return allEntries;
   }
 
   // Project methods
@@ -349,25 +533,6 @@ export class TogglAPI {
     const firstDayNextMonth = new Date(year, month + 1, 1);
 
     return this.getTimeEntriesForDateRange(firstDay, firstDayNextMonth);
-  }
-
-  // Reports API endpoints (if needed)
-  async getDetailedReport(workspaceId: number, params: any): Promise<any> {
-    // This would use the Reports API v3 if needed
-    // https://api.track.toggl.com/reports/api/v3/workspace/{workspace_id}/search/time_entries
-    const reportsUrl = `https://api.track.toggl.com/reports/api/v3/workspace/${workspaceId}/search/time_entries`;
-
-    const response = await fetch(reportsUrl, {
-      method: 'POST',
-      headers: this.headers,
-      body: JSON.stringify(params),
-    });
-
-    if (!response.ok) {
-      throw new Error(`Reports API error: ${response.status}`);
-    }
-
-    return response.json();
   }
 
   async getTimeline(): Promise<TimelineEvent[]> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,6 +97,25 @@ export interface User {
   updated_at?: string;
 }
 
+// Documented Toggl v9 GET /workspaces/{id}/users response shape.
+// The tool layer exposes only WorkspaceMemberSummary to avoid leaking private fields.
+export interface WorkspaceUser {
+  id: number;
+  email?: string;
+  fullname: string;
+  is_active?: boolean;
+  inactive?: boolean;
+  is_admin?: boolean;
+  role?: string;
+  at?: string;
+}
+
+export interface WorkspaceMemberSummary {
+  uid: number;
+  name: string;
+  active: boolean;
+}
+
 export interface Tag {
   id: number;
   workspace_id: number;

--- a/tests/cache-manager.test.ts
+++ b/tests/cache-manager.test.ts
@@ -62,9 +62,7 @@ describe('cache manager', () => {
     vi.setSystemTime(new Date('2026-05-01T10:00:00.002Z'));
     await cache.getWorkspace(2);
 
-    const workspaces = (
-      cache as unknown as { workspaces: Map<number, unknown> }
-    ).workspaces;
+    const workspaces = (cache as unknown as { workspaces: Map<number, unknown> }).workspaces;
     expect([...workspaces.keys()]).toEqual([1, 2]);
   });
 

--- a/tests/http-smoke.test.ts
+++ b/tests/http-smoke.test.ts
@@ -60,6 +60,9 @@ describe.skipIf(!existsSync(entryPoint))('http transport smoke checks', () => {
         TOGGL_API_KEY: 'dummy-token',
         TOGGL_API_TOKEN: '',
         TOGGL_TOKEN: '',
+        MCP_HTTP_AUTH_TOKEN: 'test-http-token',
+        MCP_HTTP_ALLOW_UNAUTHENTICATED: '',
+        MCP_HTTP_CORS_ORIGIN: '',
       },
       stdio: 'pipe',
     });
@@ -67,15 +70,30 @@ describe.skipIf(!existsSync(entryPoint))('http transport smoke checks', () => {
     try {
       await waitForHealth(`${baseUrl}/health`, child);
 
-      const health = (await (await fetch(`${baseUrl}/health`)).json()) as Record<string, unknown>;
+      const healthResponse = await fetch(`${baseUrl}/health`);
+      const health = (await healthResponse.json()) as Record<string, unknown>;
       expect(health).toMatchObject({
         ok: true,
         name: 'mcp-toggl',
         transport: 'http',
       });
+      expect(healthResponse.headers.get('access-control-allow-origin')).toBeNull();
+
+      const unauthorized = await fetch(`${baseUrl}/mcp`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'initialize', params: {} }),
+      });
+      expect(unauthorized.status).toBe(401);
 
       const client = new Client({ name: 'mcp-toggl-http-test', version: '1.0.0' });
-      const transport = new StreamableHTTPClientTransport(new URL(`${baseUrl}/mcp`));
+      const transport = new StreamableHTTPClientTransport(new URL(`${baseUrl}/mcp`), {
+        requestInit: {
+          headers: {
+            authorization: 'Bearer test-http-token',
+          },
+        },
+      });
       await client.connect(transport);
 
       try {

--- a/tests/http-smoke.test.ts
+++ b/tests/http-smoke.test.ts
@@ -1,0 +1,108 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { createServer } from 'node:net';
+import { resolve } from 'node:path';
+import { once } from 'node:events';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { describe, expect, it } from 'vitest';
+
+const entryPoint = resolve('dist/index.js');
+
+async function getFreePort(): Promise<number> {
+  const server = createServer();
+  await new Promise<void>((resolveListen) => {
+    server.listen(0, '127.0.0.1', resolveListen);
+  });
+  const address = server.address();
+  if (typeof address !== 'object' || address === null) {
+    throw new Error('Unable to allocate test port');
+  }
+  const port = address.port;
+  server.close();
+  await once(server, 'close');
+  return port;
+}
+
+async function waitForHealth(url: string, child: ChildProcessWithoutNullStreams): Promise<void> {
+  const started = Date.now();
+  let lastError: unknown;
+
+  while (Date.now() - started < 5_000) {
+    if (child.exitCode !== null) {
+      throw new Error(`HTTP server exited early with code ${child.exitCode}`);
+    }
+
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+      lastError = new Error(`Health returned ${response.status}`);
+    } catch (error) {
+      lastError = error;
+    }
+
+    await new Promise((resolveDelay) => setTimeout(resolveDelay, 100));
+  }
+
+  throw lastError instanceof Error ? lastError : new Error('Timed out waiting for health check');
+}
+
+describe.skipIf(!existsSync(entryPoint))('http transport smoke checks', () => {
+  it('serves health and MCP tools over Streamable HTTP', async () => {
+    const port = await getFreePort();
+    const baseUrl = `http://127.0.0.1:${port}`;
+    const child = spawn(process.execPath, [entryPoint], {
+      env: {
+        ...process.env,
+        TRANSPORT: 'http',
+        HOST: '127.0.0.1',
+        PORT: String(port),
+        TOGGL_API_KEY: 'dummy-token',
+        TOGGL_API_TOKEN: '',
+        TOGGL_TOKEN: '',
+      },
+      stdio: 'pipe',
+    });
+
+    try {
+      await waitForHealth(`${baseUrl}/health`, child);
+
+      const health = (await (await fetch(`${baseUrl}/health`)).json()) as Record<string, unknown>;
+      expect(health).toMatchObject({
+        ok: true,
+        name: 'mcp-toggl',
+        transport: 'http',
+      });
+
+      const client = new Client({ name: 'mcp-toggl-http-test', version: '1.0.0' });
+      const transport = new StreamableHTTPClientTransport(new URL(`${baseUrl}/mcp`));
+      await client.connect(transport);
+
+      try {
+        const tools = await client.listTools();
+        expect(tools.tools.some((tool) => tool.name === 'toggl_get_timeline')).toBe(true);
+
+        const result = await client.callTool({
+          name: 'toggl_get_timeline',
+          arguments: { start_date: '2026-02-30' },
+        });
+        const payload = JSON.parse(result.content?.[0]?.text ?? '{}') as Record<string, unknown>;
+        const serialized = JSON.stringify(payload);
+
+        expect(payload).toMatchObject({
+          error: true,
+          code: 'INVALID_ARGUMENT',
+        });
+        expect(payload.message).toContain('Invalid calendar date');
+        expect(serialized).not.toContain('/Users/');
+        expect(serialized).not.toContain('dist/index.js');
+        expect(serialized).not.toContain('at ');
+      } finally {
+        await client.close();
+      }
+    } finally {
+      child.kill('SIGTERM');
+      await once(child, 'close');
+    }
+  });
+});

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -1,0 +1,327 @@
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { fetchMock } = vi.hoisted(() => ({
+  fetchMock: vi.fn(),
+}));
+
+vi.mock('node-fetch', () => ({
+  default: fetchMock,
+}));
+
+function response({ status = 200, json }: { status?: number; json: unknown }) {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    headers: {
+      get: vi.fn(() => null),
+    },
+    text: vi.fn(async () => JSON.stringify(json)),
+    json: vi.fn(async () => json),
+  };
+}
+
+function installMockTogglApi() {
+  const workspace = { id: 20, name: 'Workspace', premium: false, default_currency: 'USD' };
+  const project = {
+    id: 30,
+    workspace_id: 20,
+    client_id: 40,
+    name: 'Project',
+    active: true,
+    billable: true,
+    color: '#123456',
+  };
+  const client = { id: 40, workspace_id: 20, name: 'Client', archived: false };
+  const tags = [{ id: 50, workspace_id: 20, name: 'tag' }];
+  const entry = {
+    id: 60,
+    workspace_id: 20,
+    project_id: 30,
+    billable: true,
+    start: '2026-05-01T09:00:00Z',
+    stop: '2026-05-01T10:00:00Z',
+    duration: 3600,
+    description: 'Focused work',
+    tags: ['tag'],
+    tag_ids: [50],
+  };
+
+  fetchMock.mockImplementation(async (url: string, init?: { method?: string }) => {
+    const method = init?.method ?? 'GET';
+
+    if (url.endsWith('/me'))
+      return response({ json: { id: 10, email: 'private@example.com', fullname: 'Private User' } });
+    if (url.endsWith('/workspaces')) return response({ json: [workspace] });
+    if (url.endsWith('/workspaces/20')) return response({ json: workspace });
+    if (url.endsWith('/workspaces/20/projects')) return response({ json: [project] });
+    if (url.endsWith('/workspaces/20/clients')) return response({ json: [client] });
+    if (url.endsWith('/workspaces/20/tags')) return response({ json: tags });
+    if (url.includes('/me/time_entries/current')) return response({ json: null });
+    if (url.includes('/me/time_entries')) return response({ json: [entry] });
+    if (url.endsWith('/timeline')) {
+      return response({
+        json: [
+          {
+            id: 70,
+            start_time: 1_700_000_000,
+            end_time: 1_700_000_060,
+            desktop_id: 'desktop',
+            idle: false,
+            filename: 'Browser',
+            title: 'Private window title',
+          },
+        ],
+      });
+    }
+    if (method === 'POST' && url.endsWith('/workspaces/20/time_entries')) {
+      return response({
+        json: {
+          ...entry,
+          id: 61,
+          stop: undefined,
+          duration: -1,
+          description: 'Started timer',
+        },
+      });
+    }
+
+    return response({ status: 404, json: { error: 'not found' } });
+  });
+}
+
+async function createClient() {
+  vi.resetModules();
+  vi.stubEnv('TOGGL_API_KEY', 'dummy-token');
+  vi.stubEnv('TOGGL_API_TOKEN', '');
+  vi.stubEnv('TOGGL_TOKEN', '');
+
+  const { createTogglServer } = await import('../src/index.js');
+  const server = createTogglServer();
+  const client = new Client({ name: 'mcp-toggl-unit-test', version: '1.0.0' });
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+  await server.connect(serverTransport);
+  await client.connect(clientTransport);
+
+  return { client, server };
+}
+
+async function callTool(client: Client, name: string, args: Record<string, unknown> = {}) {
+  const result = await client.callTool({ name, arguments: args });
+  return JSON.parse(result.content?.[0]?.text ?? '{}') as Record<string, unknown>;
+}
+
+describe('mcp server handlers', () => {
+  afterEach(() => {
+    fetchMock.mockReset();
+    vi.unstubAllEnvs();
+  });
+
+  it('lists the timeline privacy schema with redacted titles as the default', async () => {
+    const { client } = await createClient();
+
+    try {
+      const tools = await client.listTools();
+      const timelineTool = tools.tools.find((tool) => tool.name === 'toggl_get_timeline');
+      const properties = timelineTool?.inputSchema.properties as
+        | Record<string, Record<string, unknown>>
+        | undefined;
+
+      expect(timelineTool?.description).toContain('window titles are redacted by default');
+      expect(properties?.title_mode).toMatchObject({
+        enum: ['redacted', 'raw'],
+        default: 'redacted',
+      });
+      expect(properties?.redact_titles).toMatchObject({
+        default: true,
+        deprecated: true,
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('returns sanitized user-input errors from tool calls', async () => {
+    const { client } = await createClient();
+
+    try {
+      const payload = await callTool(client, 'toggl_get_timeline', {
+        title_mode: 'visible',
+      });
+
+      expect(payload).toMatchObject({
+        error: true,
+        code: 'INVALID_ARGUMENT',
+        message: 'title_mode must be "redacted" or "raw"',
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('does not expose internals for unknown tool errors', async () => {
+    const { client } = await createClient();
+
+    try {
+      const payload = await callTool(client, 'toggl_not_a_tool');
+      const serialized = JSON.stringify(payload);
+
+      expect(payload).toMatchObject({
+        error: true,
+        code: 'INTERNAL_ERROR',
+        message: 'Internal server error. Check server logs for details.',
+      });
+      expect(serialized).not.toContain('Unknown tool');
+      expect(serialized).not.toContain('/Users/');
+      expect(serialized).not.toContain('src/index.ts');
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('serves cache tools without calling Toggl', async () => {
+    const { client } = await createClient();
+
+    try {
+      const stats = await callTool(client, 'toggl_cache_stats');
+      expect(stats.cache_warmed).toBe(false);
+      expect(stats.hit_rate).toBe('0%');
+
+      const cleared = await callTool(client, 'toggl_clear_cache');
+      expect(cleared).toMatchObject({
+        success: true,
+        message: 'Cache cleared successfully',
+      });
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('checks auth with masked user email and workspace data', async () => {
+    installMockTogglApi();
+
+    const { client } = await createClient();
+
+    try {
+      const payload = await callTool(client, 'toggl_check_auth');
+
+      expect(payload).toMatchObject({
+        authenticated: true,
+        user: {
+          id: 10,
+          email: 'p***e@example.com',
+          fullname: 'Private User',
+        },
+        workspaces: [{ id: 20, name: 'Workspace' }],
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('runs common reporting, lookup, cache, and timer paths with mocked Toggl data', async () => {
+    installMockTogglApi();
+
+    const { client } = await createClient();
+
+    try {
+      await expect(callTool(client, 'toggl_list_workspaces')).resolves.toMatchObject({
+        count: 1,
+        workspaces: [{ id: 20, name: 'Workspace' }],
+      });
+      await expect(
+        callTool(client, 'toggl_list_projects', { workspace_id: 20 })
+      ).resolves.toMatchObject({
+        workspace_id: 20,
+        count: 1,
+        projects: [{ id: 30, name: 'Project' }],
+      });
+      await expect(
+        callTool(client, 'toggl_list_clients', { workspace_id: 20 })
+      ).resolves.toMatchObject({
+        workspace_id: 20,
+        count: 1,
+        clients: [{ id: 40, name: 'Client' }],
+      });
+      await expect(
+        callTool(client, 'toggl_warm_cache', { workspace_id: 20 })
+      ).resolves.toMatchObject({
+        success: true,
+      });
+      await expect(
+        callTool(client, 'toggl_get_time_entries', { start_date: '2026-05-01' })
+      ).resolves.toMatchObject({
+        count: 1,
+        entries: [
+          { id: 60, project_name: 'Project', client_name: 'Client', workspace_name: 'Workspace' },
+        ],
+      });
+      await expect(
+        callTool(client, 'toggl_daily_report', { date: '2026-05-01' })
+      ).resolves.toMatchObject({
+        total_seconds: 3600,
+      });
+      await expect(
+        callTool(client, 'toggl_project_summary', {
+          start_date: '2026-05-01',
+          end_date: '2026-05-01',
+        })
+      ).resolves.toMatchObject({
+        project_count: 1,
+      });
+      await expect(
+        callTool(client, 'toggl_workspace_summary', {
+          start_date: '2026-05-01',
+          end_date: '2026-05-01',
+        })
+      ).resolves.toMatchObject({
+        workspace_count: 1,
+      });
+      await expect(callTool(client, 'toggl_get_current_entry')).resolves.toMatchObject({
+        running: false,
+      });
+      await expect(
+        callTool(client, 'toggl_start_timer', {
+          workspace_id: 20,
+          description: 'Started timer',
+          project_id: 30,
+          tags: ['tag'],
+        })
+      ).resolves.toMatchObject({
+        success: true,
+        entry: { id: 61, running: true },
+      });
+      await expect(callTool(client, 'toggl_stop_timer')).resolves.toMatchObject({
+        success: false,
+        message: 'No timer currently running',
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('returns redacted timeline events by default and raw titles only on opt-in', async () => {
+    installMockTogglApi();
+
+    const { client } = await createClient();
+
+    try {
+      const redacted = await callTool(client, 'toggl_get_timeline', {});
+      expect(redacted).toMatchObject({
+        total_events: 1,
+        events: [{ title: null }],
+      });
+
+      const raw = await callTool(client, 'toggl_get_timeline', { title_mode: 'raw' });
+      expect(raw).toMatchObject({
+        total_events: 1,
+        events: [{ title: 'Private window title' }],
+      });
+    } finally {
+      await client.close();
+    }
+  });
+});

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -24,6 +24,18 @@ function response({ status = 200, json }: { status?: number; json: unknown }) {
 
 function installMockTogglApi() {
   const workspace = { id: 20, name: 'Workspace', premium: false, default_currency: 'USD' };
+  const workspaceUsers = [
+    {
+      id: 11,
+      fullname: 'Alice Manager',
+      email: 'alice@example.com',
+      is_active: true,
+      is_admin: true,
+      role: 'admin',
+      rate: 99,
+      labor_cost: 50,
+    },
+  ];
   const project = {
     id: 30,
     workspace_id: 20,
@@ -48,13 +60,14 @@ function installMockTogglApi() {
     tag_ids: [50],
   };
 
-  fetchMock.mockImplementation(async (url: string, init?: { method?: string }) => {
+  fetchMock.mockImplementation(async (url: string, init?: { body?: string; method?: string }) => {
     const method = init?.method ?? 'GET';
 
     if (url.endsWith('/me'))
       return response({ json: { id: 10, email: 'private@example.com', fullname: 'Private User' } });
     if (url.endsWith('/workspaces')) return response({ json: [workspace] });
     if (url.endsWith('/workspaces/20')) return response({ json: workspace });
+    if (url.endsWith('/workspaces/20/users')) return response({ json: { items: workspaceUsers } });
     if (url.endsWith('/workspaces/20/projects')) return response({ json: [project] });
     if (url.endsWith('/workspaces/20/clients')) return response({ json: [client] });
     if (url.endsWith('/workspaces/20/tags')) return response({ json: tags });
@@ -84,6 +97,29 @@ function installMockTogglApi() {
           duration: -1,
           description: 'Started timer',
         },
+      });
+    }
+    if (method === 'POST' && url.endsWith('/reports/api/v3/workspace/20/search/time_entries')) {
+      const body = JSON.parse(init?.body ?? '{}') as { user_ids?: number[] };
+      return response({
+        json: [
+          {
+            user_id: body.user_ids?.[0] ?? 11,
+            project_id: 30,
+            task_id: null,
+            billable: true,
+            description: 'Team report work',
+            tag_ids: [50],
+            time_entries: [
+              {
+                id: 80,
+                seconds: 3600,
+                start: '2026-05-01T09:00:00Z',
+                stop: '2026-05-01T10:00:00Z',
+              },
+            ],
+          },
+        ],
       });
     }
 
@@ -138,6 +174,37 @@ describe('mcp server handlers', () => {
         default: true,
         deprecated: true,
       });
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('lists workspace user and uid report filter schemas', async () => {
+    const { client } = await createClient();
+
+    try {
+      const tools = await client.listTools();
+      const workspaceUsersTool = tools.tools.find(
+        (tool) => tool.name === 'toggl_list_workspace_users'
+      );
+      const reportToolNames = [
+        'toggl_daily_report',
+        'toggl_weekly_report',
+        'toggl_project_summary',
+        'toggl_workspace_summary',
+      ];
+
+      expect(workspaceUsersTool?.annotations).toMatchObject({
+        readOnlyHint: true,
+        idempotentHint: true,
+      });
+      expect(workspaceUsersTool?.inputSchema.properties).toHaveProperty('workspace_id');
+
+      for (const toolName of reportToolNames) {
+        const tool = tools.tools.find((candidate) => candidate.name === toolName);
+        expect(tool?.inputSchema.properties).toHaveProperty('uid');
+        expect(tool?.inputSchema.properties).toHaveProperty('workspace_id');
+      }
     } finally {
       await client.close();
     }
@@ -247,6 +314,13 @@ describe('mcp server handlers', () => {
         clients: [{ id: 40, name: 'Client' }],
       });
       await expect(
+        callTool(client, 'toggl_list_workspace_users', { workspace_id: 20 })
+      ).resolves.toEqual({
+        workspace_id: 20,
+        count: 1,
+        users: [{ uid: 11, name: 'Alice Manager', active: true }],
+      });
+      await expect(
         callTool(client, 'toggl_warm_cache', { workspace_id: 20 })
       ).resolves.toMatchObject({
         success: true,
@@ -263,6 +337,16 @@ describe('mcp server handlers', () => {
         callTool(client, 'toggl_daily_report', { date: '2026-05-01' })
       ).resolves.toMatchObject({
         total_seconds: 3600,
+      });
+      await expect(
+        callTool(client, 'toggl_daily_report', {
+          date: '2026-05-01',
+          uid: 11,
+          workspace_id: 20,
+        })
+      ).resolves.toMatchObject({
+        total_seconds: 3600,
+        entries: [{ id: 80 }],
       });
       await expect(
         callTool(client, 'toggl_project_summary', {
@@ -297,6 +381,26 @@ describe('mcp server handlers', () => {
       await expect(callTool(client, 'toggl_stop_timer')).resolves.toMatchObject({
         success: false,
         message: 'No timer currently running',
+      });
+
+      const workspaceUsersPayload = await callTool(client, 'toggl_list_workspace_users', {
+        workspace_id: 20,
+      });
+      const serializedUsers = JSON.stringify(workspaceUsersPayload);
+      expect(serializedUsers).not.toContain('alice@example.com');
+      expect(serializedUsers).not.toContain('is_admin');
+      expect(serializedUsers).not.toContain('role');
+      expect(serializedUsers).not.toContain('rate');
+      expect(serializedUsers).not.toContain('labor_cost');
+
+      const reportCall = fetchMock.mock.calls.find(([url]) =>
+        String(url).includes('/reports/api/v3/workspace/20/search/time_entries')
+      );
+      expect(reportCall).toBeDefined();
+      expect(JSON.parse(reportCall![1]?.body as string)).toMatchObject({
+        user_ids: [11],
+        start_date: '2026-05-01',
+        end_date: '2026-05-01',
       });
     } finally {
       await client.close();

--- a/tests/stdio-smoke.test.ts
+++ b/tests/stdio-smoke.test.ts
@@ -73,7 +73,13 @@ describe.skipIf(!existsSync(entryPoint))('stdio smoke checks', () => {
       });
       expect(properties?.redact_titles).toMatchObject({
         type: 'boolean',
-        default: false,
+        default: true,
+        deprecated: true,
+      });
+      expect(properties?.title_mode).toMatchObject({
+        type: 'string',
+        enum: ['redacted', 'raw'],
+        default: 'redacted',
       });
 
       const result = await client.callTool({

--- a/tests/timeline.test.ts
+++ b/tests/timeline.test.ts
@@ -58,9 +58,25 @@ describe('timeline response shaping', () => {
     expect(response.summary).toEqual({ 'Google Chrome': 60, 'Chrome Canary': 60 });
   });
 
-  it('redacts titles while preserving non-sensitive event fields and summary', () => {
+  it('redacts titles by default while preserving non-sensitive event fields and summary', () => {
+    const response = buildTimelineResponse([event(1, 'Mail', 'Inbox - private@example.com')], {});
+
+    expect(response.summary).toEqual({ Mail: 60 });
+    expect(response.events?.[0]).toMatchObject({
+      id: 1,
+      desktop_id: 'desktop-1',
+      filename: 'Mail',
+      title: null,
+      idle: false,
+      duration_seconds: 60,
+    });
+    expect(response.events?.[0]?.start).toBeDefined();
+    expect(response.events?.[0]?.end).toBeDefined();
+  });
+
+  it('supports explicit redacted title mode', () => {
     const response = buildTimelineResponse([event(1, 'Mail', 'Inbox - private@example.com')], {
-      redact_titles: true,
+      title_mode: 'redacted',
     });
 
     expect(response.summary).toEqual({ Mail: 60 });
@@ -74,6 +90,30 @@ describe('timeline response shaping', () => {
     });
     expect(response.events?.[0]?.start).toBeDefined();
     expect(response.events?.[0]?.end).toBeDefined();
+  });
+
+  it('returns raw titles only when explicitly requested', () => {
+    const response = buildTimelineResponse([event(1, 'Browser', 'OAuth callback token=secret')], {
+      title_mode: 'raw',
+    });
+
+    expect(response.events?.[0]?.title).toBe('OAuth callback token=secret');
+  });
+
+  it('keeps redact_titles false as a deprecated raw-title compatibility flag', () => {
+    const response = buildTimelineResponse([event(1, 'Editor', 'private.md')], {
+      redact_titles: false,
+    });
+
+    expect(response.events?.[0]?.title).toBe('private.md');
+  });
+
+  it('rejects invalid title modes before returning events', () => {
+    expect(() =>
+      buildTimelineResponse([event(1, 'Editor', 'private.md')], {
+        title_mode: 'visible',
+      })
+    ).toThrow('title_mode must be "redacted" or "raw"');
   });
 
   it('uses four-decimal total_hours precision for timeline display', () => {

--- a/tests/toggl-api.test.ts
+++ b/tests/toggl-api.test.ts
@@ -14,20 +14,54 @@ function response({
   text = '',
   json,
   retryAfter,
+  headers: extraHeaders = {},
 }: {
   status: number;
   text?: string;
   json?: unknown;
   retryAfter?: string;
+  headers?: Record<string, string | undefined>;
 }) {
+  const normalizedExtraHeaders = Object.fromEntries(
+    Object.entries(extraHeaders).map(([name, value]) => [name.toLowerCase(), value])
+  );
+  const allHeaders: Record<string, string | undefined> = {
+    'retry-after': retryAfter,
+    ...normalizedExtraHeaders,
+  };
+
   return {
     status,
     ok: status >= 200 && status < 300,
     headers: {
-      get: vi.fn((name: string) => (name.toLowerCase() === 'retry-after' ? retryAfter : null)),
+      get: vi.fn((name: string) => allHeaders[name.toLowerCase()] ?? null),
     },
     text: vi.fn(async () => text),
     json: vi.fn(async () => json),
+  };
+}
+
+const TEST_WORKSPACE_ID = 111;
+const TEST_USER_ID = 222;
+const TEST_PROJECT_ID = 333;
+
+function reportRow(overrides: Record<string, unknown> = {}) {
+  return {
+    user_id: TEST_USER_ID,
+    project_id: TEST_PROJECT_ID,
+    task_id: null,
+    billable: false,
+    description: 'test entry',
+    tag_ids: [],
+    time_entries: [
+      {
+        id: 1001,
+        seconds: 3600,
+        start: '2026-05-04T10:00:00+00:00',
+        stop: '2026-05-04T11:00:00+00:00',
+      },
+    ],
+    ...overrides,
   };
 }
 
@@ -83,6 +117,301 @@ describe('toggl api errors', () => {
 
     await expect(api.getWorkspaces()).rejects.not.toMatchObject({
       message: expect.stringContaining('abc123'),
+    });
+  });
+
+  it('retries 5xx server errors and eventually throws', async () => {
+    fetchMock.mockResolvedValue(response({ status: 500, text: 'Internal Server Error' }));
+
+    const api = new TogglAPI('token');
+    await expect(api.getWorkspaces()).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('getWorkspaceUsers', () => {
+  afterEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it('fetches from the documented /users endpoint and returns the raw records', async () => {
+    fetchMock.mockResolvedValue(
+      response({
+        status: 200,
+        json: {
+          items: [
+            {
+              id: TEST_USER_ID,
+              fullname: 'Alice',
+              email: 'alice@example.com',
+              is_active: true,
+              inactive: false,
+              is_admin: false,
+              role: 'admin',
+            },
+            {
+              id: TEST_USER_ID + 1,
+              fullname: 'Bob',
+              email: 'bob@example.com',
+              is_active: true,
+              inactive: false,
+              is_admin: true,
+              role: 'admin',
+            },
+          ],
+        },
+      })
+    );
+
+    const api = new TogglAPI('token');
+    const users = await api.getWorkspaceUsers(TEST_WORKSPACE_ID);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining(`/workspaces/${TEST_WORKSPACE_ID}/users`),
+      expect.any(Object)
+    );
+    expect(users).toHaveLength(2);
+    expect(users[0]).toMatchObject({ id: TEST_USER_ID, fullname: 'Alice' });
+  });
+});
+
+describe('toWorkspaceMemberSummary', () => {
+  it('maps id/fullname/is_active to uid/name/active', () => {
+    const summary = TogglAPI.toWorkspaceMemberSummary({
+      id: TEST_USER_ID,
+      fullname: 'Alice',
+      is_active: true,
+    });
+
+    expect(summary).toEqual({ uid: TEST_USER_ID, name: 'Alice', active: true });
+  });
+
+  it('exposes only uid/name/active and drops email, admin, role, and rates', () => {
+    const summary = TogglAPI.toWorkspaceMemberSummary({
+      id: TEST_USER_ID,
+      fullname: 'Alice',
+      is_active: true,
+      email: 'alice@example.com',
+      is_admin: true,
+      role: 'admin',
+      ...({ rate: 99, labor_cost: 50, invite_url: 'https://secret' } as Record<string, unknown>),
+    });
+
+    expect(Object.keys(summary).sort()).toEqual(['active', 'name', 'uid']);
+    expect(summary).not.toHaveProperty('email');
+    expect(summary).not.toHaveProperty('is_admin');
+    expect(summary).not.toHaveProperty('role');
+    expect(summary).not.toHaveProperty('rate');
+    expect(summary).not.toHaveProperty('labor_cost');
+  });
+
+  it('does not default active to true when neither is_active nor inactive is present', () => {
+    const summary = TogglAPI.toWorkspaceMemberSummary({
+      id: TEST_USER_ID,
+      fullname: 'Alice',
+    });
+
+    expect(summary.active).toBe(false);
+  });
+
+  it('throws when id is missing at runtime', () => {
+    expect(() =>
+      TogglAPI.toWorkspaceMemberSummary({
+        fullname: 'Alice',
+      } as unknown as { id: number; fullname: string })
+    ).toThrow('Toggl workspace user is missing a numeric id.');
+  });
+});
+
+describe('getTimeEntriesForUserAndDateRange', () => {
+  afterEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it('converts exclusive end date to inclusive before calling the Reports API', async () => {
+    fetchMock.mockResolvedValue(response({ status: 200, json: [] }));
+
+    const api = new TogglAPI('token');
+    await api.getTimeEntriesForUserAndDateRange(
+      TEST_WORKSPACE_ID,
+      TEST_USER_ID,
+      new Date(2026, 4, 4),
+      new Date(2026, 4, 11)
+    );
+
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body as string);
+    expect(body.start_date).toBe('2026-05-04');
+    expect(body.end_date).toBe('2026-05-10');
+  });
+
+  it('sends user_ids as an array containing the requested uid', async () => {
+    fetchMock.mockResolvedValue(response({ status: 200, json: [] }));
+
+    const api = new TogglAPI('token');
+    await api.getTimeEntriesForUserAndDateRange(
+      TEST_WORKSPACE_ID,
+      TEST_USER_ID,
+      new Date(2026, 4, 4),
+      new Date(2026, 4, 11)
+    );
+
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body as string);
+    expect(body.user_ids).toEqual([TEST_USER_ID]);
+  });
+
+  it('flattens grouped report rows into individual TimeEntry objects', async () => {
+    fetchMock.mockResolvedValue(
+      response({
+        status: 200,
+        json: [
+          reportRow({ billable: false }),
+          reportRow({
+            billable: true,
+            time_entries: [
+              {
+                id: 1002,
+                seconds: 1800,
+                start: '2026-05-04T11:00:00+00:00',
+                stop: '2026-05-04T11:30:00+00:00',
+              },
+            ],
+          }),
+        ],
+      })
+    );
+
+    const api = new TogglAPI('token');
+    const entries = await api.getTimeEntriesForUserAndDateRange(
+      TEST_WORKSPACE_ID,
+      TEST_USER_ID,
+      new Date(2026, 4, 4),
+      new Date(2026, 4, 11)
+    );
+
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({
+      id: 1001,
+      workspace_id: TEST_WORKSPACE_ID,
+      project_id: TEST_PROJECT_ID,
+      duration: 3600,
+      description: 'test entry',
+      user_id: TEST_USER_ID,
+      billable: false,
+    });
+    expect(entries[1]).toMatchObject({ id: 1002, duration: 1800, billable: true });
+  });
+
+  it('handles a flat row that carries entry fields directly', async () => {
+    fetchMock.mockResolvedValue(
+      response({
+        status: 200,
+        json: [
+          {
+            user_id: TEST_USER_ID,
+            project_id: TEST_PROJECT_ID,
+            task_id: null,
+            billable: true,
+            description: 'flat entry',
+            tag_ids: [],
+            id: 2001,
+            seconds: 1200,
+            start: '2026-05-04T09:00:00+00:00',
+            stop: '2026-05-04T09:20:00+00:00',
+          },
+        ],
+      })
+    );
+
+    const api = new TogglAPI('token');
+    const entries = await api.getTimeEntriesForUserAndDateRange(
+      TEST_WORKSPACE_ID,
+      TEST_USER_ID,
+      new Date(2026, 4, 4),
+      new Date(2026, 4, 11)
+    );
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      id: 2001,
+      workspace_id: TEST_WORKSPACE_ID,
+      project_id: TEST_PROJECT_ID,
+      duration: 1200,
+      description: 'flat entry',
+      user_id: TEST_USER_ID,
+      billable: true,
+    });
+  });
+
+  it('fetches multiple pages until X-Next-Row-Number header is absent', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        response({
+          status: 200,
+          json: [
+            reportRow({
+              time_entries: [
+                {
+                  id: 1,
+                  seconds: 100,
+                  start: '2026-05-04T10:00:00+12:00',
+                  stop: '2026-05-04T10:01:40+12:00',
+                },
+              ],
+            }),
+          ],
+          headers: { 'X-Next-Row-Number': '2' },
+        })
+      )
+      .mockResolvedValueOnce(
+        response({
+          status: 200,
+          json: [
+            reportRow({
+              time_entries: [
+                {
+                  id: 2,
+                  seconds: 200,
+                  start: '2026-05-05T10:00:00+12:00',
+                  stop: '2026-05-05T10:03:20+12:00',
+                },
+              ],
+            }),
+          ],
+        })
+      );
+
+    const api = new TogglAPI('token');
+    const entries = await api.getTimeEntriesForUserAndDateRange(
+      TEST_WORKSPACE_ID,
+      TEST_USER_ID,
+      new Date(2026, 4, 4),
+      new Date(2026, 4, 11)
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(entries.map((entry) => entry.id)).toEqual([1, 2]);
+    const secondBody = JSON.parse(fetchMock.mock.calls[1]![1].body as string);
+    expect(secondBody.first_row_number).toBe(2);
+  });
+
+  it('throws a quota error with a tip for 402 Reports API responses', async () => {
+    fetchMock.mockResolvedValue(
+      response({ status: 402, text: 'The quota will reset in 300 seconds.' })
+    );
+
+    const api = new TogglAPI('token');
+    await expect(
+      api.getTimeEntriesForUserAndDateRange(
+        TEST_WORKSPACE_ID,
+        TEST_USER_ID,
+        new Date(2026, 4, 4),
+        new Date(2026, 4, 11)
+      )
+    ).rejects.toMatchObject({
+      code: 'TOGGL_QUOTA_LIMIT',
+      status: 402,
+      retry_after_seconds: 300,
+      tip: expect.stringContaining('quota'),
     });
   });
 });

--- a/tests/toggl-api.test.ts
+++ b/tests/toggl-api.test.ts
@@ -64,4 +64,25 @@ describe('toggl api errors', () => {
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it('sanitizes auth failures into structured errors', async () => {
+    fetchMock.mockResolvedValue(
+      response({
+        status: 401,
+        text: 'bad token abc123',
+      })
+    );
+
+    const api = new TogglAPI('token');
+    await expect(api.getWorkspaces()).rejects.toMatchObject({
+      code: 'AUTHENTICATION_FAILED',
+      status: 401,
+      message:
+        'Authentication failed (401). Verify TOGGL_API_KEY is correct, has no leading/trailing spaces, and is the Toggl Track API token.',
+    });
+
+    await expect(api.getWorkspaces()).rejects.not.toMatchObject({
+      message: expect.stringContaining('abc123'),
+    });
+  });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,7 +7,14 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],
+      include: ['src/**/*.ts'],
       exclude: ['node_modules/', 'dist/', 'tests/', '*.config.*'],
+      thresholds: {
+        statements: 50,
+        branches: 50,
+        functions: 50,
+        lines: 50,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary
- enforce 50% Vitest coverage gates and include all src/**/*.ts in coverage
- add shared MCP server setup with stdio default plus Streamable HTTP at POST /mcp and GET /health
- make timeline title privacy default-safe with title_mode support and deprecated redact_titles compatibility
- add sanitized MCP error payloads, focused MCP tests, Dockerfile, and GHCR release workflow
- document self-hosting, server-side TOGGL_API_TOKEN auth, Docker, PaaS deployment notes, and MCP HTTP bearer auth

## Breaking Changes
- Timeline event titles are now redacted by default. Existing callers that relied on raw window titles must pass `title_mode: "raw"` or `redact_titles: false`.
- Streamable HTTP deployments require `MCP_HTTP_AUTH_TOKEN` unless explicitly running unauthenticated loopback-only development mode. stdio remains the default transport.

## Test Plan
- npm run lint
- npm run build
- npm test
- npm run test:coverage
- npm audit --audit-level=high
- ../mcp-ecosystem/scripts/audit-server.sh ../mcp-toggl
- docker build -t mcp-toggl:self-host-test .
- Docker HTTP smoke: /health and MCP listTools with TOGGL_API_TOKEN=dummy and MCP_HTTP_AUTH_TOKEN set

## Related Issues
- Stale PR backlog #8, #9, #12, and #13 was triaged and closed separately.