### PR TITLE
feat: add time entry CRUD tools (closes #7, revisits #8 and #12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,16 @@ mcp-toggl --help
 | Tool | What it does |
 | --- | --- |
 | `toggl_get_current_entry` | Returns the running timer, elapsed seconds, and hydrated project/workspace context. |
-| `toggl_start_timer` | Starts a timer with description, optional project/task, and tags. |
+| `toggl_start_timer` | Starts a timer with description, optional project/task, tags, and billable flag. |
 | `toggl_stop_timer` | Stops the currently running timer. |
+
+### Time Entry CRUD
+
+| Tool | What it does |
+| --- | --- |
+| `toggl_create_time_entry` | Creates a completed time entry for retroactively logging past work. |
+| `toggl_update_time_entry` | Updates fields on an existing entry (project, task, description, tags, billable, start/stop, duration). |
+| `toggl_delete_time_entry` | Deletes a time entry by ID. |
 
 ### Lookups
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -298,6 +298,11 @@ const tools: Tool[] = [
           items: { type: 'string' },
           description: 'Tags for the entry',
         },
+        billable: {
+          type: 'boolean',
+          description:
+            'Whether the entry is billable. If omitted, Toggl applies the project default.',
+        },
       },
     },
   },
@@ -313,6 +318,121 @@ const tools: Tool[] = [
       type: 'object',
       properties: {},
       required: [],
+    },
+  },
+  {
+    name: 'toggl_create_time_entry',
+    description:
+      'Create a completed time entry for retroactively logging past work. Provide either stop OR duration (not both). For starting a live timer, use toggl_start_timer instead.',
+    annotations: {
+      readOnlyHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        start: {
+          type: 'string',
+          description: 'ISO 8601 datetime when the entry began (e.g. 2026-05-01T09:00:00Z)',
+        },
+        stop: {
+          type: 'string',
+          description: 'ISO 8601 datetime when the entry ended. Provide stop OR duration.',
+        },
+        duration: {
+          type: 'number',
+          description: 'Duration in seconds. Provide stop OR duration.',
+        },
+        description: {
+          type: 'string',
+          description: 'Description of the time entry',
+        },
+        project_id: { type: 'number', description: 'Project ID (optional)' },
+        task_id: { type: 'number', description: 'Task ID (optional)' },
+        tags: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Tag names; Toggl resolves to IDs server-side',
+        },
+        tag_ids: {
+          type: 'array',
+          items: { type: 'number' },
+          description: 'Tag IDs (alternative to tags)',
+        },
+        billable: {
+          type: 'boolean',
+          description:
+            'Whether the entry is billable. If omitted, Toggl applies the project default.',
+        },
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
+        },
+      },
+      required: ['start'],
+    },
+  },
+  {
+    name: 'toggl_update_time_entry',
+    description:
+      'Update fields on an existing time entry. Pass only the fields to change. Common workflow: an AI agent re-categorizes uncategorized entries by setting project_id and task_id.',
+    annotations: {
+      readOnlyHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        entry_id: { type: 'number', description: 'Time entry ID to update' },
+        description: { type: 'string' },
+        project_id: { type: 'number' },
+        task_id: { type: 'number' },
+        tags: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Tag names; replaces existing tags on the entry',
+        },
+        tag_ids: {
+          type: 'array',
+          items: { type: 'number' },
+          description: 'Tag IDs (alternative to tags); replaces existing tags on the entry',
+        },
+        billable: { type: 'boolean' },
+        start: { type: 'string', description: 'ISO 8601 datetime' },
+        stop: { type: 'string', description: 'ISO 8601 datetime' },
+        duration: { type: 'number', description: 'Duration in seconds' },
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
+        },
+      },
+      required: ['entry_id'],
+    },
+  },
+  {
+    name: 'toggl_delete_time_entry',
+    description: 'Delete a time entry by ID',
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        entry_id: { type: 'number', description: 'Time entry ID to delete' },
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
+        },
+      },
+      required: ['entry_id'],
     },
   },
 
@@ -716,7 +836,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           args?.description as string | undefined,
           args?.project_id as number | undefined,
           args?.task_id as number | undefined,
-          args?.tags as string[] | undefined
+          args?.tags as string[] | undefined,
+          args?.billable as boolean | undefined
         );
 
         await ensureCache();
@@ -778,6 +899,89 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             },
           ],
         };
+      }
+
+      case 'toggl_create_time_entry': {
+        const workspaceId = await resolveWorkspaceForTool(args, 'creating a time entry');
+        const start = args?.start;
+        if (typeof start !== 'string' || start.trim().length === 0) {
+          throw new Error('start is required (ISO 8601 datetime)');
+        }
+        if (args?.stop !== undefined && args?.duration !== undefined) {
+          throw new Error('Provide either stop or duration, not both');
+        }
+
+        const entry = await api.createTimeEntry(workspaceId, {
+          start,
+          stop: args?.stop as string | undefined,
+          duration: args?.duration as number | undefined,
+          description: args?.description as string | undefined,
+          project_id: args?.project_id as number | undefined,
+          task_id: args?.task_id as number | undefined,
+          tags: args?.tags as string[] | undefined,
+          tag_ids: args?.tag_ids as number[] | undefined,
+          billable: args?.billable as boolean | undefined,
+        });
+
+        await ensureCache();
+        const hydrated = await cache.hydrateTimeEntries([entry]);
+
+        return jsonResponse({
+          success: true,
+          message: 'Time entry created',
+          entry: hydrated[0],
+        });
+      }
+
+      case 'toggl_update_time_entry': {
+        const workspaceId = await resolveWorkspaceForTool(args, 'updating a time entry');
+        const entryId = args?.entry_id;
+        if (typeof entryId !== 'number') {
+          throw new Error('entry_id is required');
+        }
+
+        const updates: Record<string, unknown> = {};
+        if (args?.description !== undefined) updates.description = args.description;
+        if (args?.project_id !== undefined) updates.project_id = args.project_id;
+        if (args?.task_id !== undefined) updates.task_id = args.task_id;
+        if (args?.tags !== undefined) updates.tags = args.tags;
+        if (args?.tag_ids !== undefined) updates.tag_ids = args.tag_ids;
+        if (args?.billable !== undefined) updates.billable = args.billable;
+        if (args?.start !== undefined) updates.start = args.start;
+        if (args?.stop !== undefined) updates.stop = args.stop;
+        if (args?.duration !== undefined) updates.duration = args.duration;
+
+        if (Object.keys(updates).length === 0) {
+          throw new Error('No fields to update; provide at least one updatable field');
+        }
+
+        const updated = await api.updateTimeEntry(workspaceId, entryId, updates);
+
+        await ensureCache();
+        const hydrated = await cache.hydrateTimeEntries([updated]);
+
+        return jsonResponse({
+          success: true,
+          message: 'Time entry updated',
+          entry: hydrated[0],
+        });
+      }
+
+      case 'toggl_delete_time_entry': {
+        const workspaceId = await resolveWorkspaceForTool(args, 'deleting a time entry');
+        const entryId = args?.entry_id;
+        if (typeof entryId !== 'number') {
+          throw new Error('entry_id is required');
+        }
+
+        await api.deleteTimeEntry(workspaceId, entryId);
+
+        return jsonResponse({
+          success: true,
+          message: 'Time entry deleted',
+          workspace_id: workspaceId,
+          entry_id: entryId,
+        });
       }
 
       // Reporting tools

--- a/src/index.ts
+++ b/src/index.ts
@@ -301,7 +301,7 @@ const tools: Tool[] = [
         billable: {
           type: 'boolean',
           description:
-            'Whether the entry is billable. If omitted, Toggl applies the project default.',
+            'Whether the entry is billable. If omitted, Toggl applies the project default. Note: some Toggl plans (Free) ignore this flag and treat the entry as non-billable.',
         },
       },
     },
@@ -363,7 +363,7 @@ const tools: Tool[] = [
         billable: {
           type: 'boolean',
           description:
-            'Whether the entry is billable. If omitted, Toggl applies the project default.',
+            'Whether the entry is billable. If omitted, Toggl applies the project default. Note: some Toggl plans (Free) ignore this flag and treat the entry as non-billable.',
         },
         workspace_id: {
           type: 'number',
@@ -400,7 +400,11 @@ const tools: Tool[] = [
           items: { type: 'number' },
           description: 'Tag IDs (alternative to tags); replaces existing tags on the entry',
         },
-        billable: { type: 'boolean' },
+        billable: {
+          type: 'boolean',
+          description:
+            'Whether the entry is billable. Note: some Toggl plans (Free) ignore this flag and treat the entry as non-billable.',
+        },
         start: { type: 'string', description: 'ISO 8601 datetime' },
         stop: { type: 'string', description: 'ISO 8601 datetime' },
         duration: { type: 'number', description: 'Duration in seconds' },

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -127,12 +127,21 @@ export class TogglAPI {
           throw err;
         }
 
-        // Handle 204 No Content
+        // Handle empty bodies on success. Toggl returns 200 with content-length: 0
+        // for some write endpoints (e.g. DELETE /workspaces/{wid}/tags/{tid}); blindly
+        // calling response.json() on those throws and triggers a misleading retry.
         if (response.status === 204) {
           return {} as T;
         }
-
-        return (await response.json()) as T;
+        const contentLength = response.headers.get('content-length');
+        if (contentLength === '0') {
+          return {} as T;
+        }
+        const text = await response.text();
+        if (text.length === 0) {
+          return {} as T;
+        }
+        return JSON.parse(text) as T;
       } catch (error: any) {
         if (error?.noRetry || i === retries - 1) throw error;
         // Exponential backoff for transient/network errors

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -293,13 +293,15 @@ export class TogglAPI {
     description?: string,
     projectId?: number,
     taskId?: number,
-    tags?: string[]
+    tags?: string[],
+    billable?: boolean
   ): Promise<TimeEntry> {
     const entry: Partial<CreateTimeEntryRequest> = {
       description,
       project_id: projectId,
       task_id: taskId,
       tags,
+      billable,
       start: new Date().toISOString(),
       duration: -1, // Negative duration indicates running timer
     };

--- a/tests/toggl-api.test.ts
+++ b/tests/toggl-api.test.ts
@@ -14,20 +14,34 @@ function response({
   text = '',
   json,
   retryAfter,
+  contentLength,
 }: {
   status: number;
   text?: string;
   json?: unknown;
   retryAfter?: string;
+  contentLength?: string;
 }) {
   return {
     status,
     ok: status >= 200 && status < 300,
     headers: {
-      get: vi.fn((name: string) => (name.toLowerCase() === 'retry-after' ? retryAfter : null)),
+      get: vi.fn((name: string) => {
+        const key = name.toLowerCase();
+        if (key === 'retry-after') return retryAfter;
+        if (key === 'content-length') return contentLength;
+        return null;
+      }),
     },
-    text: vi.fn(async () => text),
-    json: vi.fn(async () => json),
+    text: vi.fn(async () => {
+      if (text) return text;
+      if (json !== undefined) return JSON.stringify(json);
+      return '';
+    }),
+    json: vi.fn(async () => {
+      if (json !== undefined) return json;
+      return JSON.parse(text);
+    }),
   };
 }
 
@@ -62,6 +76,18 @@ describe('toggl api errors', () => {
       status: 429,
       retry_after_seconds: 60,
     });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  // Toggl returns HTTP 200 with content-length: 0 (not 204) on some write endpoints,
+  // including DELETE /workspaces/{wid}/tags/{tid} and DELETE /workspaces/{wid}/time_entries/{tid}.
+  // Naive response.json() throws on the empty body, which previously triggered a misleading retry
+  // that could surface as a 404 because the first call had already succeeded server-side.
+  it('treats HTTP 200 with content-length: 0 as a successful empty response', async () => {
+    fetchMock.mockResolvedValue(response({ status: 200, contentLength: '0', text: '' }));
+
+    const api = new TogglAPI('token');
+    await expect(api.deleteTimeEntry(1, 100)).resolves.toBeUndefined();
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/toggl-api.test.ts
+++ b/tests/toggl-api.test.ts
@@ -91,3 +91,128 @@ describe('toggl api errors', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('toggl api time entry CRUD', () => {
+  afterEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it('POSTs to the workspace time_entries endpoint with start, billable, and created_with', async () => {
+    fetchMock.mockResolvedValue(
+      response({
+        status: 200,
+        json: {
+          id: 100,
+          workspace_id: 1,
+          start: '2026-05-01T09:00:00Z',
+          stop: '2026-05-01T10:00:00Z',
+          duration: 3600,
+          description: 'Focused work',
+          billable: true,
+        },
+      })
+    );
+
+    const api = new TogglAPI('token');
+    const entry = await api.createTimeEntry(1, {
+      start: '2026-05-01T09:00:00Z',
+      stop: '2026-05-01T10:00:00Z',
+      duration: 3600,
+      description: 'Focused work',
+      billable: true,
+    });
+
+    expect(entry.id).toBe(100);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.track.toggl.com/api/v9/workspaces/1/time_entries');
+    expect(init.method).toBe('POST');
+    const body = JSON.parse(init.body) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      workspace_id: 1,
+      created_with: 'mcp-toggl',
+      start: '2026-05-01T09:00:00Z',
+      stop: '2026-05-01T10:00:00Z',
+      duration: 3600,
+      description: 'Focused work',
+      billable: true,
+    });
+  });
+
+  it('PUTs to the single time_entry endpoint with only the supplied update fields', async () => {
+    fetchMock.mockResolvedValue(
+      response({
+        status: 200,
+        json: {
+          id: 100,
+          workspace_id: 1,
+          start: '2026-05-01T09:00:00Z',
+          duration: 3600,
+          project_id: 50,
+          description: 'Categorized',
+        },
+      })
+    );
+
+    const api = new TogglAPI('token');
+    const entry = await api.updateTimeEntry(1, 100, {
+      project_id: 50,
+      description: 'Categorized',
+    });
+
+    expect(entry.id).toBe(100);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.track.toggl.com/api/v9/workspaces/1/time_entries/100');
+    expect(init.method).toBe('PUT');
+    expect(JSON.parse(init.body)).toEqual({ project_id: 50, description: 'Categorized' });
+  });
+
+  it('DELETEs the single time_entry endpoint without a body', async () => {
+    fetchMock.mockResolvedValue(response({ status: 200, contentLength: '0', text: '' }));
+
+    const api = new TogglAPI('token');
+    await api.deleteTimeEntry(1, 100);
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.track.toggl.com/api/v9/workspaces/1/time_entries/100');
+    expect(init.method).toBe('DELETE');
+    expect(init.body).toBeUndefined();
+  });
+
+  it('passes billable through startTimer to the underlying createTimeEntry payload', async () => {
+    fetchMock.mockResolvedValue(
+      response({
+        status: 200,
+        json: {
+          id: 101,
+          workspace_id: 1,
+          start: '2026-05-01T09:00:00Z',
+          duration: -1,
+          billable: true,
+        },
+      })
+    );
+
+    const api = new TogglAPI('token');
+    await api.startTimer(1, 'Working', undefined, undefined, undefined, true);
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    const body = JSON.parse(init.body) as Record<string, unknown>;
+    expect(body).toMatchObject({
+      description: 'Working',
+      billable: true,
+      duration: -1,
+    });
+  });
+
+  it('does not retry create on 4xx client errors', async () => {
+    fetchMock.mockResolvedValue(
+      response({ status: 400, text: 'start cannot be in the future for completed entries' })
+    );
+
+    const api = new TogglAPI('token');
+    await expect(
+      api.createTimeEntry(1, { start: '2050-01-01T00:00:00Z', duration: 60 })
+    ).rejects.toThrow(/400/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
Adds full time entry CRUD per #7, reimplemented from current `main` per the maintainer's "fresh PR from current main with tests against the post-1.1.0 handler structure" note when closing #12 (and equivalent guidance closing #8).

> [!NOTE]
> **Tracking #36, depends on #37.** Same coordination story as #37 (tag CRUD): authored against current `main`. The request 200/empty-body fix is cherry-picked from #37 because tag DELETE and time entry DELETE share the same Toggl response shape — patch-id collision will let the duplicate commit drop cleanly when either PR rebases. Happy to rebase against post-#36/#37 `main` and add handler tests using the new `tests/mcp-server.test.ts` pattern, or merge in any order — your call.

## What's added

Three MCP tools that complete the time entry CRUD surface, plus a small extension to `toggl_start_timer`:

- `toggl_create_time_entry` — `POST /workspaces/{wid}/time_entries`. Required: `start`. Optional: `stop`, `duration`, `description`, `project_id`, `task_id`, `tags`, `tag_ids`, `billable`. Fills the create gap for retroactively logging past work — `toggl_start_timer` only creates running timers.
- `toggl_update_time_entry` — `PUT /workspaces/{wid}/time_entries/{tid}`. All fields optional except `entry_id`; only fields the caller passed are sent, so `{ project_id: 50 }` doesn't clobber description.
- `toggl_delete_time_entry` — `DELETE /workspaces/{wid}/time_entries/{tid}`.
- `toggl_start_timer` — gains optional `billable` parameter for parity.

All three new tools resolve workspace via `resolveWorkspaceForTool`, return via `jsonResponse`, and hydrate response entries via `cache.hydrateTimeEntries`. Errors flow through the central catch with `errorPayload(error)`. No new cache invalidation — time entries aren't cached as a collection.

## Includes a small `request()` fix (cherry-picked from #37)

`toggl_delete_time_entry` hits the same Toggl 200/`content-length: 0` shape as tag DELETE. The existing `request()` short-circuited only on 204 and called `response.json()` on the empty body, throwing and triggering a misleading retry that surfaced as a bogus 404. The cherry-picked fix from #37 treats 200/empty-body the same as 204. Behavior unchanged for non-empty success responses.

## Resolves prior closed work

- **#7** (open, @YoungR25): explicit feature request for `toggl_update_time_entry` with project/task/description/tags/billable. Implemented.
- **#8** (closed, @rocketworm): billable on `start_timer` + update_entry tool. Maintainer's closing note: *"rewrite from current main if billable/update-entry support is still wanted."* Reimplemented from current `main`; original author credited via `Co-Authored-By`.
- **#12** (closed, @arndjan): create + delete time entry tools. Maintainer's closing note: *"fresh PR from current main with tests against the post-1.1.0 handler structure."* Reimplemented from current `main`; original author credited via `Co-Authored-By`.

Both contributors' branches were too far behind to cherry-pick cleanly (pre-1.1.0). Their work informed the design but the implementation here is fresh against current `main` patterns: `WorkspaceResolutionError`, `jsonResponse`, `errorPayload`, `resolveWorkspaceForTool`, `cache.hydrateTimeEntries`.

## Plan-tier billable note

A small UX hint: the `billable` parameter description on all three tools that accept it now mentions that some Toggl plans (Free) silently set entry-level billable to `false` even when the project itself is billable. Agents can check the response to detect the discrepancy rather than assuming the flag applied. Verified live during smoke testing — the Toggl API accepts the flag and returns 200, but the response shows `billable: false` on Free workspaces.

## Commits

Three commits:

1. `fix(api): handle Toggl 200/empty-body responses` — cherry-picked from #37
2. `feat: add time entry CRUD tools and billable on start_timer` — Co-Authored-By: Andreas Wurm, Arnd Jan Gulmans
3. `docs: note plan-tier billable behavior in tool schemas`

## Verification

- `npm test` — 36/36 passing (5 new API-level tests: POST/PUT/DELETE shape, billable-passthrough, 4xx no-retry)
- `npm run build` — clean
- `npm run lint` — no new warnings
- Smoke-tested end-to-end against a real Toggl workspace: `create` with billable → `list` (verify visible) → `update` (assign project, hydrate via cache) → `delete` → verify cleanup. The empty-body fix is verified live; delete returns clean `success: true`, no false 404.

## Coverage with #36's proposed thresholds

Same approach as #37 — every metric improves over `main`; further gain available via handler tests once `createTogglServer` lands.

## Scope

Time entry CRUD only. No project/client write tools, no SDK upgrade.