### PR TITLE
feat: add client CRUD tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,14 @@ mcp-toggl --help
 | `toggl_list_projects` | Lists projects for a workspace using cache-backed reads after first fetch. |
 | `toggl_list_clients` | Lists clients for a workspace using cache-backed reads after first fetch. |
 
+### Client Management
+
+| Tool | What it does |
+| --- | --- |
+| `toggl_create_client` | Creates a client with optional notes and external reference. |
+| `toggl_update_client` | Updates a client. Toggl requires `name` on every update; pass the existing name when only changing notes or external reference. |
+| `toggl_delete_client` | Deletes a client by ID. |
+
 ### Cache Management
 
 | Tool | What it does |

--- a/src/cache-manager.ts
+++ b/src/cache-manager.ts
@@ -250,6 +250,15 @@ export class CacheManager {
     }
   }
 
+  invalidateWorkspaceClients(workspaceId: number): void {
+    this.clientsByWorkspace.delete(workspaceId);
+    this.clients.forEach((entry, clientId) => {
+      if (entry.data.workspace_id === workspaceId) {
+        this.clients.delete(clientId);
+      }
+    });
+  }
+
   // Task methods
   async getTask(id: number, workspaceId: number, projectId: number): Promise<Task | null> {
     const cached = this.getCached(this.tasks, id);

--- a/src/index.ts
+++ b/src/index.ts
@@ -475,6 +475,79 @@ const tools: Tool[] = [
       },
     },
   },
+  {
+    name: 'toggl_create_client',
+    description: 'Create a new client in a workspace',
+    annotations: {
+      readOnlyHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Client name' },
+        notes: { type: 'string', description: 'Optional notes for the client' },
+        external_reference: {
+          type: 'string',
+          description: 'Optional external system reference (e.g. JIRA/Salesforce ID)',
+        },
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
+        },
+      },
+      required: ['name'],
+    },
+  },
+  {
+    name: 'toggl_update_client',
+    description:
+      'Update an existing client. Toggl requires name on every update; pass the existing name unchanged when only adjusting notes or external_reference.',
+    annotations: {
+      readOnlyHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        client_id: { type: 'number', description: 'Client ID to update' },
+        name: { type: 'string', description: 'Client name (required by Toggl on update)' },
+        notes: { type: 'string' },
+        external_reference: { type: 'string' },
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
+        },
+      },
+      required: ['client_id', 'name'],
+    },
+  },
+  {
+    name: 'toggl_delete_client',
+    description: 'Delete a client by ID',
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        client_id: { type: 'number', description: 'Client ID to delete' },
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
+        },
+      },
+      required: ['client_id'],
+    },
+  },
 
   // Cache management
   {
@@ -1033,6 +1106,69 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
             },
           ],
         };
+      }
+
+      case 'toggl_create_client': {
+        const workspaceId = await resolveWorkspaceForTool(args, 'creating a client');
+        if (!args?.name || typeof args.name !== 'string') {
+          throw new Error('Client name is required');
+        }
+
+        const client = await api.createClient(workspaceId, {
+          name: args.name,
+          notes: args.notes as string | undefined,
+          external_reference: args.external_reference as string | undefined,
+        });
+
+        cache.invalidateWorkspaceClients(workspaceId);
+
+        return jsonResponse({
+          success: true,
+          message: `Client "${client.name}" created`,
+          client,
+        });
+      }
+
+      case 'toggl_update_client': {
+        const workspaceId = await resolveWorkspaceForTool(args, 'updating a client');
+        const clientId = args?.client_id;
+        if (typeof clientId !== 'number') {
+          throw new Error('client_id is required');
+        }
+        if (!args?.name || typeof args.name !== 'string') {
+          throw new Error('Client name is required (Toggl requires name on every update)');
+        }
+
+        const client = await api.updateClient(workspaceId, clientId, {
+          name: args.name,
+          notes: args.notes as string | undefined,
+          external_reference: args.external_reference as string | undefined,
+        });
+
+        cache.invalidateWorkspaceClients(workspaceId);
+
+        return jsonResponse({
+          success: true,
+          message: `Client ${clientId} updated`,
+          client,
+        });
+      }
+
+      case 'toggl_delete_client': {
+        const workspaceId = await resolveWorkspaceForTool(args, 'deleting a client');
+        const clientId = args?.client_id;
+        if (typeof clientId !== 'number') {
+          throw new Error('client_id is required');
+        }
+
+        await api.deleteClient(workspaceId, clientId);
+
+        cache.invalidateWorkspaceClients(workspaceId);
+
+        return jsonResponse({
+          success: true,
+          message: `Client ${clientId} deleted`,
+        });
       }
 
       // Cache management

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -127,12 +127,21 @@ export class TogglAPI {
           throw err;
         }
 
-        // Handle 204 No Content
+        // Handle empty bodies on success. Toggl returns 200 with content-length: 0
+        // for some write endpoints (e.g. DELETE /workspaces/{wid}/tags/{tid}); blindly
+        // calling response.json() on those throws and triggers a misleading retry.
         if (response.status === 204) {
           return {} as T;
         }
-
-        return (await response.json()) as T;
+        const contentLength = response.headers.get('content-length');
+        if (contentLength === '0') {
+          return {} as T;
+        }
+        const text = await response.text();
+        if (text.length === 0) {
+          return {} as T;
+        }
+        return JSON.parse(text) as T;
       } catch (error: any) {
         if (error?.noRetry || i === retries - 1) throw error;
         // Exponential backoff for transient/network errors

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -11,6 +11,8 @@ import type {
   TimeEntriesRequest,
   CreateTimeEntryRequest,
   UpdateTimeEntryRequest,
+  CreateClientRequest,
+  UpdateClientRequest,
   TimelineEvent,
 } from './types.js';
 
@@ -191,6 +193,26 @@ export class TogglAPI {
   // Client methods
   async getClients(workspaceId: number): Promise<Client[]> {
     return this.request<Client[]>('GET', `/workspaces/${workspaceId}/clients`);
+  }
+
+  async createClient(workspaceId: number, client: CreateClientRequest): Promise<Client> {
+    return this.request<Client>('POST', `/workspaces/${workspaceId}/clients`, client);
+  }
+
+  async updateClient(
+    workspaceId: number,
+    clientId: number,
+    updates: UpdateClientRequest
+  ): Promise<Client> {
+    return this.request<Client>(
+      'PUT',
+      `/workspaces/${workspaceId}/clients/${clientId}`,
+      updates
+    );
+  }
+
+  async deleteClient(workspaceId: number, clientId: number): Promise<void> {
+    await this.request<void>('DELETE', `/workspaces/${workspaceId}/clients/${clientId}`);
   }
 
   async getClient(clientId: number): Promise<Client> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -238,6 +238,19 @@ export interface UpdateTimeEntryRequest {
   duration?: number;
 }
 
+export interface CreateClientRequest {
+  name: string;
+  notes?: string;
+  external_reference?: string;
+}
+
+export interface UpdateClientRequest {
+  // Required by Toggl on PUT.
+  name: string;
+  notes?: string;
+  external_reference?: string;
+}
+
 export interface TimelineEvent {
   id: number;
   start_time: number; // Unix timestamp in seconds

--- a/tests/toggl-api.test.ts
+++ b/tests/toggl-api.test.ts
@@ -91,3 +91,61 @@ describe('toggl api errors', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('toggl api client CRUD', () => {
+  afterEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it('POSTs to the workspace clients endpoint with name and notes', async () => {
+    fetchMock.mockResolvedValue(
+      response({
+        status: 200,
+        json: { id: 200, workspace_id: 1, name: 'Acme', notes: 'top tier' },
+      })
+    );
+
+    const api = new TogglAPI('token');
+    const client = await api.createClient(1, { name: 'Acme', notes: 'top tier' });
+
+    expect(client.id).toBe(200);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.track.toggl.com/api/v9/workspaces/1/clients');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body)).toEqual({ name: 'Acme', notes: 'top tier' });
+  });
+
+  it('PUTs to the single client endpoint with the supplied update fields', async () => {
+    fetchMock.mockResolvedValue(
+      response({ status: 200, json: { id: 200, workspace_id: 1, name: 'Acme Inc.' } })
+    );
+
+    const api = new TogglAPI('token');
+    await api.updateClient(1, 200, { name: 'Acme Inc.', notes: 'renamed' });
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.track.toggl.com/api/v9/workspaces/1/clients/200');
+    expect(init.method).toBe('PUT');
+    expect(JSON.parse(init.body)).toEqual({ name: 'Acme Inc.', notes: 'renamed' });
+  });
+
+  it('DELETEs the single client endpoint without a body', async () => {
+    fetchMock.mockResolvedValue(response({ status: 200, contentLength: '0', text: '' }));
+
+    const api = new TogglAPI('token');
+    await api.deleteClient(1, 200);
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.track.toggl.com/api/v9/workspaces/1/clients/200');
+    expect(init.method).toBe('DELETE');
+    expect(init.body).toBeUndefined();
+  });
+
+  it('does not retry createClient on 4xx client errors', async () => {
+    fetchMock.mockResolvedValue(response({ status: 400, text: 'name is required' }));
+
+    const api = new TogglAPI('token');
+    await expect(api.createClient(1, { name: '' })).rejects.toThrow(/400/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/toggl-api.test.ts
+++ b/tests/toggl-api.test.ts
@@ -14,20 +14,34 @@ function response({
   text = '',
   json,
   retryAfter,
+  contentLength,
 }: {
   status: number;
   text?: string;
   json?: unknown;
   retryAfter?: string;
+  contentLength?: string;
 }) {
   return {
     status,
     ok: status >= 200 && status < 300,
     headers: {
-      get: vi.fn((name: string) => (name.toLowerCase() === 'retry-after' ? retryAfter : null)),
+      get: vi.fn((name: string) => {
+        const key = name.toLowerCase();
+        if (key === 'retry-after') return retryAfter;
+        if (key === 'content-length') return contentLength;
+        return null;
+      }),
     },
-    text: vi.fn(async () => text),
-    json: vi.fn(async () => json),
+    text: vi.fn(async () => {
+      if (text) return text;
+      if (json !== undefined) return JSON.stringify(json);
+      return '';
+    }),
+    json: vi.fn(async () => {
+      if (json !== undefined) return json;
+      return JSON.parse(text);
+    }),
   };
 }
 
@@ -62,6 +76,18 @@ describe('toggl api errors', () => {
       status: 429,
       retry_after_seconds: 60,
     });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  // Toggl returns HTTP 200 with content-length: 0 (not 204) on some write endpoints,
+  // including DELETE /workspaces/{wid}/tags/{tid} and DELETE /workspaces/{wid}/time_entries/{tid}.
+  // Naive response.json() throws on the empty body, which previously triggered a misleading retry
+  // that could surface as a 404 because the first call had already succeeded server-side.
+  it('treats HTTP 200 with content-length: 0 as a successful empty response', async () => {
+    fetchMock.mockResolvedValue(response({ status: 200, contentLength: '0', text: '' }));
+
+    const api = new TogglAPI('token');
+    await expect(api.deleteTimeEntry(1, 100)).resolves.toBeUndefined();
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Ok last one for now!

Adds full client CRUD (`create`, `update`, `delete`). Sister PR to #39 (project CRUD); same coordination pattern as #37, #38, and #39.

> [!NOTE]
> **Builds on #38.** The `request()` 200/empty-body fix is cherry-picked from #38 because client DELETE shares the same Toggl 200/empty response shape — patch-id collision will let the duplicate commit drop cleanly when either PR rebases. Happy to merge in any order — your call.

## What's added

- `toggl_create_client` — `POST /workspaces/{wid}/clients`. Required: `name`. Optional: `notes`, `external_reference`.
- `toggl_update_client` — `PUT /workspaces/{wid}/clients/{cid}`. **Toggl requires `name` on every update**, so the schema marks it required and the runtime guard rejects calls that omit it. Pass the existing name unchanged when only adjusting `notes` or `external_reference`. Optional: `notes`, `external_reference`.
- `toggl_delete_client` — `DELETE /workspaces/{wid}/clients/{cid}`.

All three resolve workspace via `resolveWorkspaceForTool`, return via `jsonResponse`, and call `cache.invalidateWorkspaceClients(workspaceId)` after each write so a subsequent `toggl_list_clients` reflects the change without a manual `toggl_clear_cache`.

## Out of scope

Toggl's archive/restore endpoints (`POST /clients/{cid}/archive` and `/restore`) are premium-only and offer different semantics than basic CRUD. Left as a follow-up to keep this PR tight.

## Includes the empty-body fix (cherry-picked from #38)

Client DELETE returns 200/`content-length: 0` like the other DELETE endpoints. Same fix, same patch-id collision story.

## Commits

1. `fix(api): handle Toggl 200/empty-body responses` — cherry-picked from #38
2. `feat(api): add client CRUD methods to TogglAPI client` — Co-Authored-By: Andrew Miller (create lifted from `84emllc/mcp-toggl@eef1bea`; update and delete added on top)
3. `feat(cache): add workspace client invalidation`
4. `feat(tools): expose client CRUD as MCP tools`
5. `docs: document client CRUD tools in README`

## Verification

- `npm test` — 35/35 passing (4 new API-level tests: POST/PUT/DELETE shape, 4xx no-retry)
- `npm run build` — clean
- `npm run lint` — no new warnings
- Smoke-tested end-to-end against a real Toggl workspace: `create` (with notes) → `update` (rename + notes change) → `delete`. Cache invalidation verified.

## Scope

Client CRUD only. Sister PR for project CRUD is at #39. Archive/restore (premium-only) and bulk operations are out of scope.