### PR TITLE
feat: add project CRUD tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,14 @@ mcp-toggl --help
 | `toggl_list_projects` | Lists projects for a workspace using cache-backed reads after first fetch. |
 | `toggl_list_clients` | Lists clients for a workspace using cache-backed reads after first fetch. |
 
+### Project Management
+
+| Tool | What it does |
+| --- | --- |
+| `toggl_create_project` | Creates a project with optional client, color, billable flag, and estimated hours. |
+| `toggl_update_project` | Updates project fields. Set `active: false` to archive; pass `client_id: null` to detach the client. |
+| `toggl_delete_project` | Deletes a project. Optional `time_entry_deletion_mode: "delete" \| "unassign"` controls what happens to the project's time entries. |
+
 ### Cache Management
 
 | Tool | What it does |

--- a/src/cache-manager.ts
+++ b/src/cache-manager.ts
@@ -206,6 +206,15 @@ export class CacheManager {
     }
   }
 
+  invalidateWorkspaceProjects(workspaceId: number): void {
+    this.projectsByWorkspace.delete(workspaceId);
+    this.projects.forEach((entry, projectId) => {
+      if (entry.data.workspace_id === workspaceId) {
+        this.projects.delete(projectId);
+      }
+    });
+  }
+
   // Client methods
   async getClient(id: number, workspaceId?: number): Promise<Client | null> {
     const cached = this.getCached(this.clients, id);

--- a/src/index.ts
+++ b/src/index.ts
@@ -475,6 +475,112 @@ const tools: Tool[] = [
       },
     },
   },
+  {
+    name: 'toggl_create_project',
+    description: 'Create a new project in a workspace',
+    annotations: {
+      readOnlyHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Project name' },
+        client_id: { type: 'number', description: 'Client ID to assign the project to' },
+        is_private: {
+          type: 'boolean',
+          description: 'Whether the project is private. Defaults to false.',
+        },
+        active: {
+          type: 'boolean',
+          description: 'Whether the project is active. Defaults to true.',
+        },
+        color: { type: 'string', description: 'Hex color (e.g. "#06aaf5")' },
+        billable: {
+          type: 'boolean',
+          description:
+            'Whether time tracked on this project is billable by default. Note: some Toggl plans (Free) ignore this flag.',
+        },
+        auto_estimates: { type: 'boolean', description: 'Enable auto-estimates' },
+        estimated_hours: { type: 'number', description: 'Estimated hours for the project' },
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
+        },
+      },
+      required: ['name'],
+    },
+  },
+  {
+    name: 'toggl_update_project',
+    description:
+      'Update fields on an existing project. Pass only the fields to change. Set active=false to archive; pass client_id=null to remove the client assignment.',
+    annotations: {
+      readOnlyHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        project_id: { type: 'number', description: 'Project ID to update' },
+        name: { type: 'string', description: 'New project name' },
+        client_id: {
+          type: ['number', 'null'],
+          description: 'New client ID; pass null to remove the assignment',
+        },
+        is_private: { type: 'boolean' },
+        active: {
+          type: 'boolean',
+          description: 'Set to false to archive the project',
+        },
+        color: { type: 'string', description: 'Hex color (e.g. "#06aaf5")' },
+        billable: {
+          type: 'boolean',
+          description:
+            'Whether time tracked on this project is billable by default. Note: some Toggl plans (Free) ignore this flag.',
+        },
+        auto_estimates: { type: 'boolean' },
+        estimated_hours: { type: 'number' },
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
+        },
+      },
+      required: ['project_id'],
+    },
+  },
+  {
+    name: 'toggl_delete_project',
+    description: 'Delete a project by ID',
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        project_id: { type: 'number', description: 'Project ID to delete' },
+        time_entry_deletion_mode: {
+          type: 'string',
+          enum: ['delete', 'unassign'],
+          description:
+            "How to handle time entries on this project: 'delete' removes them; 'unassign' detaches them. If omitted, Toggl applies its default.",
+        },
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
+        },
+      },
+      required: ['project_id'],
+    },
+  },
 
   // Cache management
   {
@@ -1033,6 +1139,87 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             },
           ],
         };
+      }
+
+      case 'toggl_create_project': {
+        const workspaceId = await resolveWorkspaceForTool(args, 'creating a project');
+        if (!args?.name || typeof args.name !== 'string') {
+          throw new Error('Project name is required');
+        }
+
+        const project = await api.createProject(workspaceId, {
+          name: args.name,
+          client_id: args.client_id as number | undefined,
+          is_private: args.is_private as boolean | undefined,
+          active: args.active as boolean | undefined,
+          color: args.color as string | undefined,
+          billable: args.billable as boolean | undefined,
+          auto_estimates: args.auto_estimates as boolean | undefined,
+          estimated_hours: args.estimated_hours as number | undefined,
+        });
+
+        cache.invalidateWorkspaceProjects(workspaceId);
+
+        return jsonResponse({
+          success: true,
+          message: `Project "${project.name}" created`,
+          project,
+        });
+      }
+
+      case 'toggl_update_project': {
+        const workspaceId = await resolveWorkspaceForTool(args, 'updating a project');
+        const projectId = args?.project_id;
+        if (typeof projectId !== 'number') {
+          throw new Error('project_id is required');
+        }
+
+        const updates: Record<string, unknown> = {};
+        for (const key of [
+          'name',
+          'client_id',
+          'is_private',
+          'active',
+          'color',
+          'billable',
+          'auto_estimates',
+          'estimated_hours',
+        ] as const) {
+          if (args && key in args) {
+            updates[key] = args[key];
+          }
+        }
+
+        const project = await api.updateProject(workspaceId, projectId, updates);
+
+        cache.invalidateWorkspaceProjects(workspaceId);
+
+        return jsonResponse({
+          success: true,
+          message: `Project ${projectId} updated`,
+          project,
+        });
+      }
+
+      case 'toggl_delete_project': {
+        const workspaceId = await resolveWorkspaceForTool(args, 'deleting a project');
+        const projectId = args?.project_id;
+        if (typeof projectId !== 'number') {
+          throw new Error('project_id is required');
+        }
+
+        const mode = args?.time_entry_deletion_mode;
+        const teDeletionMode =
+          mode === 'delete' || mode === 'unassign' ? mode : undefined;
+
+        await api.deleteProject(workspaceId, projectId, teDeletionMode);
+
+        cache.invalidateWorkspaceProjects(workspaceId);
+
+        return jsonResponse({
+          success: true,
+          message: `Project ${projectId} deleted`,
+        });
       }
 
       // Cache management

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -172,18 +172,29 @@ export class TogglAPI {
   }
 
   // Project methods
-  async getProjects(workspaceId: number): Promise<Project[]> {
-    return this.request<Project[]>('GET', `/workspaces/${workspaceId}/projects`);
+  async getProjects(
+    workspaceId: number,
+    active?: 'true' | 'false' | 'both'
+  ): Promise<Project[]> {
+    const query = active ? `?active=${active}` : '';
+    return this.request<Project[]>('GET', `/workspaces/${workspaceId}/projects${query}`);
   }
 
-  async getProject(projectId: number): Promise<Project> {
-    // First, we need to find which workspace this project belongs to
-    // This is a limitation of Toggl API v9 - no direct project endpoint
+  async getProject(projectId: number, workspaceId?: number): Promise<Project> {
+    if (workspaceId) {
+      return this.request<Project>('GET', `/workspaces/${workspaceId}/projects/${projectId}`);
+    }
+    // Fallback: try the direct endpoint per workspace until one matches.
     const workspaces = await this.getWorkspaces();
     for (const workspace of workspaces) {
-      const projects = await this.getProjects(workspace.id);
-      const project = projects.find((p) => p.id === projectId);
-      if (project) return project;
+      try {
+        return await this.request<Project>(
+          'GET',
+          `/workspaces/${workspace.id}/projects/${projectId}`
+        );
+      } catch {
+        continue;
+      }
     }
     throw new Error(`Project ${projectId} not found`);
   }

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -127,12 +127,21 @@ export class TogglAPI {
           throw err;
         }
 
-        // Handle 204 No Content
+        // Handle empty bodies on success. Toggl returns 200 with content-length: 0
+        // for some write endpoints (e.g. DELETE /workspaces/{wid}/tags/{tid}); blindly
+        // calling response.json() on those throws and triggers a misleading retry.
         if (response.status === 204) {
           return {} as T;
         }
-
-        return (await response.json()) as T;
+        const contentLength = response.headers.get('content-length');
+        if (contentLength === '0') {
+          return {} as T;
+        }
+        const text = await response.text();
+        if (text.length === 0) {
+          return {} as T;
+        }
+        return JSON.parse(text) as T;
       } catch (error: any) {
         if (error?.noRetry || i === retries - 1) throw error;
         // Exponential backoff for transient/network errors

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -11,6 +11,9 @@ import type {
   TimeEntriesRequest,
   CreateTimeEntryRequest,
   UpdateTimeEntryRequest,
+  CreateProjectRequest,
+  UpdateProjectRequest,
+  ProjectDeleteMode,
   TimelineEvent,
 } from './types.js';
 
@@ -197,6 +200,35 @@ export class TogglAPI {
       }
     }
     throw new Error(`Project ${projectId} not found`);
+  }
+
+  async createProject(workspaceId: number, project: CreateProjectRequest): Promise<Project> {
+    return this.request<Project>('POST', `/workspaces/${workspaceId}/projects`, {
+      ...project,
+      active: project.active ?? true,
+      is_private: project.is_private ?? false,
+    });
+  }
+
+  async updateProject(
+    workspaceId: number,
+    projectId: number,
+    updates: UpdateProjectRequest
+  ): Promise<Project> {
+    return this.request<Project>(
+      'PUT',
+      `/workspaces/${workspaceId}/projects/${projectId}`,
+      updates
+    );
+  }
+
+  async deleteProject(
+    workspaceId: number,
+    projectId: number,
+    timeEntryDeletionMode?: ProjectDeleteMode
+  ): Promise<void> {
+    const query = timeEntryDeletionMode ? `?teDeletionMode=${timeEntryDeletionMode}` : '';
+    await this.request<void>('DELETE', `/workspaces/${workspaceId}/projects/${projectId}${query}`);
   }
 
   // Client methods

--- a/src/types.ts
+++ b/src/types.ts
@@ -238,6 +238,32 @@ export interface UpdateTimeEntryRequest {
   duration?: number;
 }
 
+export interface CreateProjectRequest {
+  name: string;
+  client_id?: number;
+  is_private?: boolean;
+  active?: boolean;
+  color?: string;
+  billable?: boolean;
+  auto_estimates?: boolean;
+  estimated_hours?: number;
+}
+
+export interface UpdateProjectRequest {
+  name?: string;
+  // null clears the client assignment (Toggl accepts null in the PUT body).
+  client_id?: number | null;
+  is_private?: boolean;
+  active?: boolean;
+  color?: string;
+  billable?: boolean;
+  auto_estimates?: boolean;
+  estimated_hours?: number;
+}
+
+// 'delete' removes the project's time entries; 'unassign' detaches them.
+export type ProjectDeleteMode = 'delete' | 'unassign';
+
 export interface TimelineEvent {
   id: number;
   start_time: number; // Unix timestamp in seconds

--- a/tests/toggl-api.test.ts
+++ b/tests/toggl-api.test.ts
@@ -91,3 +91,103 @@ describe('toggl api errors', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('toggl api project CRUD', () => {
+  afterEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it('GETs the active filter onto the projects endpoint when supplied', async () => {
+    fetchMock.mockResolvedValue(response({ status: 200, json: [] }));
+
+    const api = new TogglAPI('token');
+    await api.getProjects(1, 'true');
+
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.track.toggl.com/api/v9/workspaces/1/projects?active=true');
+  });
+
+  it('GETs the project directly when workspace_id is provided', async () => {
+    fetchMock.mockResolvedValue(
+      response({ status: 200, json: { id: 50, workspace_id: 1, name: 'Web' } })
+    );
+
+    const api = new TogglAPI('token');
+    await api.getProject(50, 1);
+
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.track.toggl.com/api/v9/workspaces/1/projects/50');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('POSTs to the workspace projects endpoint and applies active/is_private defaults', async () => {
+    fetchMock.mockResolvedValue(
+      response({
+        status: 200,
+        json: { id: 50, workspace_id: 1, name: 'New Project', active: true, is_private: false },
+      })
+    );
+
+    const api = new TogglAPI('token');
+    const project = await api.createProject(1, { name: 'New Project' });
+
+    expect(project.id).toBe(50);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.track.toggl.com/api/v9/workspaces/1/projects');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body)).toEqual({
+      name: 'New Project',
+      active: true,
+      is_private: false,
+    });
+  });
+
+  it('PUTs to the single project endpoint with only the supplied update fields', async () => {
+    fetchMock.mockResolvedValue(
+      response({
+        status: 200,
+        json: { id: 50, workspace_id: 1, name: 'Renamed', client_id: null },
+      })
+    );
+
+    const api = new TogglAPI('token');
+    await api.updateProject(1, 50, { name: 'Renamed', client_id: null });
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.track.toggl.com/api/v9/workspaces/1/projects/50');
+    expect(init.method).toBe('PUT');
+    expect(JSON.parse(init.body)).toEqual({ name: 'Renamed', client_id: null });
+  });
+
+  it('DELETEs the single project endpoint without a body', async () => {
+    fetchMock.mockResolvedValue(response({ status: 200, contentLength: '0', text: '' }));
+
+    const api = new TogglAPI('token');
+    await api.deleteProject(1, 50);
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.track.toggl.com/api/v9/workspaces/1/projects/50');
+    expect(init.method).toBe('DELETE');
+    expect(init.body).toBeUndefined();
+  });
+
+  it('passes teDeletionMode through deleteProject as a query string', async () => {
+    fetchMock.mockResolvedValue(response({ status: 200, contentLength: '0', text: '' }));
+
+    const api = new TogglAPI('token');
+    await api.deleteProject(1, 50, 'unassign');
+
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(url).toBe(
+      'https://api.track.toggl.com/api/v9/workspaces/1/projects/50?teDeletionMode=unassign'
+    );
+  });
+
+  it('does not retry createProject on 4xx client errors', async () => {
+    fetchMock.mockResolvedValue(response({ status: 400, text: 'name is required' }));
+
+    const api = new TogglAPI('token');
+    await expect(api.createProject(1, { name: '' })).rejects.toThrow(/400/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/toggl-api.test.ts
+++ b/tests/toggl-api.test.ts
@@ -14,20 +14,34 @@ function response({
   text = '',
   json,
   retryAfter,
+  contentLength,
 }: {
   status: number;
   text?: string;
   json?: unknown;
   retryAfter?: string;
+  contentLength?: string;
 }) {
   return {
     status,
     ok: status >= 200 && status < 300,
     headers: {
-      get: vi.fn((name: string) => (name.toLowerCase() === 'retry-after' ? retryAfter : null)),
+      get: vi.fn((name: string) => {
+        const key = name.toLowerCase();
+        if (key === 'retry-after') return retryAfter;
+        if (key === 'content-length') return contentLength;
+        return null;
+      }),
     },
-    text: vi.fn(async () => text),
-    json: vi.fn(async () => json),
+    text: vi.fn(async () => {
+      if (text) return text;
+      if (json !== undefined) return JSON.stringify(json);
+      return '';
+    }),
+    json: vi.fn(async () => {
+      if (json !== undefined) return json;
+      return JSON.parse(text);
+    }),
   };
 }
 
@@ -62,6 +76,18 @@ describe('toggl api errors', () => {
       status: 429,
       retry_after_seconds: 60,
     });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  // Toggl returns HTTP 200 with content-length: 0 (not 204) on some write endpoints,
+  // including DELETE /workspaces/{wid}/tags/{tid} and DELETE /workspaces/{wid}/time_entries/{tid}.
+  // Naive response.json() throws on the empty body, which previously triggered a misleading retry
+  // that could surface as a 404 because the first call had already succeeded server-side.
+  it('treats HTTP 200 with content-length: 0 as a successful empty response', async () => {
+    fetchMock.mockResolvedValue(response({ status: 200, contentLength: '0', text: '' }));
+
+    const api = new TogglAPI('token');
+    await expect(api.deleteTimeEntry(1, 100)).resolves.toBeUndefined();
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Adds full project CRUD (`create`, `update`, `delete`) plus a small ergonomic refactor of `getProject`/`getProjects`. Builds on the same coordination story as #37 and #38.

> [!NOTE]
> **Builds on #38.** The `request()` 200/empty-body fix is cherry-picked from #38 because project DELETE shares the same Toggl response shape as tag DELETE and time entry DELETE — patch-id collision will let the duplicate commit drop cleanly when either PR rebases. Happy to merge in any order or rebase against post-#38 `main` — your call.

## What's added

- `toggl_create_project` — `POST /workspaces/{wid}/projects`. Required: `name`. Optional: `client_id`, `is_private`, `active`, `color`, `billable`, `auto_estimates`, `estimated_hours`. Defaults `active: true` and `is_private: false` to match Toggl's documented defaults.
- `toggl_update_project` — `PUT /workspaces/{wid}/projects/{pid}`. All fields optional except `project_id`; only fields the caller passed are sent. Set `active: false` to archive; pass `client_id: null` to detach the client (the schema declares `client_id: ['number', 'null']` and the runtime preserves the explicit `null`).
- `toggl_delete_project` — `DELETE /workspaces/{wid}/projects/{pid}`. Surfaces Toggl's optional `?teDeletionMode=delete|unassign` as a `time_entry_deletion_mode` parameter so callers can choose between deleting the project's time entries or detaching them.

All three resolve workspace via `resolveWorkspaceForTool`, return via `jsonResponse`, and call `cache.invalidateWorkspaceProjects(workspaceId)` after each write so a subsequent `toggl_list_projects` reflects the change without a manual `toggl_clear_cache`.

## Small ergonomic refactor along for the ride

- `getProject(projectId, workspaceId?)` — when the workspace is known, hits `GET /workspaces/{wid}/projects/{pid}` directly instead of fanning out across all workspaces. Falls back to the old per-workspace probe when only a project ID is supplied. Non-breaking: existing `getProject(projectId)` callers still work.
- `getProjects(workspaceId, active?)` — accepts `'true' | 'false' | 'both'` and maps to Toggl's `?active` query param. Optional, defaults to Toggl's default.

Both originally lifted from `84emllc/mcp-toggl@eef1bea` and credited via `Co-Authored-By`.

## Includes the empty-body fix (cherry-picked from #38)

Project DELETE returns 200/`content-length: 0` like tag and time entry DELETE. Same fix, same patch-id collision story.

## Live-test caveat: 402 on `billable: true`

Toggl returns HTTP 402 when the workspace plan can't apply the `billable` flag on a project. The existing `request()` code surfaces all 402s as `TOGGL_QUOTA_LIMIT`, which is technically misleading (it's a feature-gate, not a rate limit). Pre-existing behavior; not in scope here. Confirmed via live smoke testing that immediately following a non-billable update succeeds, ruling out a real rate limit. All other update fields work cleanly on Free plans.

## Commits

1. `fix(api): handle Toggl 200/empty-body responses` — cherry-picked from #38
2. `refactor(api): allow direct workspace lookup in getProject` — Co-Authored-By: Andrew Miller
3. `feat(api): add project CRUD methods to TogglAPI client` — Co-Authored-By: Andrew Miller
4. `feat(cache): add workspace project invalidation`
5. `feat(tools): expose project CRUD as MCP tools`
6. `docs: document project CRUD tools in README`

## Verification

- `npm test` — 38/38 passing (7 new API-level tests: GET active filter, GET direct lookup, POST/PUT/DELETE shape, teDeletionMode passthrough, 4xx no-retry)
- `npm run build` — clean
- `npm run lint` — no new warnings
- Smoke-tested end-to-end against a real Toggl workspace: `create` (with color) → `update` (rename) → `update` (archive via `active: false`) → `delete`. Cache invalidation verified — subsequent `toggl_list_projects` reflects each change.

## Scope

Project CRUD only. Sister PR for client CRUD is at #40. Archive/restore endpoints, color presets, and bulk operations are out of scope.