### PR TITLE
feat(toggl): add workspace user reporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Chart prompts depend on your MCP client. The server returns the structured data;
 
 **Recoverable errors**: workspace resolution errors include `available_workspaces`, and Toggl quota/rate-limit errors include structured retry hints.
 
+**Team reporting**: report tools support `uid` plus `workspace_id` to pull a workspace member's entries through the Toggl Reports API v3. Use `toggl_list_workspace_users` to find privacy-safe member identifiers.
+
 ## Quick Start
 
 ### Prerequisites
@@ -116,12 +118,12 @@ mcp-toggl --help
 
 ### Reports and Insights
 
-| Tool                     | What it does                                                                                                        |
-| ------------------------ | ------------------------------------------------------------------------------------------------------------------- |
-| `toggl_daily_report`     | Hours by project and workspace for a date. Use `format: "text"` for display text or `"json"` for structured output. |
-| `toggl_weekly_report`    | 7-day breakdown with daily totals and project rollups. Use `week_offset: -1` for last week.                         |
-| `toggl_get_time_entries` | Raw hydrated entries by period, date range, workspace, or project.                                                  |
-| `toggl_get_timeline`     | Toggl Track Desktop app usage summary with optional raw events.                                                     |
+| Tool                     | What it does                                                                                                                                  |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `toggl_daily_report`     | Hours by project and workspace for a date. Use `format: "text"` for display text or `"json"` for structured output. Supports `uid` filtering. |
+| `toggl_weekly_report`    | 7-day breakdown with daily totals and project rollups. Use `week_offset: -1` for last week. Supports `uid` filtering.                         |
+| `toggl_get_time_entries` | Raw hydrated entries by period, date range, workspace, or project.                                                                            |
+| `toggl_get_timeline`     | Toggl Track Desktop app usage summary with optional raw events.                                                                               |
 
 ### Timer Control
 
@@ -133,12 +135,13 @@ mcp-toggl --help
 
 ### Lookups
 
-| Tool                    | What it does                                                                     |
-| ----------------------- | -------------------------------------------------------------------------------- |
-| `toggl_check_auth`      | Verifies token access and lists available workspaces without exposing the token. |
-| `toggl_list_workspaces` | Lists all accessible workspaces.                                                 |
-| `toggl_list_projects`   | Lists projects for a workspace using cache-backed reads after first fetch.       |
-| `toggl_list_clients`    | Lists clients for a workspace using cache-backed reads after first fetch.        |
+| Tool                         | What it does                                                                                                             |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `toggl_check_auth`           | Verifies token access and lists available workspaces without exposing the token.                                         |
+| `toggl_list_workspaces`      | Lists all accessible workspaces.                                                                                         |
+| `toggl_list_projects`        | Lists projects for a workspace using cache-backed reads after first fetch.                                               |
+| `toggl_list_clients`         | Lists clients for a workspace using cache-backed reads after first fetch.                                                |
+| `toggl_list_workspace_users` | Lists workspace members as `uid`, `name`, and `active` only. Use a member's `uid` to filter reports by that team member. |
 
 ### Cache Management
 
@@ -150,10 +153,10 @@ mcp-toggl --help
 
 ### Summaries
 
-| Tool                      | What it does                                          |
-| ------------------------- | ----------------------------------------------------- |
-| `toggl_project_summary`   | Total hours per project for a period or date range.   |
-| `toggl_workspace_summary` | Total hours per workspace for a period or date range. |
+| Tool                      | What it does                                                                    |
+| ------------------------- | ------------------------------------------------------------------------------- |
+| `toggl_project_summary`   | Total hours per project for a period or date range. Supports `uid` filtering.   |
+| `toggl_workspace_summary` | Total hours per workspace for a period or date range. Supports `uid` filtering. |
 
 ## Timeline Privacy
 
@@ -233,21 +236,21 @@ Fly, Render, Coolify, and a bare VPS all use the same image and env vars. Requir
 
 ## Configuration Reference
 
-| Env var                            | Required         | Default   | Notes                                                                                   |
-| ---------------------------------- | ---------------- | --------- | --------------------------------------------------------------------------------------- |
-| `TOGGL_API_KEY`                    | One token env    | -         | Toggl API token for local stdio installs.                                               |
-| `TOGGL_API_TOKEN`                  | One token env    | -         | Toggl API token for Docker/PaaS installs.                                               |
-| `TOGGL_TOKEN`                      | No               | -         | Legacy alias. Prefer `TOGGL_API_KEY` or `TOGGL_API_TOKEN`.                              |
-| `TOGGL_DEFAULT_WORKSPACE_ID`       | No               | -         | Used when a tool requires a workspace and none is passed.                               |
-| `TOGGL_CACHE_TTL`                  | No               | `3600000` | Cache TTL in milliseconds. Default is 1 hour.                                           |
-| `TOGGL_CACHE_SIZE`                 | No               | `1000`    | Maximum cached entity budget.                                                           |
-| `TOGGL_BATCH_SIZE`                 | No               | `100`     | Batch size used by API pagination helpers.                                              |
-| `TRANSPORT`                        | No               | `stdio`   | Use `http` for Streamable HTTP self-hosting.                                            |
-| `MCP_HTTP_AUTH_TOKEN`              | HTTP deployments | -         | Bearer token required for `/mcp` unless loopback unauthenticated mode is explicitly set. |
-| `MCP_HTTP_CORS_ORIGIN`             | No               | -         | Optional browser CORS origin. No CORS response headers are sent by default.             |
-| `MCP_HTTP_ALLOW_UNAUTHENTICATED`   | No               | `false`   | Set to `true` only for loopback-only HTTP development without auth.                     |
-| `PORT`                             | No               | `3000`    | HTTP port when `TRANSPORT=http`.                                                        |
-| `HOST`                             | No               | `0.0.0.0` | HTTP bind host when `TRANSPORT=http`.                                                   |
+| Env var                          | Required         | Default   | Notes                                                                                    |
+| -------------------------------- | ---------------- | --------- | ---------------------------------------------------------------------------------------- |
+| `TOGGL_API_KEY`                  | One token env    | -         | Toggl API token for local stdio installs.                                                |
+| `TOGGL_API_TOKEN`                | One token env    | -         | Toggl API token for Docker/PaaS installs.                                                |
+| `TOGGL_TOKEN`                    | No               | -         | Legacy alias. Prefer `TOGGL_API_KEY` or `TOGGL_API_TOKEN`.                               |
+| `TOGGL_DEFAULT_WORKSPACE_ID`     | No               | -         | Used when a tool requires a workspace and none is passed.                                |
+| `TOGGL_CACHE_TTL`                | No               | `3600000` | Cache TTL in milliseconds. Default is 1 hour.                                            |
+| `TOGGL_CACHE_SIZE`               | No               | `1000`    | Maximum cached entity budget.                                                            |
+| `TOGGL_BATCH_SIZE`               | No               | `100`     | Batch size used by API pagination helpers.                                               |
+| `TRANSPORT`                      | No               | `stdio`   | Use `http` for Streamable HTTP self-hosting.                                             |
+| `MCP_HTTP_AUTH_TOKEN`            | HTTP deployments | -         | Bearer token required for `/mcp` unless loopback unauthenticated mode is explicitly set. |
+| `MCP_HTTP_CORS_ORIGIN`           | No               | -         | Optional browser CORS origin. No CORS response headers are sent by default.              |
+| `MCP_HTTP_ALLOW_UNAUTHENTICATED` | No               | `false`   | Set to `true` only for loopback-only HTTP development without auth.                      |
+| `PORT`                           | No               | `3000`    | HTTP port when `TRANSPORT=http`.                                                         |
+| `HOST`                           | No               | `0.0.0.0` | HTTP bind host when `TRANSPORT=http`.                                                    |
 
 ## Caveats
 

--- a/server.json
+++ b/server.json
@@ -69,6 +69,10 @@
       "description": "List clients in a workspace"
     },
     {
+      "name": "toggl_list_workspace_users",
+      "description": "List workspace members (uid, name, active) for per-user report filtering"
+    },
+    {
       "name": "toggl_warm_cache",
       "description": "Pre-fetch workspace, project, client, and tag data"
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -222,6 +222,19 @@ async function resolveWorkspaceForTool(
   });
 }
 
+function reportDateRangeFromArgs(args: Record<string, unknown> | undefined): {
+  start: Date;
+  end: Date;
+} {
+  const range = localDateRangeFromArgs(args);
+  if (range?.start && range.end) return { start: range.start, end: range.end };
+  return getDateRange('week');
+}
+
+function readUid(args: Record<string, unknown> | undefined): number | undefined {
+  return typeof args?.uid === 'number' ? args.uid : undefined;
+}
+
 // Define tool schemas
 const tools: Tool[] = [
   // Health/authentication
@@ -362,6 +375,16 @@ const tools: Tool[] = [
           enum: ['json', 'text'],
           description: 'Output format (default: json)',
         },
+        uid: {
+          type: 'number',
+          description:
+            "Toggl user id to report on. When provided, uses Reports API v3 to fetch that workspace member's entries.",
+        },
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID for uid report filtering. If omitted, workspace resolution uses the configured default or sole workspace.',
+        },
       },
     },
   },
@@ -384,6 +407,16 @@ const tools: Tool[] = [
           type: 'string',
           enum: ['json', 'text'],
           description: 'Output format (default: json)',
+        },
+        uid: {
+          type: 'number',
+          description:
+            "Toggl user id to report on. When provided, uses Reports API v3 to fetch that workspace member's entries.",
+        },
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID for uid report filtering. If omitted, workspace resolution uses the configured default or sole workspace.',
         },
       },
     },
@@ -414,7 +447,13 @@ const tools: Tool[] = [
         },
         workspace_id: {
           type: 'number',
-          description: 'Filter by workspace ID',
+          description:
+            'Filter by workspace ID. Also used as the Reports API workspace when uid is provided.',
+        },
+        uid: {
+          type: 'number',
+          description:
+            "Toggl user id to report on. When provided, uses Reports API v3 to fetch that workspace member's entries.",
         },
       },
     },
@@ -442,6 +481,16 @@ const tools: Tool[] = [
         end_date: {
           type: 'string',
           description: 'End date (YYYY-MM-DD format, inclusive, local timezone)',
+        },
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID for uid report filtering. If omitted, workspace resolution uses the configured default or sole workspace.',
+        },
+        uid: {
+          type: 'number',
+          description:
+            "Toggl user id to report on. When provided, uses Reports API v3 to fetch that workspace member's entries.",
         },
       },
     },
@@ -496,6 +545,26 @@ const tools: Tool[] = [
           type: 'number',
           description:
             'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
+        },
+      },
+    },
+  },
+  {
+    name: 'toggl_list_workspace_users',
+    description:
+      'List workspace members as privacy-safe uid, name, and active fields for per-user report filtering.',
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace.',
         },
       },
     },
@@ -837,7 +906,16 @@ export function createTogglServer(): Server {
           const nextDay = new Date(date);
           nextDay.setDate(nextDay.getDate() + 1);
 
-          const entries = await api.getTimeEntriesForDateRange(date, nextDay);
+          const uid = readUid(args);
+          const entries =
+            uid !== undefined
+              ? await api.getTimeEntriesForUserAndDateRange(
+                  await resolveWorkspaceForTool(args, 'generating a daily report'),
+                  uid,
+                  date,
+                  nextDay
+                )
+              : await api.getTimeEntriesForDateRange(date, nextDay);
           const hydrated = await cache.hydrateTimeEntries(entries);
 
           const report = generateDailyReport(toLocalYMD(date), hydrated);
@@ -867,9 +945,6 @@ export function createTogglServer(): Server {
           await ensureCache();
 
           const weekOffset = (args?.week_offset as number) || 0;
-          const entries = await api.getTimeEntriesForWeek(weekOffset);
-          const hydrated = await cache.hydrateTimeEntries(entries);
-
           // Calculate week boundaries in local time.
           const today = new Date();
           today.setHours(0, 0, 0, 0);
@@ -879,6 +954,20 @@ export function createTogglServer(): Server {
           monday.setDate(diff + weekOffset * 7);
           const sunday = new Date(monday);
           sunday.setDate(sunday.getDate() + 6);
+          const nextMonday = new Date(monday);
+          nextMonday.setDate(nextMonday.getDate() + 7);
+
+          const uid = readUid(args);
+          const entries =
+            uid !== undefined
+              ? await api.getTimeEntriesForUserAndDateRange(
+                  await resolveWorkspaceForTool(args, 'generating a weekly report'),
+                  uid,
+                  monday,
+                  nextMonday
+                )
+              : await api.getTimeEntriesForWeek(weekOffset);
+          const hydrated = await cache.hydrateTimeEntries(entries);
 
           const report = generateWeeklyReport(monday, sunday, hydrated);
 
@@ -906,21 +995,19 @@ export function createTogglServer(): Server {
         case 'toggl_project_summary': {
           await ensureCache();
 
-          let entries: TimeEntry[];
+          const range = reportDateRangeFromArgs(args);
+          const uid = readUid(args);
+          let entries =
+            uid !== undefined
+              ? await api.getTimeEntriesForUserAndDateRange(
+                  await resolveWorkspaceForTool(args, 'generating a project summary'),
+                  uid,
+                  range.start,
+                  range.end
+                )
+              : await api.getTimeEntriesForDateRange(range.start, range.end);
 
-          if (args?.period) {
-            const range = getDateRange(args.period as any);
-            entries = await api.getTimeEntriesForDateRange(range.start, range.end);
-          } else if (args?.start_date && args?.end_date) {
-            const start = parseLocalYMD(args.start_date as string);
-            const end = parseInclusiveEndDate(args.end_date as string);
-            entries = await api.getTimeEntriesForDateRange(start, end);
-          } else {
-            // Default to current week
-            entries = await api.getTimeEntriesForWeek(0);
-          }
-
-          if (args?.workspace_id) {
+          if (uid === undefined && args?.workspace_id) {
             entries = entries.filter((e) => e.workspace_id === args.workspace_id);
           }
 
@@ -956,19 +1043,17 @@ export function createTogglServer(): Server {
         case 'toggl_workspace_summary': {
           await ensureCache();
 
-          let entries: TimeEntry[];
-
-          if (args?.period) {
-            const range = getDateRange(args.period as any);
-            entries = await api.getTimeEntriesForDateRange(range.start, range.end);
-          } else if (args?.start_date && args?.end_date) {
-            const start = parseLocalYMD(args.start_date as string);
-            const end = parseInclusiveEndDate(args.end_date as string);
-            entries = await api.getTimeEntriesForDateRange(start, end);
-          } else {
-            // Default to current week
-            entries = await api.getTimeEntriesForWeek(0);
-          }
+          const range = reportDateRangeFromArgs(args);
+          const uid = readUid(args);
+          const entries =
+            uid !== undefined
+              ? await api.getTimeEntriesForUserAndDateRange(
+                  await resolveWorkspaceForTool(args, 'generating a workspace summary'),
+                  uid,
+                  range.start,
+                  range.end
+                )
+              : await api.getTimeEntriesForDateRange(range.start, range.end);
 
           const hydrated = await cache.hydrateTimeEntries(entries);
           const byWorkspace = groupEntriesByWorkspace(hydrated);
@@ -1074,6 +1159,29 @@ export function createTogglServer(): Server {
                       name: c.name,
                       archived: c.archived,
                     })),
+                  },
+                  null,
+                  2
+                ),
+              },
+            ],
+          };
+        }
+
+        case 'toggl_list_workspace_users': {
+          const workspaceId = await resolveWorkspaceForTool(args, 'listing workspace users');
+          const users = await api.getWorkspaceUsers(workspaceId);
+          const summaries = users.map((user) => TogglAPI.toWorkspaceMemberSummary(user));
+
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(
+                  {
+                    workspace_id: workspaceId,
+                    count: summaries.length,
+                    users: summaries,
                   },
                   null,
                   2

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -1,4 +1,4 @@
-import fetch from 'node-fetch';
+import fetch, { type RequestInit, type Response } from 'node-fetch';
 import { toLocalYMD } from './utils.js';
 import type {
   Workspace,
@@ -6,6 +6,8 @@ import type {
   Client,
   Task,
   User,
+  WorkspaceUser,
+  WorkspaceMemberSummary,
   Tag,
   TimeEntry,
   TimeEntriesRequest,
@@ -68,19 +70,12 @@ export class TogglAPI {
     };
   }
 
-  // Generic API request method
-  private async request<T>(method: string, endpoint: string, body?: any, retries = 3): Promise<T> {
-    const url = `${this.baseUrl}${endpoint}`;
-
+  // Shared fetch loop for retryable network, 429, and 5xx responses.
+  private async fetchWithRetry(url: string, init: RequestInit, retries = 3): Promise<Response> {
     for (let i = 0; i < retries; i++) {
       try {
-        const response = await fetch(url, {
-          method,
-          headers: this.headers,
-          body: body ? JSON.stringify(body) : undefined,
-        });
+        const response = await fetch(url, init);
 
-        // Handle rate limiting without sleeping for multi-minute quota resets.
         if (response.status === 429) {
           const retryAfterSeconds = parseRetryAfterSeconds(response.headers.get('Retry-After'));
           const delay = retryAfterSeconds !== undefined ? retryAfterSeconds * 1000 : (i + 1) * 2000;
@@ -100,42 +95,12 @@ export class TogglAPI {
           });
         }
 
-        if (!response.ok) {
-          const text = await response.text();
-          if (response.status === 402) {
-            const retryAfterSeconds = parseQuotaResetSeconds(text);
-            throw new TogglAPIError({
-              status: response.status,
-              code: 'TOGGL_QUOTA_LIMIT',
-              message: `Toggl API quota limit reached.${retryAfterSeconds !== undefined ? ` Quota resets in ${retryAfterSeconds} seconds.` : ''}`,
-              retryAfterSeconds,
-              tip: 'Wait for the Toggl quota window to reset. Cache-backed list tools avoid repeated project/client fetches after they are warmed.',
-            });
-          }
-
-          if (response.status >= 400 && response.status < 500) {
-            const isAuth = response.status === 401 || response.status === 403;
-            throw new TogglAPIError({
-              status: response.status,
-              code: isAuth ? 'AUTHENTICATION_FAILED' : 'TOGGL_API_CLIENT_ERROR',
-              message: isAuth
-                ? `Authentication failed (${response.status}). Verify TOGGL_API_KEY is correct, has no leading/trailing spaces, and is the Toggl Track API token.`
-                : `Toggl API rejected the request (${response.status}).`,
-              tip: isAuth
-                ? 'Regenerate or copy your Toggl Track API token from track.toggl.com/profile and restart the MCP server.'
-                : 'Check the tool arguments and Toggl workspace permissions, then retry.',
-            });
-          }
-
-          throw new Error(`Toggl API request failed (${response.status}).`);
+        if (response.status >= 500 && i < retries - 1) {
+          await new Promise((resolve) => setTimeout(resolve, (i + 1) * 1000));
+          continue;
         }
 
-        // Handle 204 No Content
-        if (response.status === 204) {
-          return {} as T;
-        }
-
-        return (await response.json()) as T;
+        return response;
       } catch (error: any) {
         if (error?.noRetry || i === retries - 1) throw error;
         // Exponential backoff for transient/network errors
@@ -144,6 +109,60 @@ export class TogglAPI {
     }
 
     throw new Error('Max retries reached');
+  }
+
+  // Generic API request method
+  private async request<T>(method: string, endpoint: string, body?: any, retries = 3): Promise<T> {
+    const url = `${this.baseUrl}${endpoint}`;
+    const response = await this.fetchWithRetry(
+      url,
+      {
+        method,
+        headers: this.headers,
+        body: body ? JSON.stringify(body) : undefined,
+      },
+      retries
+    );
+
+    if (!response.ok) {
+      const text = await response.text();
+      if (response.status === 402) {
+        const retryAfterSeconds = parseQuotaResetSeconds(text);
+        throw new TogglAPIError({
+          status: response.status,
+          code: 'TOGGL_QUOTA_LIMIT',
+          message: `Toggl API quota limit reached.${retryAfterSeconds !== undefined ? ` Quota resets in ${retryAfterSeconds} seconds.` : ''}`,
+          retryAfterSeconds,
+          tip: 'Wait for the Toggl quota window to reset. Cache-backed list tools avoid repeated project/client fetches after they are warmed.',
+        });
+      }
+
+      if (response.status >= 400 && response.status < 500) {
+        const isAuth = response.status === 401 || response.status === 403;
+        throw new TogglAPIError({
+          status: response.status,
+          code: isAuth ? 'AUTHENTICATION_FAILED' : 'TOGGL_API_CLIENT_ERROR',
+          message: isAuth
+            ? `Authentication failed (${response.status}). Verify TOGGL_API_KEY is correct, has no leading/trailing spaces, and is the Toggl Track API token.`
+            : `Toggl API rejected the request (${response.status}).`,
+          tip: isAuth
+            ? 'Regenerate or copy your Toggl Track API token from track.toggl.com/profile and restart the MCP server.'
+            : 'Check the tool arguments and Toggl workspace permissions, then retry.',
+        });
+      }
+
+      throw new Error(`Toggl API request failed (${response.status}).`);
+    }
+
+    if (response.status === 204) {
+      return {} as T;
+    }
+
+    try {
+      return (await response.json()) as T;
+    } catch (_error) {
+      return {} as T;
+    }
   }
 
   // User methods
@@ -163,6 +182,160 @@ export class TogglAPI {
 
   async getWorkspace(workspaceId: number): Promise<Workspace> {
     return this.request<Workspace>('GET', `/workspaces/${workspaceId}`);
+  }
+
+  async getWorkspaceUsers(workspaceId: number): Promise<WorkspaceUser[]> {
+    const response = await this.request<WorkspaceUser[] | { items?: WorkspaceUser[] }>(
+      'GET',
+      `/workspaces/${workspaceId}/users`
+    );
+
+    if (Array.isArray(response)) return response;
+    if (Array.isArray(response.items)) return response.items;
+    throw new Error('Toggl workspace users response had an unexpected shape.');
+  }
+
+  static toWorkspaceMemberSummary(raw: WorkspaceUser): WorkspaceMemberSummary {
+    return {
+      uid: raw.id as number,
+      name: raw.fullname ?? '',
+      active: raw.is_active ?? !raw.inactive,
+    };
+  }
+
+  private async reportsRequest<T>(
+    workspaceId: number,
+    endpoint: string,
+    body: Record<string, unknown>,
+    retries = 3
+  ): Promise<{ data: T; nextRowNumber?: number }> {
+    const url = `https://api.track.toggl.com/reports/api/v3/workspace/${workspaceId}${endpoint}`;
+    const response = await this.fetchWithRetry(
+      url,
+      {
+        method: 'POST',
+        headers: this.headers,
+        body: JSON.stringify(body),
+      },
+      retries
+    );
+
+    if (!response.ok) {
+      const text = await response.text();
+      if (response.status === 402) {
+        const retryAfterSeconds = parseQuotaResetSeconds(text);
+        throw new TogglAPIError({
+          status: response.status,
+          code: 'TOGGL_QUOTA_LIMIT',
+          message: `Toggl Reports API quota limit reached.${retryAfterSeconds !== undefined ? ` Quota resets in ${retryAfterSeconds} seconds.` : ''}`,
+          retryAfterSeconds,
+          tip: 'Wait for the Toggl quota window to reset, or use a narrower date range to reduce API usage.',
+        });
+      }
+
+      if (response.status >= 400 && response.status < 500) {
+        const isAuth = response.status === 401 || response.status === 403;
+        throw new TogglAPIError({
+          status: response.status,
+          code: isAuth ? 'AUTHENTICATION_FAILED' : 'REPORTS_API_CLIENT_ERROR',
+          message: isAuth
+            ? `Reports API authentication failed (${response.status}). Verify TOGGL_API_KEY is correct.`
+            : `Toggl Reports API rejected the request (${response.status}).`,
+          tip: isAuth
+            ? 'Regenerate or copy your Toggl Track API token from track.toggl.com/profile and restart the MCP server.'
+            : 'Check report arguments, workspace permissions, and uid access, then retry.',
+        });
+      }
+
+      throw new Error(`Toggl Reports API request failed (${response.status}).`);
+    }
+
+    const nextHeader = response.headers.get('X-Next-Row-Number');
+    const nextRowNumber = nextHeader ? Number.parseInt(nextHeader, 10) : undefined;
+
+    try {
+      return { data: (await response.json()) as T, nextRowNumber };
+    } catch (_error) {
+      return { data: {} as T, nextRowNumber };
+    }
+  }
+
+  async getTimeEntriesForUserAndDateRange(
+    workspaceId: number,
+    userId: number,
+    startDate: Date,
+    endDate: Date
+  ): Promise<TimeEntry[]> {
+    const inclusiveEnd = new Date(endDate);
+    inclusiveEnd.setDate(inclusiveEnd.getDate() - 1);
+
+    type ReportTimeEntry = {
+      id?: number;
+      seconds?: number;
+      start?: string;
+      stop?: string | null;
+    };
+    type ReportRow = {
+      user_id?: number;
+      project_id?: number | null;
+      task_id?: number | null;
+      billable?: boolean;
+      description?: string;
+      tag_ids?: number[] | null;
+      time_entries?: ReportTimeEntry[];
+    } & ReportTimeEntry;
+
+    const allEntries: TimeEntry[] = [];
+    let firstRowNumber = 1;
+
+    while (true) {
+      const { data: rows, nextRowNumber } = await this.reportsRequest<ReportRow[]>(
+        workspaceId,
+        '/search/time_entries',
+        {
+          user_ids: [userId],
+          start_date: toLocalYMD(startDate),
+          end_date: toLocalYMD(inclusiveEnd),
+          first_row_number: firstRowNumber,
+        }
+      );
+
+      const reportRows = Array.isArray(rows) ? rows : [];
+      for (const row of reportRows) {
+        const entries =
+          Array.isArray(row.time_entries) && row.time_entries.length > 0 ? row.time_entries : [row];
+
+        for (const entry of entries) {
+          if (
+            typeof entry.id !== 'number' ||
+            typeof entry.seconds !== 'number' ||
+            typeof entry.start !== 'string'
+          ) {
+            continue;
+          }
+
+          allEntries.push({
+            id: entry.id,
+            workspace_id: workspaceId,
+            project_id: row.project_id ?? undefined,
+            task_id: row.task_id ?? undefined,
+            billable: row.billable,
+            start: entry.start,
+            stop: entry.stop ?? undefined,
+            duration: entry.seconds,
+            description: row.description,
+            tag_ids: row.tag_ids ?? [],
+            tags: [],
+            user_id: row.user_id ?? userId,
+          });
+        }
+      }
+
+      if (!nextRowNumber || nextRowNumber <= firstRowNumber || reportRows.length === 0) break;
+      firstRowNumber = nextRowNumber;
+    }
+
+    return allEntries;
   }
 
   // Project methods
@@ -349,25 +522,6 @@ export class TogglAPI {
     const firstDayNextMonth = new Date(year, month + 1, 1);
 
     return this.getTimeEntriesForDateRange(firstDay, firstDayNextMonth);
-  }
-
-  // Reports API endpoints (if needed)
-  async getDetailedReport(workspaceId: number, params: any): Promise<any> {
-    // This would use the Reports API v3 if needed
-    // https://api.track.toggl.com/reports/api/v3/workspace/{workspace_id}/search/time_entries
-    const reportsUrl = `https://api.track.toggl.com/reports/api/v3/workspace/${workspaceId}/search/time_entries`;
-
-    const response = await fetch(reportsUrl, {
-      method: 'POST',
-      headers: this.headers,
-      body: JSON.stringify(params),
-    });
-
-    if (!response.ok) {
-      throw new Error(`Reports API error: ${response.status}`);
-    }
-
-    return response.json();
   }
 
   async getTimeline(): Promise<TimelineEvent[]> {

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -196,10 +196,21 @@ export class TogglAPI {
   }
 
   static toWorkspaceMemberSummary(raw: WorkspaceUser): WorkspaceMemberSummary {
+    if (typeof raw.id !== 'number') {
+      throw new Error('Toggl workspace user is missing a numeric id.');
+    }
+
+    const active =
+      typeof raw.is_active === 'boolean'
+        ? raw.is_active
+        : typeof raw.inactive === 'boolean'
+          ? !raw.inactive
+          : false;
+
     return {
-      uid: raw.id as number,
-      name: raw.fullname ?? '',
-      active: raw.is_active ?? !raw.inactive,
+      uid: raw.id,
+      name: raw.fullname,
+      active,
     };
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -100,9 +100,9 @@ export interface User {
 // Documented Toggl v9 GET /workspaces/{id}/users response shape.
 // The tool layer exposes only WorkspaceMemberSummary to avoid leaking private fields.
 export interface WorkspaceUser {
-  id?: number;
+  id: number;
   email?: string;
-  fullname?: string;
+  fullname: string;
   is_active?: boolean;
   inactive?: boolean;
   is_admin?: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,6 +97,25 @@ export interface User {
   updated_at?: string;
 }
 
+// Documented Toggl v9 GET /workspaces/{id}/users response shape.
+// The tool layer exposes only WorkspaceMemberSummary to avoid leaking private fields.
+export interface WorkspaceUser {
+  id?: number;
+  email?: string;
+  fullname?: string;
+  is_active?: boolean;
+  inactive?: boolean;
+  is_admin?: boolean;
+  role?: string;
+  at?: string;
+}
+
+export interface WorkspaceMemberSummary {
+  uid: number;
+  name: string;
+  active: boolean;
+}
+
 export interface Tag {
   id: number;
   workspace_id: number;

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -24,6 +24,18 @@ function response({ status = 200, json }: { status?: number; json: unknown }) {
 
 function installMockTogglApi() {
   const workspace = { id: 20, name: 'Workspace', premium: false, default_currency: 'USD' };
+  const workspaceUsers = [
+    {
+      id: 11,
+      fullname: 'Alice Manager',
+      email: 'alice@example.com',
+      is_active: true,
+      is_admin: true,
+      role: 'admin',
+      rate: 99,
+      labor_cost: 50,
+    },
+  ];
   const project = {
     id: 30,
     workspace_id: 20,
@@ -48,13 +60,14 @@ function installMockTogglApi() {
     tag_ids: [50],
   };
 
-  fetchMock.mockImplementation(async (url: string, init?: { method?: string }) => {
+  fetchMock.mockImplementation(async (url: string, init?: { body?: string; method?: string }) => {
     const method = init?.method ?? 'GET';
 
     if (url.endsWith('/me'))
       return response({ json: { id: 10, email: 'private@example.com', fullname: 'Private User' } });
     if (url.endsWith('/workspaces')) return response({ json: [workspace] });
     if (url.endsWith('/workspaces/20')) return response({ json: workspace });
+    if (url.endsWith('/workspaces/20/users')) return response({ json: { items: workspaceUsers } });
     if (url.endsWith('/workspaces/20/projects')) return response({ json: [project] });
     if (url.endsWith('/workspaces/20/clients')) return response({ json: [client] });
     if (url.endsWith('/workspaces/20/tags')) return response({ json: tags });
@@ -84,6 +97,29 @@ function installMockTogglApi() {
           duration: -1,
           description: 'Started timer',
         },
+      });
+    }
+    if (method === 'POST' && url.endsWith('/reports/api/v3/workspace/20/search/time_entries')) {
+      const body = JSON.parse(init?.body ?? '{}') as { user_ids?: number[] };
+      return response({
+        json: [
+          {
+            user_id: body.user_ids?.[0] ?? 11,
+            project_id: 30,
+            task_id: null,
+            billable: true,
+            description: 'Team report work',
+            tag_ids: [50],
+            time_entries: [
+              {
+                id: 80,
+                seconds: 3600,
+                start: '2026-05-01T09:00:00Z',
+                stop: '2026-05-01T10:00:00Z',
+              },
+            ],
+          },
+        ],
       });
     }
 
@@ -138,6 +174,37 @@ describe('mcp server handlers', () => {
         default: true,
         deprecated: true,
       });
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('lists workspace user and uid report filter schemas', async () => {
+    const { client } = await createClient();
+
+    try {
+      const tools = await client.listTools();
+      const workspaceUsersTool = tools.tools.find(
+        (tool) => tool.name === 'toggl_list_workspace_users'
+      );
+      const reportToolNames = [
+        'toggl_daily_report',
+        'toggl_weekly_report',
+        'toggl_project_summary',
+        'toggl_workspace_summary',
+      ];
+
+      expect(workspaceUsersTool?.annotations).toMatchObject({
+        readOnlyHint: true,
+        idempotentHint: true,
+      });
+      expect(workspaceUsersTool?.inputSchema.properties).toHaveProperty('workspace_id');
+
+      for (const toolName of reportToolNames) {
+        const tool = tools.tools.find((candidate) => candidate.name === toolName);
+        expect(tool?.inputSchema.properties).toHaveProperty('uid');
+        expect(tool?.inputSchema.properties).toHaveProperty('workspace_id');
+      }
     } finally {
       await client.close();
     }
@@ -247,6 +314,13 @@ describe('mcp server handlers', () => {
         clients: [{ id: 40, name: 'Client' }],
       });
       await expect(
+        callTool(client, 'toggl_list_workspace_users', { workspace_id: 20 })
+      ).resolves.toEqual({
+        workspace_id: 20,
+        count: 1,
+        users: [{ uid: 11, name: 'Alice Manager', active: true }],
+      });
+      await expect(
         callTool(client, 'toggl_warm_cache', { workspace_id: 20 })
       ).resolves.toMatchObject({
         success: true,
@@ -263,6 +337,16 @@ describe('mcp server handlers', () => {
         callTool(client, 'toggl_daily_report', { date: '2026-05-01' })
       ).resolves.toMatchObject({
         total_seconds: 3600,
+      });
+      await expect(
+        callTool(client, 'toggl_daily_report', {
+          date: '2026-05-01',
+          uid: 11,
+          workspace_id: 20,
+        })
+      ).resolves.toMatchObject({
+        total_seconds: 3600,
+        entries: [{ id: 80 }],
       });
       await expect(
         callTool(client, 'toggl_project_summary', {
@@ -297,6 +381,26 @@ describe('mcp server handlers', () => {
       await expect(callTool(client, 'toggl_stop_timer')).resolves.toMatchObject({
         success: false,
         message: 'No timer currently running',
+      });
+
+      const workspaceUsersPayload = await callTool(client, 'toggl_list_workspace_users', {
+        workspace_id: 20,
+      });
+      const serializedUsers = JSON.stringify(workspaceUsersPayload);
+      expect(serializedUsers).not.toContain('alice@example.com');
+      expect(serializedUsers).not.toContain('is_admin');
+      expect(serializedUsers).not.toContain('role');
+      expect(serializedUsers).not.toContain('rate');
+      expect(serializedUsers).not.toContain('labor_cost');
+
+      const reportCall = fetchMock.mock.calls.find(([url]) =>
+        String(url).includes('/reports/api/v3/workspace/20/search/time_entries')
+      );
+      expect(reportCall).toBeDefined();
+      expect(JSON.parse(reportCall![1]?.body as string)).toMatchObject({
+        user_ids: [11],
+        start_date: '2026-05-01',
+        end_date: '2026-05-01',
       });
     } finally {
       await client.close();

--- a/tests/toggl-api.test.ts
+++ b/tests/toggl-api.test.ts
@@ -14,20 +14,51 @@ function response({
   text = '',
   json,
   retryAfter,
+  headers: extraHeaders = {},
 }: {
   status: number;
   text?: string;
   json?: unknown;
   retryAfter?: string;
+  headers?: Record<string, string | undefined>;
 }) {
+  const allHeaders: Record<string, string | undefined> = {
+    'retry-after': retryAfter,
+    ...extraHeaders,
+  };
+
   return {
     status,
     ok: status >= 200 && status < 300,
     headers: {
-      get: vi.fn((name: string) => (name.toLowerCase() === 'retry-after' ? retryAfter : null)),
+      get: vi.fn((name: string) => allHeaders[name.toLowerCase()] ?? null),
     },
     text: vi.fn(async () => text),
     json: vi.fn(async () => json),
+  };
+}
+
+const TEST_WORKSPACE_ID = 111;
+const TEST_USER_ID = 222;
+const TEST_PROJECT_ID = 333;
+
+function reportRow(overrides: Record<string, unknown> = {}) {
+  return {
+    user_id: TEST_USER_ID,
+    project_id: TEST_PROJECT_ID,
+    task_id: null,
+    billable: false,
+    description: 'test entry',
+    tag_ids: [],
+    time_entries: [
+      {
+        id: 1001,
+        seconds: 3600,
+        start: '2026-05-04T10:00:00+00:00',
+        stop: '2026-05-04T11:00:00+00:00',
+      },
+    ],
+    ...overrides,
   };
 }
 
@@ -83,6 +114,284 @@ describe('toggl api errors', () => {
 
     await expect(api.getWorkspaces()).rejects.not.toMatchObject({
       message: expect.stringContaining('abc123'),
+    });
+  });
+
+  it('retries 5xx server errors and eventually throws', async () => {
+    fetchMock.mockResolvedValue(response({ status: 500, text: 'Internal Server Error' }));
+
+    const api = new TogglAPI('token');
+    await expect(api.getWorkspaces()).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('getWorkspaceUsers', () => {
+  afterEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it('fetches from the documented /users endpoint and returns the raw records', async () => {
+    fetchMock.mockResolvedValue(
+      response({
+        status: 200,
+        json: {
+          items: [
+            {
+              id: TEST_USER_ID,
+              fullname: 'Alice',
+              email: 'alice@example.com',
+              is_active: true,
+              inactive: false,
+              is_admin: false,
+              role: 'admin',
+            },
+            {
+              id: TEST_USER_ID + 1,
+              fullname: 'Bob',
+              email: 'bob@example.com',
+              is_active: true,
+              inactive: false,
+              is_admin: true,
+              role: 'admin',
+            },
+          ],
+        },
+      })
+    );
+
+    const api = new TogglAPI('token');
+    const users = await api.getWorkspaceUsers(TEST_WORKSPACE_ID);
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining(`/workspaces/${TEST_WORKSPACE_ID}/users`),
+      expect.any(Object)
+    );
+    expect(users).toHaveLength(2);
+    expect(users[0]).toMatchObject({ id: TEST_USER_ID, fullname: 'Alice' });
+  });
+});
+
+describe('toWorkspaceMemberSummary', () => {
+  it('maps id/fullname/is_active to uid/name/active', () => {
+    const summary = TogglAPI.toWorkspaceMemberSummary({
+      id: TEST_USER_ID,
+      fullname: 'Alice',
+      is_active: true,
+    });
+
+    expect(summary).toEqual({ uid: TEST_USER_ID, name: 'Alice', active: true });
+  });
+
+  it('exposes only uid/name/active and drops email, admin, role, and rates', () => {
+    const summary = TogglAPI.toWorkspaceMemberSummary({
+      id: TEST_USER_ID,
+      fullname: 'Alice',
+      is_active: true,
+      email: 'alice@example.com',
+      is_admin: true,
+      role: 'admin',
+      ...({ rate: 99, labor_cost: 50, invite_url: 'https://secret' } as Record<string, unknown>),
+    });
+
+    expect(Object.keys(summary).sort()).toEqual(['active', 'name', 'uid']);
+    expect(summary).not.toHaveProperty('email');
+    expect(summary).not.toHaveProperty('is_admin');
+    expect(summary).not.toHaveProperty('role');
+    expect(summary).not.toHaveProperty('rate');
+    expect(summary).not.toHaveProperty('labor_cost');
+  });
+});
+
+describe('getTimeEntriesForUserAndDateRange', () => {
+  afterEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it('converts exclusive end date to inclusive before calling the Reports API', async () => {
+    fetchMock.mockResolvedValue(response({ status: 200, json: [] }));
+
+    const api = new TogglAPI('token');
+    await api.getTimeEntriesForUserAndDateRange(
+      TEST_WORKSPACE_ID,
+      TEST_USER_ID,
+      new Date(2026, 4, 4),
+      new Date(2026, 4, 11)
+    );
+
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body as string);
+    expect(body.start_date).toBe('2026-05-04');
+    expect(body.end_date).toBe('2026-05-10');
+  });
+
+  it('sends user_ids as an array containing the requested uid', async () => {
+    fetchMock.mockResolvedValue(response({ status: 200, json: [] }));
+
+    const api = new TogglAPI('token');
+    await api.getTimeEntriesForUserAndDateRange(
+      TEST_WORKSPACE_ID,
+      TEST_USER_ID,
+      new Date(2026, 4, 4),
+      new Date(2026, 4, 11)
+    );
+
+    const body = JSON.parse(fetchMock.mock.calls[0]![1].body as string);
+    expect(body.user_ids).toEqual([TEST_USER_ID]);
+  });
+
+  it('flattens grouped report rows into individual TimeEntry objects', async () => {
+    fetchMock.mockResolvedValue(
+      response({
+        status: 200,
+        json: [
+          reportRow({ billable: false }),
+          reportRow({
+            billable: true,
+            time_entries: [
+              {
+                id: 1002,
+                seconds: 1800,
+                start: '2026-05-04T11:00:00+00:00',
+                stop: '2026-05-04T11:30:00+00:00',
+              },
+            ],
+          }),
+        ],
+      })
+    );
+
+    const api = new TogglAPI('token');
+    const entries = await api.getTimeEntriesForUserAndDateRange(
+      TEST_WORKSPACE_ID,
+      TEST_USER_ID,
+      new Date(2026, 4, 4),
+      new Date(2026, 4, 11)
+    );
+
+    expect(entries).toHaveLength(2);
+    expect(entries[0]).toMatchObject({
+      id: 1001,
+      workspace_id: TEST_WORKSPACE_ID,
+      project_id: TEST_PROJECT_ID,
+      duration: 3600,
+      description: 'test entry',
+      user_id: TEST_USER_ID,
+      billable: false,
+    });
+    expect(entries[1]).toMatchObject({ id: 1002, duration: 1800, billable: true });
+  });
+
+  it('handles a flat row that carries entry fields directly', async () => {
+    fetchMock.mockResolvedValue(
+      response({
+        status: 200,
+        json: [
+          {
+            user_id: TEST_USER_ID,
+            project_id: TEST_PROJECT_ID,
+            task_id: null,
+            billable: true,
+            description: 'flat entry',
+            tag_ids: [],
+            id: 2001,
+            seconds: 1200,
+            start: '2026-05-04T09:00:00+00:00',
+            stop: '2026-05-04T09:20:00+00:00',
+          },
+        ],
+      })
+    );
+
+    const api = new TogglAPI('token');
+    const entries = await api.getTimeEntriesForUserAndDateRange(
+      TEST_WORKSPACE_ID,
+      TEST_USER_ID,
+      new Date(2026, 4, 4),
+      new Date(2026, 4, 11)
+    );
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      id: 2001,
+      workspace_id: TEST_WORKSPACE_ID,
+      project_id: TEST_PROJECT_ID,
+      duration: 1200,
+      description: 'flat entry',
+      user_id: TEST_USER_ID,
+      billable: true,
+    });
+  });
+
+  it('fetches multiple pages until X-Next-Row-Number header is absent', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        response({
+          status: 200,
+          json: [
+            reportRow({
+              time_entries: [
+                {
+                  id: 1,
+                  seconds: 100,
+                  start: '2026-05-04T10:00:00+12:00',
+                  stop: '2026-05-04T10:01:40+12:00',
+                },
+              ],
+            }),
+          ],
+          headers: { 'x-next-row-number': '2' },
+        })
+      )
+      .mockResolvedValueOnce(
+        response({
+          status: 200,
+          json: [
+            reportRow({
+              time_entries: [
+                {
+                  id: 2,
+                  seconds: 200,
+                  start: '2026-05-05T10:00:00+12:00',
+                  stop: '2026-05-05T10:03:20+12:00',
+                },
+              ],
+            }),
+          ],
+        })
+      );
+
+    const api = new TogglAPI('token');
+    const entries = await api.getTimeEntriesForUserAndDateRange(
+      TEST_WORKSPACE_ID,
+      TEST_USER_ID,
+      new Date(2026, 4, 4),
+      new Date(2026, 4, 11)
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(entries.map((entry) => entry.id)).toEqual([1, 2]);
+    const secondBody = JSON.parse(fetchMock.mock.calls[1]![1].body as string);
+    expect(secondBody.first_row_number).toBe(2);
+  });
+
+  it('throws a quota error with a tip for 402 Reports API responses', async () => {
+    fetchMock.mockResolvedValue(
+      response({ status: 402, text: 'The quota will reset in 300 seconds.' })
+    );
+
+    const api = new TogglAPI('token');
+    await expect(
+      api.getTimeEntriesForUserAndDateRange(
+        TEST_WORKSPACE_ID,
+        TEST_USER_ID,
+        new Date(2026, 4, 4),
+        new Date(2026, 4, 11)
+      )
+    ).rejects.toMatchObject({
+      code: 'TOGGL_QUOTA_LIMIT',
+      status: 402,
+      retry_after_seconds: 300,
+      tip: expect.stringContaining('quota'),
     });
   });
 });

--- a/tests/toggl-api.test.ts
+++ b/tests/toggl-api.test.ts
@@ -22,9 +22,12 @@ function response({
   retryAfter?: string;
   headers?: Record<string, string | undefined>;
 }) {
+  const normalizedExtraHeaders = Object.fromEntries(
+    Object.entries(extraHeaders).map(([name, value]) => [name.toLowerCase(), value])
+  );
   const allHeaders: Record<string, string | undefined> = {
     'retry-after': retryAfter,
-    ...extraHeaders,
+    ...normalizedExtraHeaders,
   };
 
   return {
@@ -201,6 +204,23 @@ describe('toWorkspaceMemberSummary', () => {
     expect(summary).not.toHaveProperty('rate');
     expect(summary).not.toHaveProperty('labor_cost');
   });
+
+  it('does not default active to true when neither is_active nor inactive is present', () => {
+    const summary = TogglAPI.toWorkspaceMemberSummary({
+      id: TEST_USER_ID,
+      fullname: 'Alice',
+    });
+
+    expect(summary.active).toBe(false);
+  });
+
+  it('throws when id is missing at runtime', () => {
+    expect(() =>
+      TogglAPI.toWorkspaceMemberSummary({
+        fullname: 'Alice',
+      } as unknown as { id: number; fullname: string })
+    ).toThrow('Toggl workspace user is missing a numeric id.');
+  });
 });
 
 describe('getTimeEntriesForUserAndDateRange', () => {
@@ -339,7 +359,7 @@ describe('getTimeEntriesForUserAndDateRange', () => {
               ],
             }),
           ],
-          headers: { 'x-next-row-number': '2' },
+          headers: { 'X-Next-Row-Number': '2' },
         })
       )
       .mockResolvedValueOnce(


### PR DESCRIPTION
## Summary
- refreshes PR #46 on top of the self-host HTTP foundation branch
- adds privacy-safe `toggl_list_workspace_users` using documented `GET /workspaces/{id}/users`, returning only `uid`, `name`, and `active`
- adds optional `uid` report filtering through Toggl Reports API v3 for daily, weekly, project summary, and workspace summary tools
- keeps existing authenticated-user report behavior unchanged when `uid` is omitted
- carries forward original contributor work with attribution to Vincent Ardern

## Breaking Changes
None.

## Related
- Refreshes and supersedes #46 pending review of this stacked branch
- Stacked on #36 / `feat/self-host-streamable-http`

## Verification
- `npm run build`
- `npm test`
- `npm run test:coverage`
- `npm run lint` (exits 0 with existing no-explicit-any warnings)
- `npm audit --audit-level=high` (exits 0; existing moderate brace-expansion advisory remains)

Co-authored-by: Vincent Ardern <vincent@charityaccounts.co.nz>