### PR TITLE
feat: workspace user listing and per-user report filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Chart prompts depend on your MCP client. The server returns the structured data;
 
 **Recoverable errors**: workspace resolution errors include `available_workspaces`, and Toggl quota/rate-limit errors include structured retry hints.
 
+**Team reporting**: report tools support a `uid` + `workspace_id` pair to pull any workspace member's entries via the Reports API v3.
+
 ## Quick Start
 
 ### Prerequisites
@@ -118,8 +120,8 @@ mcp-toggl --help
 
 | Tool | What it does |
 | --- | --- |
-| `toggl_daily_report` | Hours by project and workspace for a date. Use `format: "text"` for display text or `"json"` for structured output. |
-| `toggl_weekly_report` | 7-day breakdown with daily totals and project rollups. Use `week_offset: -1` for last week. |
+| `toggl_daily_report` | Hours by project and workspace for a date. Use `format: "text"` for display text or `"json"` for structured output. Supports `uid` filtering. |
+| `toggl_weekly_report` | 7-day breakdown with daily totals and project rollups. Use `week_offset: -1` for last week. Supports `uid` filtering. |
 | `toggl_get_time_entries` | Raw hydrated entries by period, date range, workspace, or project. |
 | `toggl_get_timeline` | Toggl Track Desktop app usage summary with optional raw events. |
 
@@ -139,6 +141,7 @@ mcp-toggl --help
 | `toggl_list_workspaces` | Lists all accessible workspaces. |
 | `toggl_list_projects` | Lists projects for a workspace using cache-backed reads after first fetch. |
 | `toggl_list_clients` | Lists clients for a workspace using cache-backed reads after first fetch. |
+| `toggl_list_workspace_users` | Lists all members of a workspace with their `uid` values. Use these to filter reports by a specific team member. |
 
 ### Cache Management
 
@@ -152,8 +155,8 @@ mcp-toggl --help
 
 | Tool | What it does |
 | --- | --- |
-| `toggl_project_summary` | Total hours per project for a period or date range. |
-| `toggl_workspace_summary` | Total hours per workspace for a period or date range. |
+| `toggl_project_summary` | Total hours per project for a period or date range. Supports `uid` filtering. |
+| `toggl_workspace_summary` | Total hours per workspace for a period or date range. Supports `uid` filtering. |
 
 ## Timeline Privacy
 

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ mcp-toggl --help
 | `toggl_list_workspaces` | Lists all accessible workspaces. |
 | `toggl_list_projects` | Lists projects for a workspace using cache-backed reads after first fetch. |
 | `toggl_list_clients` | Lists clients for a workspace using cache-backed reads after first fetch. |
-| `toggl_list_workspace_users` | Lists all members of a workspace with their `uid` values. Use these to filter reports by a specific team member. |
+| `toggl_list_workspace_users` | Lists workspace members as `uid`, `name`, and `active` only (no email, admin, or rates). Use a member's `uid` to filter reports by that team member. |
 
 ### Cache Management
 

--- a/server.json
+++ b/server.json
@@ -69,6 +69,10 @@
       "description": "List clients in a workspace"
     },
     {
+      "name": "toggl_list_workspace_users",
+      "description": "List workspace members (uid, name, active) for per-user report filtering"
+    },
+    {
       "name": "toggl_warm_cache",
       "description": "Pre-fetch workspace, project, client, and tag data"
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import { CacheManager } from './cache-manager.js';
 import { WorkspaceResolutionError, parseWorkspaceId, resolveWorkspaceId } from './workspace.js';
 import {
   getDateRange,
+  isDatePeriod,
   generateDailyReport,
   generateWeeklyReport,
   formatReportForDisplay,
@@ -170,6 +171,17 @@ async function ensureCache(): Promise<void> {
       console.error('Failed to warm cache:', error);
     }
   }
+}
+
+function resolveDateRange(args: Record<string, unknown> | undefined): { start: Date; end: Date } {
+  if (args?.period && isDatePeriod(args.period)) return getDateRange(args.period);
+  if (args?.start_date && args?.end_date) {
+    return {
+      start: parseLocalYMD(args.start_date as string),
+      end: parseInclusiveEndDate(args.end_date as string),
+    };
+  }
+  return getDateRange('week');
 }
 
 async function resolveWorkspaceForTool(
@@ -337,6 +349,14 @@ const tools: Tool[] = [
           enum: ['json', 'text'],
           description: 'Output format (default: json)',
         },
+        uid: {
+          type: 'number',
+          description: 'Toggl uid to report on. When provided, uses the Reports API to fetch that workspace member\'s entries. Requires workspace_id.',
+        },
+        workspace_id: {
+          type: 'number',
+          description: 'Workspace ID. Required when uid is provided.',
+        },
       },
     },
   },
@@ -359,6 +379,15 @@ const tools: Tool[] = [
           type: 'string',
           enum: ['json', 'text'],
           description: 'Output format (default: json)',
+        },
+        uid: {
+          type: 'number',
+          description:
+            'Toggl uid to report on. When provided, uses the Reports API to fetch that workspace member\'s entries instead of the authenticated user\'s. Requires workspace_id.',
+        },
+        workspace_id: {
+          type: 'number',
+          description: 'Workspace ID. Required when uid is provided.',
         },
       },
     },
@@ -389,7 +418,11 @@ const tools: Tool[] = [
         },
         workspace_id: {
           type: 'number',
-          description: 'Filter by workspace ID',
+          description: 'Filter by workspace ID. Required when uid is provided.',
+        },
+        uid: {
+          type: 'number',
+          description: 'Toggl uid to report on. When provided, uses the Reports API to fetch that workspace member\'s entries. Requires workspace_id.',
         },
       },
     },
@@ -417,6 +450,14 @@ const tools: Tool[] = [
         end_date: {
           type: 'string',
           description: 'End date (YYYY-MM-DD format, inclusive, local timezone)',
+        },
+        workspace_id: {
+          type: 'number',
+          description: 'Workspace ID. Required when user_id is provided.',
+        },
+        uid: {
+          type: 'number',
+          description: 'Toggl uid to report on. When provided, uses the Reports API to fetch that workspace member\'s entries. Requires workspace_id.',
         },
       },
     },
@@ -471,6 +512,25 @@ const tools: Tool[] = [
           type: 'number',
           description:
             'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
+        },
+      },
+    },
+  },
+  {
+    name: 'toggl_list_workspace_users',
+    description: 'List all members of a workspace with their uid values. Use this to find uid values for filtering toggl_weekly_report, toggl_project_summary, and toggl_workspace_summary by a specific team member.',
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace.',
         },
       },
     },
@@ -789,7 +849,13 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         const nextDay = new Date(date);
         nextDay.setDate(nextDay.getDate() + 1);
 
-        const entries = await api.getTimeEntriesForDateRange(date, nextDay);
+        let entries;
+        if (args?.uid) {
+          const workspaceId = await resolveWorkspaceForTool(args, 'toggl_daily_report');
+          entries = await api.getTimeEntriesForUserAndDateRange(workspaceId, args.uid as number, date, nextDay);
+        } else {
+          entries = await api.getTimeEntriesForDateRange(date, nextDay);
+        }
         const hydrated = await cache.hydrateTimeEntries(entries);
 
         const report = generateDailyReport(toLocalYMD(date), hydrated);
@@ -819,10 +885,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         await ensureCache();
 
         const weekOffset = (args?.week_offset as number) || 0;
-        const entries = await api.getTimeEntriesForWeek(weekOffset);
-        const hydrated = await cache.hydrateTimeEntries(entries);
 
-        // Calculate week boundaries in local time.
+        // Calculate week boundaries in local time (needed for both paths).
         const today = new Date();
         today.setHours(0, 0, 0, 0);
         const dayOfWeek = today.getDay();
@@ -831,7 +895,18 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         monday.setDate(diff + weekOffset * 7);
         const sunday = new Date(monday);
         sunday.setDate(sunday.getDate() + 6);
+        const nextMonday = new Date(monday);
+        nextMonday.setDate(nextMonday.getDate() + 7);
 
+        let entries: TimeEntry[];
+        if (args?.uid) {
+          const workspaceId = await resolveWorkspaceForTool(args, 'toggl_weekly_report');
+          entries = await api.getTimeEntriesForUserAndDateRange(workspaceId, args.uid as number, monday, nextMonday);
+        } else {
+          entries = await api.getTimeEntriesForWeek(weekOffset);
+        }
+
+        const hydrated = await cache.hydrateTimeEntries(entries);
         const report = generateWeeklyReport(monday, sunday, hydrated);
 
         if (args?.format === 'text') {
@@ -858,22 +933,17 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case 'toggl_project_summary': {
         await ensureCache();
 
+        const range = resolveDateRange(args);
         let entries: TimeEntry[];
 
-        if (args?.period) {
-          const range = getDateRange(args.period as any);
-          entries = await api.getTimeEntriesForDateRange(range.start, range.end);
-        } else if (args?.start_date && args?.end_date) {
-          const start = parseLocalYMD(args.start_date as string);
-          const end = parseInclusiveEndDate(args.end_date as string);
-          entries = await api.getTimeEntriesForDateRange(start, end);
+        if (args?.uid) {
+          const workspaceId = await resolveWorkspaceForTool(args, 'toggl_project_summary');
+          entries = await api.getTimeEntriesForUserAndDateRange(workspaceId, args.uid as number, range.start, range.end);
         } else {
-          // Default to current week
-          entries = await api.getTimeEntriesForWeek(0);
-        }
-
-        if (args?.workspace_id) {
-          entries = entries.filter((e) => e.workspace_id === args.workspace_id);
+          entries = await api.getTimeEntriesForDateRange(range.start, range.end);
+          if (args?.workspace_id) {
+            entries = entries.filter((e) => e.workspace_id === args.workspace_id);
+          }
         }
 
         const hydrated = await cache.hydrateTimeEntries(entries);
@@ -908,18 +978,14 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       case 'toggl_workspace_summary': {
         await ensureCache();
 
+        const range = resolveDateRange(args);
         let entries: TimeEntry[];
 
-        if (args?.period) {
-          const range = getDateRange(args.period as any);
-          entries = await api.getTimeEntriesForDateRange(range.start, range.end);
-        } else if (args?.start_date && args?.end_date) {
-          const start = parseLocalYMD(args.start_date as string);
-          const end = parseInclusiveEndDate(args.end_date as string);
-          entries = await api.getTimeEntriesForDateRange(start, end);
+        if (args?.uid) {
+          const workspaceId = await resolveWorkspaceForTool(args, 'toggl_workspace_summary');
+          entries = await api.getTimeEntriesForUserAndDateRange(workspaceId, args.uid as number, range.start, range.end);
         } else {
-          // Default to current week
-          entries = await api.getTimeEntriesForWeek(0);
+          entries = await api.getTimeEntriesForDateRange(range.start, range.end);
         }
 
         const hydrated = await cache.hydrateTimeEntries(entries);
@@ -1025,6 +1091,34 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                     id: c.id,
                     name: c.name,
                     archived: c.archived,
+                  })),
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      }
+
+      case 'toggl_list_workspace_users': {
+        const workspaceId = await resolveWorkspaceForTool(args, 'listing workspace users');
+        const users = await api.getWorkspaceUsers(workspaceId);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  workspace_id: workspaceId,
+                  count: users.length,
+                  users: users.map((u) => ({
+                    uid: u.uid,
+                    name: u.name ?? u.fullname,
+                    email: u.email,
+                    active: u.active,
+                    admin: u.admin,
                   })),
                 },
                 null,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1113,13 +1113,9 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                 {
                   workspace_id: workspaceId,
                   count: users.length,
-                  users: users.map((u) => ({
-                    uid: u.uid,
-                    name: u.name ?? u.fullname,
-                    email: u.email,
-                    active: u.active,
-                    admin: u.admin,
-                  })),
+                  // Map to the privacy-safe {uid,name,active} shape. The mapper drops email,
+                  // admin/role, and any rate fields so they're never exposed by default.
+                  users: users.map(TogglAPI.toWorkspaceMemberSummary),
                 },
                 null,
                 2

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -1,4 +1,4 @@
-import fetch from 'node-fetch';
+import fetch, { type RequestInit, type Response } from 'node-fetch';
 import { toLocalYMD } from './utils.js';
 import type {
   Workspace,
@@ -6,6 +6,7 @@ import type {
   Client,
   Task,
   User,
+  WorkspaceUser,
   Tag,
   TimeEntry,
   TimeEntriesRequest,
@@ -68,29 +69,23 @@ export class TogglAPI {
     };
   }
 
-  // Generic API request method
-  private async request<T>(method: string, endpoint: string, body?: any, retries = 3): Promise<T> {
-    const url = `${this.baseUrl}${endpoint}`;
-
+  // Shared fetch loop: handles 429 rate-limit backoff, 5xx retry, and network errors.
+  // Returns the raw Response (including 4xx) so callers can produce context-specific errors.
+  private async fetchWithRetry(url: string, init: RequestInit, retries = 3): Promise<Response> {
     for (let i = 0; i < retries; i++) {
       try {
-        const response = await fetch(url, {
-          method,
-          headers: this.headers,
-          body: body ? JSON.stringify(body) : undefined,
-        });
+        const response = await fetch(url, init);
 
-        // Handle rate limiting without sleeping for multi-minute quota resets.
         if (response.status === 429) {
           const retryAfterSeconds = parseRetryAfterSeconds(response.headers.get('Retry-After'));
-          const delay = retryAfterSeconds !== undefined ? retryAfterSeconds * 1000 : (i + 1) * 2000;
+          const delay =
+            retryAfterSeconds !== undefined ? retryAfterSeconds * 1000 : (i + 1) * 2000;
           if (delay <= MAX_AUTO_RETRY_MS && i < retries - 1) {
             // Log to stderr so we don't pollute MCP stdio
             console.error(`Rate limited. Retrying after ${delay}ms...`);
             await new Promise((resolve) => setTimeout(resolve, delay));
             continue;
           }
-
           throw new TogglAPIError({
             status: response.status,
             code: 'RATE_LIMITED',
@@ -100,47 +95,55 @@ export class TogglAPI {
           });
         }
 
-        if (!response.ok) {
-          const text = await response.text();
-          if (response.status === 402) {
-            const retryAfterSeconds = parseQuotaResetSeconds(text);
-            throw new TogglAPIError({
-              status: response.status,
-              code: 'TOGGL_QUOTA_LIMIT',
-              message: `Toggl API quota limit reached.${retryAfterSeconds !== undefined ? ` Quota resets in ${retryAfterSeconds} seconds.` : ''}`,
-              retryAfterSeconds,
-              tip: 'Wait for the Toggl quota window to reset. Cache-backed list tools avoid repeated project/client fetches after they are warmed.',
-            });
-          }
-
-          const isAuth = response.status === 401 || response.status === 403;
-          const message = isAuth
-            ? `Authentication failed (${response.status}). ` +
-              `Verify TOGGL_API_KEY is correct, has no leading/trailing spaces, and is the Toggl Track API token. ` +
-              `Server response: ${text}`
-            : `Toggl API error (${response.status}): ${text}`;
-          const err = new Error(message);
-          // 4xx client errors won't succeed on retry (incl. 401/403); 5xx and network errors do retry.
-          if (response.status >= 400 && response.status < 500) {
-            Object.assign(err, { noRetry: true });
-          }
-          throw err;
+        // Retry on server errors; return everything else (including 4xx) to the caller.
+        if (response.status >= 500 && i < retries - 1) {
+          await new Promise((resolve) => setTimeout(resolve, (i + 1) * 1000));
+          continue;
         }
 
-        // Handle 204 No Content
-        if (response.status === 204) {
-          return {} as T;
-        }
-
-        return (await response.json()) as T;
+        return response;
       } catch (error: any) {
         if (error?.noRetry || i === retries - 1) throw error;
-        // Exponential backoff for transient/network errors
+        // Exponential backoff for transient network errors
         await new Promise((resolve) => setTimeout(resolve, (i + 1) * 1000));
       }
     }
 
     throw new Error('Max retries reached');
+  }
+
+  private async request<T>(method: string, endpoint: string, body?: any, retries = 3): Promise<T> {
+    const url = `${this.baseUrl}${endpoint}`;
+    const response = await this.fetchWithRetry(
+      url,
+      { method, headers: this.headers, body: body ? JSON.stringify(body) : undefined },
+      retries
+    );
+
+    if (response.status === 204) return {} as T;
+
+    if (!response.ok) {
+      const text = await response.text();
+      if (response.status === 402) {
+        const retryAfterSeconds = parseQuotaResetSeconds(text);
+        throw new TogglAPIError({
+          status: response.status,
+          code: 'TOGGL_QUOTA_LIMIT',
+          message: `Toggl API quota limit reached.${retryAfterSeconds !== undefined ? ` Quota resets in ${retryAfterSeconds} seconds.` : ''}`,
+          retryAfterSeconds,
+          tip: 'Wait for the Toggl quota window to reset. Cache-backed list tools avoid repeated project/client fetches after they are warmed.',
+        });
+      }
+      const isAuth = response.status === 401 || response.status === 403;
+      const message = isAuth
+        ? `Authentication failed (${response.status}). ` +
+          `Verify TOGGL_API_KEY is correct, has no leading/trailing spaces, and is the Toggl Track API token. ` +
+          `Server response: ${text}`
+        : `Toggl API error (${response.status}): ${text}`;
+      throw new Error(message);
+    }
+
+    return (await response.json()) as T;
   }
 
   // User methods
@@ -160,6 +163,106 @@ export class TogglAPI {
 
   async getWorkspace(workspaceId: number): Promise<Workspace> {
     return this.request<Workspace>('GET', `/workspaces/${workspaceId}`);
+  }
+
+  async getWorkspaceUsers(workspaceId: number): Promise<WorkspaceUser[]> {
+    return this.request<WorkspaceUser[]>('GET', `/workspaces/${workspaceId}/workspace_users`);
+  }
+
+  private async reportsRequest<T>(
+    workspaceId: number,
+    endpoint: string,
+    body: Record<string, unknown>,
+    retries = 3
+  ): Promise<{ data: T; nextRowNumber?: number }> {
+    const url = `https://api.track.toggl.com/reports/api/v3/workspace/${workspaceId}${endpoint}`;
+    const response = await this.fetchWithRetry(
+      url,
+      { method: 'POST', headers: this.headers, body: JSON.stringify(body) },
+      retries
+    );
+
+    if (!response.ok) {
+      const text = await response.text();
+      if (response.status === 402) {
+        const retryAfterSeconds = parseQuotaResetSeconds(text);
+        throw new TogglAPIError({
+          status: response.status,
+          code: 'TOGGL_QUOTA_LIMIT',
+          message: `Toggl Reports API quota limit reached.${retryAfterSeconds !== undefined ? ` Quota resets in ${retryAfterSeconds} seconds.` : ''}`,
+          retryAfterSeconds,
+          tip: 'Wait for the Toggl quota window to reset, or use a narrower date range to reduce API usage.',
+        });
+      }
+      throw new Error(`Reports API error (${response.status}): ${text}`);
+    }
+
+    const nextHeader = response.headers.get('X-Next-Row-Number');
+    const nextRowNumber = nextHeader ? Number.parseInt(nextHeader, 10) : undefined;
+    return { data: (await response.json()) as T, nextRowNumber };
+  }
+
+  // endDate is exclusive, matching the convention used by all other date-range methods.
+  // The Reports API uses inclusive end dates; conversion happens internally.
+  async getTimeEntriesForUserAndDateRange(
+    workspaceId: number,
+    userId: number,
+    startDate: Date,
+    endDate: Date
+  ): Promise<TimeEntry[]> {
+    // Convert exclusive end to inclusive for the Reports API.
+    const inclusiveEnd = new Date(endDate);
+    inclusiveEnd.setDate(inclusiveEnd.getDate() - 1);
+    type ReportRow = {
+      user_id: number;
+      project_id: number | null;
+      task_id: number | null;
+      billable: boolean;
+      description: string;
+      tag_ids: number[];
+      time_entries: Array<{ id: number; seconds: number; start: string; stop: string }>;
+    };
+
+    const allEntries: TimeEntry[] = [];
+    let firstRowNumber = 1;
+
+    while (true) {
+      const { data: rows, nextRowNumber } = await this.reportsRequest<ReportRow[]>(
+        workspaceId,
+        '/search/time_entries',
+        {
+          user_ids: [userId],
+          start_date: toLocalYMD(startDate),
+          end_date: toLocalYMD(inclusiveEnd),
+          first_row_number: firstRowNumber,
+        }
+      );
+
+      // Flatten grouped rows into individual TimeEntry objects.
+      for (const row of rows) {
+        for (const te of row.time_entries) {
+          allEntries.push({
+            id: te.id,
+            workspace_id: workspaceId,
+            project_id: row.project_id ?? undefined,
+            task_id: row.task_id ?? undefined,
+            billable: row.billable,
+            start: te.start,
+            stop: te.stop,
+            duration: te.seconds,
+            description: row.description,
+            tag_ids: row.tag_ids,
+            tags: [],
+            user_id: row.user_id,
+          });
+        }
+      }
+
+      if (!nextRowNumber || rows.length === 0) break;
+      firstRowNumber = nextRowNumber;
+    }
+
+    return allEntries;
   }
 
   // Project methods
@@ -346,25 +449,6 @@ export class TogglAPI {
     const firstDayNextMonth = new Date(year, month + 1, 1);
 
     return this.getTimeEntriesForDateRange(firstDay, firstDayNextMonth);
-  }
-
-  // Reports API endpoints (if needed)
-  async getDetailedReport(workspaceId: number, params: any): Promise<any> {
-    // This would use the Reports API v3 if needed
-    // https://api.track.toggl.com/reports/api/v3/workspace/{workspace_id}/search/time_entries
-    const reportsUrl = `https://api.track.toggl.com/reports/api/v3/workspace/${workspaceId}/search/time_entries`;
-
-    const response = await fetch(reportsUrl, {
-      method: 'POST',
-      headers: this.headers,
-      body: JSON.stringify(params),
-    });
-
-    if (!response.ok) {
-      throw new Error(`Reports API error: ${response.status}`);
-    }
-
-    return response.json();
   }
 
   async getTimeline(): Promise<TimelineEvent[]> {

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -7,6 +7,7 @@ import type {
   Task,
   User,
   WorkspaceUser,
+  WorkspaceMemberSummary,
   Tag,
   TimeEntry,
   TimeEntriesRequest,
@@ -166,7 +167,20 @@ export class TogglAPI {
   }
 
   async getWorkspaceUsers(workspaceId: number): Promise<WorkspaceUser[]> {
-    return this.request<WorkspaceUser[]>('GET', `/workspaces/${workspaceId}/workspace_users`);
+    // Documented Toggl v9 endpoint "Get workspace users". Each item's user id is the `id`
+    // field (the docs call it the "Global user identifier") — there is no `uid` here.
+    // Membership status is `is_active`. The endpoint also returns `email`, `is_admin`, and
+    // `role`, which toWorkspaceMemberSummary() strips before the tool returns them.
+    // Chosen over /workspace_users: the only documented `workspace_users` GET is org-scoped
+    // (/organizations/{org}/workspaces/{ws}/workspace_users), which we don't have an org id
+    // for; the non-org /workspace_users path is undocumented in v9.
+    return this.request<WorkspaceUser[]>('GET', `/workspaces/${workspaceId}/users`);
+  }
+
+  // Maps a raw /users record to the privacy-safe shape the tool exposes. Kept as a standalone
+  // pure function so the "no email/admin/role leaks" guarantee is directly unit-testable.
+  static toWorkspaceMemberSummary(raw: WorkspaceUser): WorkspaceMemberSummary {
+    return { uid: raw.id as number, name: raw.fullname as string, active: raw.is_active as boolean };
   }
 
   private async reportsRequest<T>(
@@ -213,6 +227,11 @@ export class TogglAPI {
     // Convert exclusive end to inclusive for the Reports API.
     const inclusiveEnd = new Date(endDate);
     inclusiveEnd.setDate(inclusiveEnd.getDate() - 1);
+    // A row from /search/time_entries. In practice each row wraps its entries in a nested
+    // `time_entries` array, but the v9 docs don't publish this endpoint's response schema
+    // (the 200 is only labelled "Returns grouped time entries"), so we also tolerate a row
+    // that carries the entry fields directly — see the defensive flatten below.
+    type ReportEntry = { id: number; seconds: number; start: string; stop: string };
     type ReportRow = {
       user_id: number;
       project_id: number | null;
@@ -220,8 +239,8 @@ export class TogglAPI {
       billable: boolean;
       description: string;
       tag_ids: number[];
-      time_entries: Array<{ id: number; seconds: number; start: string; stop: string }>;
-    };
+      time_entries?: ReportEntry[];
+    } & Partial<ReportEntry>;
 
     const allEntries: TimeEntry[] = [];
     let firstRowNumber = 1;
@@ -235,12 +254,21 @@ export class TogglAPI {
           start_date: toLocalYMD(startDate),
           end_date: toLocalYMD(inclusiveEnd),
           first_row_number: firstRowNumber,
+          // `grouped` is intentionally not sent: the docs confirm it defaults to false and it
+          // only affects description-filtered queries (which this one isn't), so it has no
+          // effect here.
         }
       );
 
-      // Flatten grouped rows into individual TimeEntry objects.
+      // Flatten each row into individual TimeEntry objects. The response shape is undocumented,
+      // so be defensive: if a row nests its entries under `time_entries`, use those; otherwise
+      // treat the row itself as a single entry.
       for (const row of rows) {
-        for (const te of row.time_entries) {
+        const entries: ReportEntry[] =
+          Array.isArray(row.time_entries) && row.time_entries.length > 0
+            ? row.time_entries
+            : [{ id: row.id as number, seconds: row.seconds as number, start: row.start as string, stop: row.stop as string }];
+        for (const te of entries) {
           allEntries.push({
             id: te.id,
             workspace_id: workspaceId,

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,6 +97,18 @@ export interface User {
   updated_at?: string;
 }
 
+export interface WorkspaceUser {
+  id: number;
+  uid: number;
+  workspace_id: number;
+  email?: string;
+  name?: string;
+  fullname?: string;
+  active?: boolean;
+  admin?: boolean;
+  at?: string;
+}
+
 export interface Tag {
   id: number;
   workspace_id: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,16 +97,29 @@ export interface User {
   updated_at?: string;
 }
 
+// Item shape of the documented Toggl v9 "Get workspace users" endpoint
+// (GET /workspaces/{id}/users). `id` is the global user identifier (there is no `uid`);
+// membership status is `is_active` (with `inactive` as its inverse). `email`, `is_admin`,
+// and `role` are returned by the API but stripped before the tool exposes them — see
+// TogglAPI.toWorkspaceMemberSummary. Fields are optional to tolerate API additions.
 export interface WorkspaceUser {
-  id: number;
-  uid: number;
-  workspace_id: number;
+  id?: number;
   email?: string;
-  name?: string;
   fullname?: string;
-  active?: boolean;
-  admin?: boolean;
+  is_active?: boolean;
+  inactive?: boolean;
+  is_admin?: boolean;
+  role?: string;
   at?: string;
+}
+
+// Privacy-safe view of a workspace member returned by the toggl_list_workspace_users tool:
+// just enough to identify a member and feed the report tools' `uid` filter. Deliberately
+// excludes email, admin/role, and any rate/billing fields.
+export interface WorkspaceMemberSummary {
+  uid: number;
+  name: string;
+  active: boolean;
 }
 
 export interface Tag {

--- a/tests/toggl-api.test.ts
+++ b/tests/toggl-api.test.ts
@@ -104,13 +104,13 @@ describe('getWorkspaceUsers', () => {
     fetchMock.mockReset();
   });
 
-  it('fetches from the workspace_users endpoint', async () => {
+  it('fetches from the documented /users endpoint and returns the raw records', async () => {
     fetchMock.mockResolvedValue(
       response({
         status: 200,
         json: [
-          { id: 1, uid: TEST_USER_ID, workspace_id: TEST_WORKSPACE_ID, name: 'Alice', email: 'alice@example.com', active: true, admin: false },
-          { id: 2, uid: TEST_USER_ID + 1, workspace_id: TEST_WORKSPACE_ID, name: 'Bob', email: 'bob@example.com', active: true, admin: true },
+          { id: TEST_USER_ID, fullname: 'Alice', email: 'alice@example.com', is_active: true, inactive: false, is_admin: false, role: 'admin' },
+          { id: TEST_USER_ID + 1, fullname: 'Bob', email: 'bob@example.com', is_active: true, inactive: false, is_admin: true, role: 'admin' },
         ],
       })
     );
@@ -119,11 +119,43 @@ describe('getWorkspaceUsers', () => {
     const users = await api.getWorkspaceUsers(TEST_WORKSPACE_ID);
 
     expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringContaining(`/workspaces/${TEST_WORKSPACE_ID}/workspace_users`),
+      expect.stringContaining(`/workspaces/${TEST_WORKSPACE_ID}/users`),
       expect.any(Object)
     );
     expect(users).toHaveLength(2);
-    expect(users[0]).toMatchObject({ uid: TEST_USER_ID, name: 'Alice' });
+    expect(users[0]).toMatchObject({ id: TEST_USER_ID, fullname: 'Alice' });
+  });
+});
+
+describe('toWorkspaceMemberSummary', () => {
+  it('maps id/fullname/is_active to uid/name/active', () => {
+    const summary = TogglAPI.toWorkspaceMemberSummary({
+      id: TEST_USER_ID,
+      fullname: 'Alice',
+      is_active: true,
+    });
+
+    expect(summary).toEqual({ uid: TEST_USER_ID, name: 'Alice', active: true });
+  });
+
+  it('exposes only uid/name/active and drops email, admin, role, and rates', () => {
+    const summary = TogglAPI.toWorkspaceMemberSummary({
+      id: TEST_USER_ID,
+      fullname: 'Alice',
+      is_active: true,
+      email: 'alice@example.com',
+      is_admin: true,
+      role: 'admin',
+      // fields the /workspace_users endpoint can carry; must never leak through this mapper
+      ...({ rate: 99, labor_cost: 50, invite_url: 'https://secret' } as Record<string, unknown>),
+    });
+
+    expect(Object.keys(summary).sort()).toEqual(['active', 'name', 'uid']);
+    expect(summary).not.toHaveProperty('email');
+    expect(summary).not.toHaveProperty('is_admin');
+    expect(summary).not.toHaveProperty('role');
+    expect(summary).not.toHaveProperty('rate');
+    expect(summary).not.toHaveProperty('labor_cost');
   });
 });
 
@@ -177,6 +209,42 @@ describe('getTimeEntriesForUserAndDateRange', () => {
       billable: false,
     });
     expect(entries[1]).toMatchObject({ id: 1002, duration: 1800, billable: true });
+  });
+
+  it('handles a flat row that carries entry fields directly (no nested time_entries)', async () => {
+    // The v3 response body schema is undocumented; defend against a row that is itself a single
+    // entry rather than a group wrapping a time_entries array.
+    fetchMock.mockResolvedValue(response({
+      status: 200,
+      json: [
+        {
+          user_id: TEST_USER_ID,
+          project_id: TEST_PROJECT_ID,
+          task_id: null,
+          billable: true,
+          description: 'flat entry',
+          tag_ids: [],
+          id: 2001,
+          seconds: 1200,
+          start: '2026-05-04T09:00:00+00:00',
+          stop: '2026-05-04T09:20:00+00:00',
+        },
+      ],
+    }));
+
+    const api = new TogglAPI('token');
+    const entries = await api.getTimeEntriesForUserAndDateRange(TEST_WORKSPACE_ID, TEST_USER_ID, new Date(2026, 4, 4), new Date(2026, 4, 11));
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      id: 2001,
+      workspace_id: TEST_WORKSPACE_ID,
+      project_id: TEST_PROJECT_ID,
+      duration: 1200,
+      description: 'flat entry',
+      user_id: TEST_USER_ID,
+      billable: true,
+    });
   });
 
   it('fetches multiple pages until X-Next-Row-Number header is absent', async () => {

--- a/tests/toggl-api.test.ts
+++ b/tests/toggl-api.test.ts
@@ -14,20 +14,45 @@ function response({
   text = '',
   json,
   retryAfter,
+  headers: extraHeaders = {},
 }: {
   status: number;
   text?: string;
   json?: unknown;
   retryAfter?: string;
+  headers?: Record<string, string | undefined>;
 }) {
+  const allHeaders: Record<string, string | undefined> = {
+    'retry-after': retryAfter,
+    ...extraHeaders,
+  };
   return {
     status,
     ok: status >= 200 && status < 300,
     headers: {
-      get: vi.fn((name: string) => (name.toLowerCase() === 'retry-after' ? retryAfter : null)),
+      get: vi.fn((name: string) => allHeaders[name.toLowerCase()] ?? null),
     },
     text: vi.fn(async () => text),
     json: vi.fn(async () => json),
+  };
+}
+
+const TEST_WORKSPACE_ID = 111;
+const TEST_USER_ID = 222;
+const TEST_PROJECT_ID = 333;
+
+function reportRow(overrides: Record<string, unknown> = {}) {
+  return {
+    user_id: TEST_USER_ID,
+    project_id: TEST_PROJECT_ID,
+    task_id: null,
+    billable: false,
+    description: 'test entry',
+    tag_ids: [],
+    time_entries: [
+      { id: 1001, seconds: 3600, start: '2026-05-04T10:00:00+00:00', stop: '2026-05-04T11:00:00+00:00' },
+    ],
+    ...overrides,
   };
 }
 
@@ -63,5 +88,131 @@ describe('toggl api errors', () => {
       retry_after_seconds: 60,
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries 5xx server errors and eventually throws', async () => {
+    fetchMock.mockResolvedValue(response({ status: 500, text: 'Internal Server Error' }));
+
+    const api = new TogglAPI('token');
+    await expect(api.getWorkspaces()).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(3); // default retries = 3
+  });
+});
+
+describe('getWorkspaceUsers', () => {
+  afterEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it('fetches from the workspace_users endpoint', async () => {
+    fetchMock.mockResolvedValue(
+      response({
+        status: 200,
+        json: [
+          { id: 1, uid: TEST_USER_ID, workspace_id: TEST_WORKSPACE_ID, name: 'Alice', email: 'alice@example.com', active: true, admin: false },
+          { id: 2, uid: TEST_USER_ID + 1, workspace_id: TEST_WORKSPACE_ID, name: 'Bob', email: 'bob@example.com', active: true, admin: true },
+        ],
+      })
+    );
+
+    const api = new TogglAPI('token');
+    const users = await api.getWorkspaceUsers(TEST_WORKSPACE_ID);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining(`/workspaces/${TEST_WORKSPACE_ID}/workspace_users`),
+      expect.any(Object)
+    );
+    expect(users).toHaveLength(2);
+    expect(users[0]).toMatchObject({ uid: TEST_USER_ID, name: 'Alice' });
+  });
+});
+
+describe('getTimeEntriesForUserAndDateRange', () => {
+  afterEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it('converts exclusive end date to inclusive before calling the Reports API', async () => {
+    fetchMock.mockResolvedValue(response({ status: 200, json: [] }));
+
+    const api = new TogglAPI('token');
+    // May 4 → May 11 exclusive (one full week)
+    await api.getTimeEntriesForUserAndDateRange(TEST_WORKSPACE_ID, TEST_USER_ID, new Date(2026, 4, 4), new Date(2026, 4, 11));
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body.start_date).toBe('2026-05-04');
+    expect(body.end_date).toBe('2026-05-10'); // May 11 - 1 day = May 10 inclusive
+  });
+
+  it('sends user_ids (Reports API field) as an array containing the requested uid', async () => {
+    fetchMock.mockResolvedValue(response({ status: 200, json: [] }));
+
+    const api = new TogglAPI('token');
+    await api.getTimeEntriesForUserAndDateRange(TEST_WORKSPACE_ID, TEST_USER_ID, new Date(2026, 4, 4), new Date(2026, 4, 11));
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body.user_ids).toEqual([TEST_USER_ID]);
+  });
+
+  it('flattens grouped report rows into individual TimeEntry objects, preserving all fields', async () => {
+    fetchMock.mockResolvedValue(response({
+      status: 200,
+      json: [
+        reportRow({ billable: false }),
+        reportRow({ billable: true, time_entries: [{ id: 1002, seconds: 1800, start: '2026-05-04T11:00:00+00:00', stop: '2026-05-04T11:30:00+00:00' }] }),
+      ],
+    }));
+
+    const api = new TogglAPI('token');
+    const entries = await api.getTimeEntriesForUserAndDateRange(TEST_WORKSPACE_ID, TEST_USER_ID, new Date(2026, 4, 4), new Date(2026, 4, 11));
+
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({
+      id: 1001,
+      workspace_id: TEST_WORKSPACE_ID,
+      project_id: TEST_PROJECT_ID,
+      duration: 3600,
+      description: 'test entry',
+      user_id: TEST_USER_ID,
+      billable: false,
+    });
+    expect(entries[1]).toMatchObject({ id: 1002, duration: 1800, billable: true });
+  });
+
+  it('fetches multiple pages until X-Next-Row-Number header is absent', async () => {
+    fetchMock
+      .mockResolvedValueOnce(response({
+        status: 200,
+        json: [reportRow({ time_entries: [{ id: 1, seconds: 100, start: '2026-05-04T10:00:00+12:00', stop: '2026-05-04T10:01:40+12:00' }] })],
+        headers: { 'x-next-row-number': '2' },
+      }))
+      .mockResolvedValueOnce(response({
+        status: 200,
+        json: [reportRow({ time_entries: [{ id: 2, seconds: 200, start: '2026-05-05T10:00:00+12:00', stop: '2026-05-05T10:03:20+12:00' }] })],
+      }));
+
+    const api = new TogglAPI('token');
+    const entries = await api.getTimeEntriesForUserAndDateRange(TEST_WORKSPACE_ID, TEST_USER_ID, new Date(2026, 4, 4), new Date(2026, 4, 11));
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(entries.map((e) => e.id)).toEqual([1, 2]);
+    const secondBody = JSON.parse(fetchMock.mock.calls[1][1].body as string);
+    expect(secondBody.first_row_number).toBe(2);
+  });
+
+  it('throws a quota error with a tip for 402 Reports API responses', async () => {
+    fetchMock.mockResolvedValue(
+      response({ status: 402, text: 'The quota will reset in 300 seconds.' })
+    );
+
+    const api = new TogglAPI('token');
+    await expect(
+      api.getTimeEntriesForUserAndDateRange(TEST_WORKSPACE_ID, TEST_USER_ID, new Date(2026, 4, 4), new Date(2026, 4, 11))
+    ).rejects.toMatchObject({
+      code: 'TOGGL_QUOTA_LIMIT',
+      status: 402,
+      retry_after_seconds: 300,
+      tip: expect.stringContaining('quota'),
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Adds **`toggl_list_workspace_users`** — lists all members of a workspace with their `uid` values
- Extends all four report tools (**`toggl_daily_report`**, **`toggl_weekly_report`**, **`toggl_project_summary`**, **`toggl_workspace_summary`**) with optional `uid` + `workspace_id` parameters that route through the Reports API v3 to fetch a specific team member's entries instead of the authenticated user's
- Refactors the duplicated retry/rate-limit loop into a shared `fetchWithRetry()` private method used by both `request()` and the new `reportsRequest()` helper, and removes the unused `getDetailedReport()` stub
- Extracts `resolveDateRange()` to eliminate repeated date-range logic across the four report handlers

## How it works

When `uid` is omitted the existing code path is unchanged — no extra API calls, no performance impact. When `uid` is provided, the Reports API v3 (`/search/time_entries`) is used with `user_ids` filtering and automatic cursor-based pagination via the `X-Next-Row-Number` response header.

The Reports API returns grouped rows with nested `time_entries` arrays; these are flattened into the same `TimeEntry` shape the rest of the codebase uses, so hydration and report generation work without modification. The Reports API uses inclusive end dates — conversion from the codebase's exclusive-end convention happens inside `getTimeEntriesForUserAndDateRange()`.

## Test plan

- [ ] `npm test` — all 37 tests pass
- [ ] `toggl_list_workspace_users` returns workspace members with `uid` values
- [ ] `toggl_daily_report` / `toggl_weekly_report` with `uid` returns correct entries for that member
- [ ] All report tools without `uid` behave identically to before

🤖 Generated with [Claude Code](https://claude.ai/claude-code)