### PR TITLE
fix: paginate getProjects/getClients so all results resolve

### DIFF
--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -162,9 +162,40 @@ export class TogglAPI {
     return this.request<Workspace>('GET', `/workspaces/${workspaceId}`);
   }
 
+  // Toggl v9 list endpoints paginate by `page`/`per_page` (1-indexed, sorted by name).
+  // Without explicit pagination the API returns only the first page and silently drops
+  // the tail, so any project/client past it fails to resolve and shows as "Project <id>".
+  private static readonly PAGE_SIZE = 200;
+  private static readonly MAX_PAGES = 100;
+
+  private async requestAllPages<T extends { id?: number }>(endpoint: string): Promise<T[]> {
+    const sep = endpoint.includes('?') ? '&' : '?';
+    const all: T[] = [];
+    let prevFirstId: number | undefined;
+
+    for (let page = 1; page <= TogglAPI.MAX_PAGES; page++) {
+      const batch = await this.request<T[]>(
+        'GET',
+        `${endpoint}${sep}per_page=${TogglAPI.PAGE_SIZE}&page=${page}`
+      );
+      if (!Array.isArray(batch) || batch.length === 0) break;
+
+      // Guard against endpoints that ignore `page` and keep returning the same window,
+      // which would otherwise loop until MAX_PAGES.
+      const firstId = batch[0]?.id;
+      if (page > 1 && firstId !== undefined && firstId === prevFirstId) break;
+      prevFirstId = firstId;
+
+      all.push(...batch);
+      if (batch.length < TogglAPI.PAGE_SIZE) break;
+    }
+
+    return all;
+  }
+
   // Project methods
   async getProjects(workspaceId: number): Promise<Project[]> {
-    return this.request<Project[]>('GET', `/workspaces/${workspaceId}/projects`);
+    return this.requestAllPages<Project>(`/workspaces/${workspaceId}/projects`);
   }
 
   async getProject(projectId: number): Promise<Project> {
@@ -181,7 +212,7 @@ export class TogglAPI {
 
   // Client methods
   async getClients(workspaceId: number): Promise<Client[]> {
-    return this.request<Client[]>('GET', `/workspaces/${workspaceId}/clients`);
+    return this.requestAllPages<Client>(`/workspaces/${workspaceId}/clients`);
   }
 
   async getClient(clientId: number): Promise<Client> {

--- a/tests/toggl-api.test.ts
+++ b/tests/toggl-api.test.ts
@@ -65,3 +65,49 @@ describe('toggl api errors', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('list endpoint pagination', () => {
+  afterEach(() => {
+    fetchMock.mockReset();
+  });
+
+  const page = (count: number, startId: number) =>
+    Array.from({ length: count }, (_, i) => ({ id: startId + i, name: `item-${startId + i}` }));
+
+  it('fetches every page of projects until a short page is returned', async () => {
+    fetchMock
+      .mockResolvedValueOnce(response({ status: 200, json: page(200, 1) }))
+      .mockResolvedValueOnce(response({ status: 200, json: page(7, 1000) }));
+
+    const api = new TogglAPI('token');
+    const projects = await api.getProjects(2154504);
+
+    expect(projects).toHaveLength(207);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const urls = fetchMock.mock.calls.map((c) => c[0] as string);
+    expect(urls[0]).toContain('/workspaces/2154504/projects?per_page=200&page=1');
+    expect(urls[1]).toContain('/workspaces/2154504/projects?per_page=200&page=2');
+  });
+
+  it('makes a single request when the first page is shorter than the page size', async () => {
+    fetchMock.mockResolvedValueOnce(response({ status: 200, json: page(3, 1) }));
+
+    const api = new TogglAPI('token');
+    const clients = await api.getClients(2154504);
+
+    expect(clients).toHaveLength(3);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toContain('/workspaces/2154504/clients?per_page=200&page=1');
+  });
+
+  it('stops instead of looping when the endpoint ignores the page param', async () => {
+    // Same full page returned regardless of page number — must not loop forever.
+    fetchMock.mockResolvedValue(response({ status: 200, json: page(200, 1) }));
+
+    const api = new TogglAPI('token');
+    const projects = await api.getProjects(2154504);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(projects).toHaveLength(200);
+  });
+});


### PR DESCRIPTION
## Problem

`getProjects` and `getClients` issue a single un-paginated `GET` to the Toggl v9 list endpoints. Those endpoints paginate by `page`/`per_page` (sorted by name) and return only the **first page** by default, silently dropping the rest.

As a result, any project or client past the first page fails name resolution and surfaces as the `Project <id>` fallback in reports and summaries. Workspaces with more projects than a single page hit this for everything after the first page.

## Fix

- Add a private `requestAllPages()` helper that walks `?per_page=200&page=N` until a short page is returned.
- Two safety guards: a non-advancing-page detector (breaks if an endpoint ignores `page` and re-returns the same window, preventing an infinite loop) and a `MAX_PAGES` backstop.
- Route both `getProjects` and `getClients` through it (clients had the identical bug).

This is offset pagination (`page`/`per_page`), verified against the v9 `/workspaces/{id}/projects` endpoint — `page=2` returns a distinct, later, name-sorted window.

## Tests

TDD: three tests written first and watched fail, then pass:
- fetches every page until a short page (multi-page),
- single request when the first page is short,
- stops instead of looping when the endpoint ignores `page`.

Full suite green (30 passed, 3 pre-existing skips), `tsc --noEmit` clean, ESLint 0 errors.

## Notes / out of scope

- Pagination only. `getProjects` still uses Toggl's default `active`-only filter, so genuinely *archived* projects still won't name-resolve — left for a separate change (e.g. an `active=both` option).
- `PAGE_SIZE` is hardcoded to 200 rather than wired to the documented `TOGGL_BATCH_SIZE` env var, since the `TogglAPI` constructor doesn't currently receive config. Happy to thread it through if preferred.