### PR TITLE
feat: add --http flag for native Streamable HTTP transport

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "dotenv": "^17.4.2",
+        "express": "^5.2.1",
         "node-fetch": "^3.3.2",
         "zod": "^4.3.6"
       },
@@ -19,6 +20,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@types/express": "^5.0.6",
         "@types/node": "^25.6.0",
         "@vitest/coverage-v8": "^4.1.5",
         "eslint": "^10.2.1",
@@ -1163,6 +1165,17 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -1172,6 +1185,16 @@
       "dependencies": {
         "@types/deep-eql": "*",
         "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/deep-eql": {
@@ -1195,6 +1218,38 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/express": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.6.tgz",
+      "integrity": "sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/serve-static": "^2"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1210,6 +1265,41 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-2.2.0.tgz",
+      "integrity": "sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -54,11 +54,13 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "dotenv": "^17.4.2",
+    "express": "^5.2.1",
     "node-fetch": "^3.3.2",
     "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@types/express": "^5.0.6",
     "@types/node": "^25.6.0",
     "@vitest/coverage-v8": "^4.1.5",
     "eslint": "^10.2.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -186,18 +186,24 @@ async function resolveWorkspaceForTool(
   });
 }
 
-// Create MCP server
-const server = new Server(
-  {
-    name: 'mcp-toggl',
-    version: VERSION,
-  },
-  {
-    capabilities: {
-      tools: {},
-    },
-  }
-);
+// Build a fresh Server with all request handlers registered. The MCP SDK's
+// Protocol.connect() throws if called twice on the same instance while a
+// transport is still attached, so HTTP mode creates one Server per request
+// rather than sharing this instance across concurrent connections.
+function createServer(): Server {
+  const s = new Server(
+    { name: 'mcp-toggl', version: VERSION },
+    { capabilities: { tools: {} } }
+  );
+
+  s.setRequestHandler(ListToolsRequestSchema, async () => {
+    return { tools };
+  });
+
+  s.setRequestHandler(CallToolRequestSchema, callToolHandler);
+
+  return s;
+}
 
 // Define tool schemas
 const tools: Tool[] = [
@@ -579,13 +585,9 @@ const tools: Tool[] = [
   },
 ];
 
-// Handle tool listing
-server.setRequestHandler(ListToolsRequestSchema, async () => {
-  return { tools };
-});
-
-// Handle tool calls
-server.setRequestHandler(CallToolRequestSchema, async (request) => {
+// Handle tool calls. Defined at module scope so a fresh Server instance
+// can be wired up per request in HTTP mode without rebuilding closures.
+const callToolHandler = async (request: { params: { name: string; arguments?: Record<string, unknown> } }) => {
   const { name, arguments: args } = request.params;
 
   try {
@@ -1138,7 +1140,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   } catch (error: unknown) {
     return jsonResponse(errorPayload(error));
   }
-});
+};
 
 // Pick transport based on --http flag.
 //   --http               → all interfaces, port 8099
@@ -1153,36 +1155,84 @@ function parseHttpArg(args: string[]): { host: string; port: number } | null {
   } else if (idx + 1 < args.length && !args[idx + 1].startsWith('--')) {
     raw = args[idx + 1];
   }
-  if (!raw) return { host: '0.0.0.0', port: 8099 };
-  if (raw.includes(':')) {
-    const [h, p] = raw.split(':');
-    return { host: h || '0.0.0.0', port: parseInt(p, 10) || 8099 };
+  if (!raw) return { host: DEFAULT_HTTP_HOST, port: DEFAULT_HTTP_PORT };
+  return parseHostPort(raw);
+}
+
+const DEFAULT_HTTP_HOST = '127.0.0.1';
+const DEFAULT_HTTP_PORT = 8099;
+
+function parseHostPort(raw: string): { host: string; port: number } {
+  // Bracketed IPv6: [::1]:8099
+  const bracketed = raw.match(/^\[([^\]]+)\](?::(\d+))?$/);
+  if (bracketed) {
+    return { host: bracketed[1], port: parseIntOrDefault(bracketed[2], DEFAULT_HTTP_PORT) };
   }
-  return { host: '0.0.0.0', port: parseInt(raw, 10) || 8099 };
+  // No colon → port-only
+  if (!raw.includes(':')) {
+    return { host: DEFAULT_HTTP_HOST, port: parseIntOrDefault(raw, DEFAULT_HTTP_PORT) };
+  }
+  // Single colon → host:port
+  const lastColon = raw.lastIndexOf(':');
+  if (raw.indexOf(':') === lastColon) {
+    return {
+      host: raw.slice(0, lastColon) || DEFAULT_HTTP_HOST,
+      port: parseIntOrDefault(raw.slice(lastColon + 1), DEFAULT_HTTP_PORT),
+    };
+  }
+  // Multiple colons unbracketed → ambiguous, treat as bare IPv6 host
+  return { host: raw, port: DEFAULT_HTTP_PORT };
+}
+
+function parseIntOrDefault(s: string | undefined, fallback: number): number {
+  if (s === undefined || s === '') return fallback;
+  const n = Number.parseInt(s, 10);
+  return Number.isNaN(n) ? fallback : n;
 }
 
 async function runStdio() {
+  const s = createServer();
   const transport = new StdioServerTransport();
-  await server.connect(transport);
+  await s.connect(transport);
   console.error('Toggl MCP server running (stdio)');
 }
 
 async function runHttp(host: string, port: number) {
-  // Stateless: each request creates a fresh transport. Toggl tool calls all
-  // go to the upstream Toggl API, so there is no session state to keep, and
-  // a per-request transport keeps the server self-contained behind a proxy.
+  // Stateless: each request gets its own Server + transport. Protocol.connect
+  // throws on a second connect against the same Server while another
+  // transport is still attached, so sharing the instance would race under
+  // concurrent requests.
   const app = express();
   app.use(express.json({ limit: '4mb' }));
 
+  // Convert express.json() body-parse failures into JSON-RPC parse errors so
+  // MCP clients see a structured response instead of the default Express
+  // HTML page.
+  app.use(
+    (err: unknown, _req: express.Request, res: express.Response, next: express.NextFunction) => {
+      if (err instanceof SyntaxError && 'body' in (err as object) && !res.headersSent) {
+        res.status(400).json({
+          jsonrpc: '2.0',
+          error: { code: -32700, message: 'Parse error' },
+          id: null,
+        });
+        return;
+      }
+      next(err);
+    }
+  );
+
   const handle = async (req: express.Request, res: express.Response) => {
+    const s = createServer();
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+    });
+    res.on('close', () => {
+      transport.close();
+      s.close().catch(() => {});
+    });
     try {
-      const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: undefined,
-      });
-      res.on('close', () => {
-        transport.close();
-      });
-      await server.connect(transport);
+      await s.connect(transport);
       await transport.handleRequest(req, res, req.body);
     } catch (err) {
       console.error('HTTP handler error:', err);

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,10 +156,14 @@ cache.setAPI(api);
 
 // Track if cache has been warmed
 let cacheWarmed = false;
+// In-flight warm-up so concurrent first requests share one sweep against
+// the Toggl API instead of each firing a duplicate.
+let warmPromise: Promise<void> | null = null;
 
-// Helper to ensure cache is warm
 async function ensureCache(): Promise<void> {
-  if (!cacheWarmed) {
+  if (cacheWarmed) return;
+  if (warmPromise) return warmPromise;
+  warmPromise = (async () => {
     try {
       const workspaces = await cache.getWorkspaces();
       const singleWorkspaceId = workspaces.length === 1 ? workspaces[0]!.id : undefined;
@@ -170,8 +174,11 @@ async function ensureCache(): Promise<void> {
       cacheWarmed = true;
     } catch (error) {
       console.error('Failed to warm cache:', error);
+    } finally {
+      warmPromise = null;
     }
-  }
+  })();
+  return warmPromise;
 }
 
 async function resolveWorkspaceForTool(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
   Tool,
 } from '@modelcontextprotocol/sdk/types.js';
+import express from 'express';
 import { config } from 'dotenv';
 import { TogglAPI, TimelineNotEnabledError, TogglAPIError } from './toggl-api.js';
 import { buildTimelineResponse } from './timeline.js';
@@ -1138,11 +1140,82 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   }
 });
 
-// Start the server
-async function main() {
+// Pick transport based on --http flag.
+//   --http               → all interfaces, port 8099
+//   --http :8099         → all interfaces, explicit port
+//   --http 0.0.0.0:8099  → explicit host and port
+function parseHttpArg(args: string[]): { host: string; port: number } | null {
+  const idx = args.findIndex((a) => a === '--http' || a.startsWith('--http='));
+  if (idx === -1) return null;
+  let raw: string | undefined;
+  if (args[idx].startsWith('--http=')) {
+    raw = args[idx].slice('--http='.length);
+  } else if (idx + 1 < args.length && !args[idx + 1].startsWith('--')) {
+    raw = args[idx + 1];
+  }
+  if (!raw) return { host: '0.0.0.0', port: 8099 };
+  if (raw.includes(':')) {
+    const [h, p] = raw.split(':');
+    return { host: h || '0.0.0.0', port: parseInt(p, 10) || 8099 };
+  }
+  return { host: '0.0.0.0', port: parseInt(raw, 10) || 8099 };
+}
+
+async function runStdio() {
   const transport = new StdioServerTransport();
   await server.connect(transport);
-  console.error('Toggl MCP server running');
+  console.error('Toggl MCP server running (stdio)');
+}
+
+async function runHttp(host: string, port: number) {
+  // Stateless: each request creates a fresh transport. Toggl tool calls all
+  // go to the upstream Toggl API, so there is no session state to keep, and
+  // a per-request transport keeps the server self-contained behind a proxy.
+  const app = express();
+  app.use(express.json({ limit: '4mb' }));
+
+  const handle = async (req: express.Request, res: express.Response) => {
+    try {
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+      });
+      res.on('close', () => {
+        transport.close();
+      });
+      await server.connect(transport);
+      await transport.handleRequest(req, res, req.body);
+    } catch (err) {
+      console.error('HTTP handler error:', err);
+      if (!res.headersSent) {
+        res.status(500).json({
+          jsonrpc: '2.0',
+          error: { code: -32603, message: 'Internal server error' },
+          id: null,
+        });
+      }
+    }
+  };
+
+  app.get('/mcp', handle);
+  app.post('/mcp', handle);
+  app.delete('/mcp', handle);
+
+  app.get('/healthz', (_req: express.Request, res: express.Response) => {
+    res.status(200).type('text/plain').send('ok');
+  });
+
+  app.listen(port, host, () => {
+    console.error(`Toggl MCP server running (http) on ${host}:${port}/mcp`);
+  });
+}
+
+async function main() {
+  const http = parseHttpArg(argv);
+  if (http) {
+    await runHttp(http.host, http.port);
+  } else {
+    await runStdio();
+  }
 }
 
 main().catch((error) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1197,25 +1197,21 @@ async function runStdio() {
   console.error('Toggl MCP server running (stdio)');
 }
 
+function jsonRpcError(code: number, message: string) {
+  return { jsonrpc: '2.0', error: { code, message }, id: null };
+}
+
 async function runHttp(host: string, port: number) {
-  // Stateless: each request gets its own Server + transport. Protocol.connect
-  // throws on a second connect against the same Server while another
-  // transport is still attached, so sharing the instance would race under
-  // concurrent requests.
+  // See createServer() for why each request gets its own Server instance.
   const app = express();
   app.use(express.json({ limit: '4mb' }));
 
-  // Convert express.json() body-parse failures into JSON-RPC parse errors so
-  // MCP clients see a structured response instead of the default Express
-  // HTML page.
+  // Translate body-parse failures into JSON-RPC parse errors so MCP clients
+  // see a structured response instead of Express's default HTML page.
   app.use(
     (err: unknown, _req: express.Request, res: express.Response, next: express.NextFunction) => {
       if (err instanceof SyntaxError && 'body' in (err as object) && !res.headersSent) {
-        res.status(400).json({
-          jsonrpc: '2.0',
-          error: { code: -32700, message: 'Parse error' },
-          id: null,
-        });
+        res.status(400).json(jsonRpcError(-32700, 'Parse error'));
         return;
       }
       next(err);
@@ -1237,11 +1233,7 @@ async function runHttp(host: string, port: number) {
     } catch (err) {
       console.error('HTTP handler error:', err);
       if (!res.headersSent) {
-        res.status(500).json({
-          jsonrpc: '2.0',
-          error: { code: -32603, message: 'Internal server error' },
-          id: null,
-        });
+        res.status(500).json(jsonRpcError(-32603, 'Internal server error'));
       }
     }
   };


### PR DESCRIPTION
## Summary
Adds an optional --http [host:]port CLI flag that runs the server with Streamable HTTP transport behind an Express handler at GET/POST/DELETE /mcp, alongside the existing stdio transport.

Stdio mode is unchanged and remains the default. A /healthz endpoint is exposed in HTTP mode for container probes or reverse-proxy upstream health checks.

## Motivation
Lets self-hosters front mcp-toggl with a reverse proxy that handles auth and multi-backend routing (an MCP gateway) instead of wrapping stdio in supergateway. The supergateway wrapper has been observed to crash on mid-request client disconnects under @modelcontextprotocol/sdk 1.x, which surfaces in clients as "the connector lost authentication" even though the OAuth refresh token is still valid.

ms-365-mcp-server already takes this shape (--http [address], stateless transport-per-request), so the flag name and semantics here mirror it for self-host parity.

## Design
- **Stateless transport per request**: each call instantiates its own StreamableHTTPServerTransport with sessionIdGenerator: undefined. Every Toggl tool call eventually proxies to the Toggl REST API anyway, so there's no per-session state worth keeping on the server, and the per-request transport keeps the server self-contained behind a proxy that might multiplex many clients.
- **Express, not Fastify**: matches the import surface ms-365-mcp-server already uses; avoids adding a third HTTP framework to the npm ecosystem on the Claude side.
- **No auth surface**: TOGGL_API_KEY is an env-var secret, not a per-user token, so this server intentionally has no built-in OAuth. Operators who need per-user auth front it with a gateway (the same pattern this PR is designed for).

## Changes
- src/index.ts: import StreamableHTTPServerTransport + express; add parseHttpArg / runHttp / runStdio; rewrite main() to dispatch on --http.
- package.json: add express (runtime) + @types/express (dev). Both versions match upstream's existing convention.

## Test plan
- [x] npm install && npm run build → clean
- [x] node dist/index.js (no flag) → stdio works as before
- [x] node dist/index.js --http :8099 → listens on :8099, tools/list returns 200 with a Toggl tool catalogue
- [x] curl http://localhost:8099/healthz returns 200 "ok"
- [x] Docker image built from the branch responds correctly to claude.ai's Streamable HTTP probes through a reverse proxy

## Out of scope
- Auth on the HTTP endpoint. The server has never had per-user auth and intentionally does not add it; operators who need that put a proxy in front (this PR enables that).

🤖 Generated with [Claude Code](https://claude.com/claude-code)