### PR TITLE
feat(toggl): add time entry task tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,8 +128,16 @@ mcp-toggl --help
 | Tool                      | What it does                                                                        |
 | ------------------------- | ----------------------------------------------------------------------------------- |
 | `toggl_get_current_entry` | Returns the running timer, elapsed seconds, and hydrated project/workspace context. |
-| `toggl_start_timer`       | Starts a timer with description, optional project/task, and tags.                   |
+| `toggl_start_timer`       | Starts a timer with description, optional project/task, tags, and billable flag.    |
 | `toggl_stop_timer`        | Stops the currently running timer.                                                  |
+
+### Time Entry CRUD
+
+| Tool                      | What it does                                                                                |
+| ------------------------- | ------------------------------------------------------------------------------------------- |
+| `toggl_create_time_entry` | Creates a completed time entry for retroactively logging past work.                         |
+| `toggl_update_time_entry` | Updates fields on an existing entry, including project, task, description, tags, and times. |
+| `toggl_delete_time_entry` | Deletes a time entry by ID.                                                                 |
 
 ### Lookups
 
@@ -139,6 +147,7 @@ mcp-toggl --help
 | `toggl_list_workspaces` | Lists all accessible workspaces.                                                 |
 | `toggl_list_projects`   | Lists projects for a workspace using cache-backed reads after first fetch.       |
 | `toggl_list_clients`    | Lists clients for a workspace using cache-backed reads after first fetch.        |
+| `toggl_list_tasks`      | Lists tasks for a project so entries can be assigned to a valid `task_id`.       |
 
 ### Cache Management
 

--- a/server.json
+++ b/server.json
@@ -41,6 +41,18 @@
       "description": "Stop the currently running timer"
     },
     {
+      "name": "toggl_create_time_entry",
+      "description": "Create a completed time entry"
+    },
+    {
+      "name": "toggl_update_time_entry",
+      "description": "Update an existing time entry"
+    },
+    {
+      "name": "toggl_delete_time_entry",
+      "description": "Delete a time entry"
+    },
+    {
       "name": "toggl_daily_report",
       "description": "Generate a daily report with project and workspace breakdowns"
     },
@@ -67,6 +79,10 @@
     {
       "name": "toggl_list_clients",
       "description": "List clients in a workspace"
+    },
+    {
+      "name": "toggl_list_tasks",
+      "description": "List tasks in a project"
     },
     {
       "name": "toggl_warm_cache",

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ import {
   parseLocalYMD,
   localDateRangeFromArgs,
 } from './utils.js';
-import type { CacheConfig, TimelineEvent, TimeEntry } from './types.js';
+import type { CacheConfig, TimelineEvent, TimeEntry, UpdateTimeEntryRequest } from './types.js';
 
 function parseInclusiveEndDate(value: string): Date {
   const date = parseLocalYMD(value);
@@ -59,9 +59,15 @@ function isUserInputError(error: unknown): error is Error {
     'Invalid date format:',
     'Invalid calendar date:',
     'Invalid period:',
+    'Invalid argument:',
     'start_date must',
     'end_date must',
     'title_mode must',
+    'start is required',
+    'Provide either stop or duration',
+    'entry_id is required',
+    'No fields to update',
+    'project_id is required',
   ].some((prefix) => error.message.startsWith(prefix));
 }
 
@@ -222,6 +228,92 @@ async function resolveWorkspaceForTool(
   });
 }
 
+function invalidArgument(message: string): never {
+  throw new Error(`Invalid argument: ${message}`);
+}
+
+function optionalStringArg(
+  args: Record<string, unknown> | undefined,
+  key: string
+): string | undefined {
+  const value = args?.[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string') invalidArgument(`${key} must be a string`);
+  return value;
+}
+
+function requiredNonEmptyStringArg(
+  args: Record<string, unknown> | undefined,
+  key: string,
+  missingMessage: string
+): string {
+  const value = args?.[key];
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new Error(missingMessage);
+  }
+  return value;
+}
+
+function optionalFiniteNumberArg(
+  args: Record<string, unknown> | undefined,
+  key: string
+): number | undefined {
+  const value = args?.[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    invalidArgument(`${key} must be a finite number`);
+  }
+  return value;
+}
+
+function requiredFiniteNumberArg(
+  args: Record<string, unknown> | undefined,
+  key: string,
+  missingMessage: string
+): number {
+  if (args?.[key] === undefined) {
+    throw new Error(missingMessage);
+  }
+  return optionalFiniteNumberArg(args, key)!;
+}
+
+function optionalBooleanArg(
+  args: Record<string, unknown> | undefined,
+  key: string
+): boolean | undefined {
+  const value = args?.[key];
+  if (value === undefined) return undefined;
+  if (typeof value !== 'boolean') invalidArgument(`${key} must be a boolean`);
+  return value;
+}
+
+function optionalStringArrayArg(
+  args: Record<string, unknown> | undefined,
+  key: string
+): string[] | undefined {
+  const value = args?.[key];
+  if (value === undefined) return undefined;
+  if (!Array.isArray(value) || value.some((item) => typeof item !== 'string')) {
+    invalidArgument(`${key} must be an array of strings`);
+  }
+  return value;
+}
+
+function optionalNumberArrayArg(
+  args: Record<string, unknown> | undefined,
+  key: string
+): number[] | undefined {
+  const value = args?.[key];
+  if (value === undefined) return undefined;
+  if (
+    !Array.isArray(value) ||
+    value.some((item) => typeof item !== 'number' || !Number.isFinite(item))
+  ) {
+    invalidArgument(`${key} must be an array of finite numbers`);
+  }
+  return value;
+}
+
 // Define tool schemas
 const tools: Tool[] = [
   // Health/authentication
@@ -323,6 +415,11 @@ const tools: Tool[] = [
           items: { type: 'string' },
           description: 'Tags for the entry',
         },
+        billable: {
+          type: 'boolean',
+          description:
+            'Whether the entry is billable. If omitted, Toggl applies the project default. Some Toggl plans ignore this flag and treat the entry as non-billable.',
+        },
       },
     },
   },
@@ -338,6 +435,155 @@ const tools: Tool[] = [
       type: 'object',
       properties: {},
       required: [],
+    },
+  },
+  {
+    name: 'toggl_create_time_entry',
+    description:
+      'Create a completed time entry for retroactively logging past work. Provide either stop or duration, not both. For a live timer, use toggl_start_timer.',
+    annotations: {
+      readOnlyHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        start: {
+          type: 'string',
+          description: 'ISO 8601 datetime when the entry began',
+        },
+        stop: {
+          type: 'string',
+          description: 'ISO 8601 datetime when the entry ended. Provide stop or duration.',
+        },
+        duration: {
+          type: 'number',
+          description: 'Duration in seconds. Provide stop or duration.',
+        },
+        description: {
+          type: 'string',
+          description: 'Description of the time entry',
+        },
+        project_id: {
+          type: 'number',
+          description: 'Project ID (optional)',
+        },
+        task_id: {
+          type: 'number',
+          description: 'Task ID (optional)',
+        },
+        tags: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Tag names; Toggl resolves them server-side',
+        },
+        tag_ids: {
+          type: 'array',
+          items: { type: 'number' },
+          description: 'Tag IDs, alternative to tags',
+        },
+        billable: {
+          type: 'boolean',
+          description:
+            'Whether the entry is billable. If omitted, Toggl applies the project default. Some Toggl plans ignore this flag and treat the entry as non-billable.',
+        },
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
+        },
+      },
+      required: ['start'],
+      oneOf: [{ required: ['stop'] }, { required: ['duration'] }],
+    },
+  },
+  {
+    name: 'toggl_update_time_entry',
+    description: 'Update fields on an existing time entry. Pass only the fields to change.',
+    annotations: {
+      readOnlyHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        entry_id: {
+          type: 'number',
+          description: 'Time entry ID to update',
+        },
+        description: {
+          type: 'string',
+          description: 'Updated description',
+        },
+        project_id: {
+          type: 'number',
+          description: 'Updated project ID',
+        },
+        task_id: {
+          type: 'number',
+          description: 'Updated task ID',
+        },
+        tags: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Tag names; replaces existing tags on the entry',
+        },
+        tag_ids: {
+          type: 'array',
+          items: { type: 'number' },
+          description: 'Tag IDs; replaces existing tags on the entry',
+        },
+        billable: {
+          type: 'boolean',
+          description:
+            'Whether the entry is billable. Some Toggl plans ignore this flag and treat the entry as non-billable.',
+        },
+        start: {
+          type: 'string',
+          description: 'Updated ISO 8601 start datetime',
+        },
+        stop: {
+          type: 'string',
+          description: 'Updated ISO 8601 stop datetime',
+        },
+        duration: {
+          type: 'number',
+          description: 'Updated duration in seconds',
+        },
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
+        },
+      },
+      required: ['entry_id'],
+    },
+  },
+  {
+    name: 'toggl_delete_time_entry',
+    description: 'Delete a time entry by ID',
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        entry_id: {
+          type: 'number',
+          description: 'Time entry ID to delete',
+        },
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
+        },
+      },
+      required: ['entry_id'],
     },
   },
 
@@ -498,6 +744,30 @@ const tools: Tool[] = [
             'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
         },
       },
+    },
+  },
+  {
+    name: 'toggl_list_tasks',
+    description: 'List tasks for a project in a workspace',
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        project_id: {
+          type: 'number',
+          description: 'Project ID to list tasks for',
+        },
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
+        },
+      },
+      required: ['project_id'],
     },
   },
 
@@ -761,10 +1031,11 @@ export function createTogglServer(): Server {
 
           const entry = await api.startTimer(
             workspaceId,
-            args?.description as string | undefined,
-            args?.project_id as number | undefined,
-            args?.task_id as number | undefined,
-            args?.tags as string[] | undefined
+            optionalStringArg(args, 'description'),
+            optionalFiniteNumberArg(args, 'project_id'),
+            optionalFiniteNumberArg(args, 'task_id'),
+            optionalStringArrayArg(args, 'tags'),
+            optionalBooleanArg(args, 'billable')
           );
 
           await ensureCache();
@@ -826,6 +1097,99 @@ export function createTogglServer(): Server {
               },
             ],
           };
+        }
+
+        case 'toggl_create_time_entry': {
+          const workspaceId = await resolveWorkspaceForTool(args, 'creating a time entry');
+          const start = requiredNonEmptyStringArg(
+            args,
+            'start',
+            'start is required (ISO 8601 datetime)'
+          );
+          const stop = optionalStringArg(args, 'stop');
+          const duration = optionalFiniteNumberArg(args, 'duration');
+          if (stop !== undefined && duration !== undefined) {
+            throw new Error('Provide either stop or duration, not both');
+          }
+          if (stop === undefined && duration === undefined) {
+            throw new Error('Provide either stop or duration');
+          }
+
+          const entry = await api.createTimeEntry(workspaceId, {
+            start,
+            stop,
+            duration,
+            description: optionalStringArg(args, 'description'),
+            project_id: optionalFiniteNumberArg(args, 'project_id'),
+            task_id: optionalFiniteNumberArg(args, 'task_id'),
+            tags: optionalStringArrayArg(args, 'tags'),
+            tag_ids: optionalNumberArrayArg(args, 'tag_ids'),
+            billable: optionalBooleanArg(args, 'billable'),
+          });
+
+          await ensureCache();
+          const hydrated = await cache.hydrateTimeEntries([entry]);
+
+          return jsonResponse({
+            success: true,
+            message: 'Time entry created',
+            entry: hydrated[0],
+          });
+        }
+
+        case 'toggl_update_time_entry': {
+          const workspaceId = await resolveWorkspaceForTool(args, 'updating a time entry');
+          const entryId = requiredFiniteNumberArg(args, 'entry_id', 'entry_id is required');
+
+          const updates: UpdateTimeEntryRequest = {};
+          const description = optionalStringArg(args, 'description');
+          const projectId = optionalFiniteNumberArg(args, 'project_id');
+          const taskId = optionalFiniteNumberArg(args, 'task_id');
+          const tags = optionalStringArrayArg(args, 'tags');
+          const tagIds = optionalNumberArrayArg(args, 'tag_ids');
+          const billable = optionalBooleanArg(args, 'billable');
+          const start = optionalStringArg(args, 'start');
+          const stop = optionalStringArg(args, 'stop');
+          const duration = optionalFiniteNumberArg(args, 'duration');
+
+          if (description !== undefined) updates.description = description;
+          if (projectId !== undefined) updates.project_id = projectId;
+          if (taskId !== undefined) updates.task_id = taskId;
+          if (tags !== undefined) updates.tags = tags;
+          if (tagIds !== undefined) updates.tag_ids = tagIds;
+          if (billable !== undefined) updates.billable = billable;
+          if (start !== undefined) updates.start = start;
+          if (stop !== undefined) updates.stop = stop;
+          if (duration !== undefined) updates.duration = duration;
+
+          if (Object.keys(updates).length === 0) {
+            throw new Error('No fields to update; provide at least one updatable field');
+          }
+
+          const updated = await api.updateTimeEntry(workspaceId, entryId, updates);
+
+          await ensureCache();
+          const hydrated = await cache.hydrateTimeEntries([updated]);
+
+          return jsonResponse({
+            success: true,
+            message: 'Time entry updated',
+            entry: hydrated[0],
+          });
+        }
+
+        case 'toggl_delete_time_entry': {
+          const workspaceId = await resolveWorkspaceForTool(args, 'deleting a time entry');
+          const entryId = requiredFiniteNumberArg(args, 'entry_id', 'entry_id is required');
+
+          await api.deleteTimeEntry(workspaceId, entryId);
+
+          return jsonResponse({
+            success: true,
+            message: 'Time entry deleted',
+            workspace_id: workspaceId,
+            entry_id: entryId,
+          });
         }
 
         // Reporting tools
@@ -1081,6 +1445,26 @@ export function createTogglServer(): Server {
               },
             ],
           };
+        }
+
+        case 'toggl_list_tasks': {
+          const workspaceId = await resolveWorkspaceForTool(args, 'listing tasks');
+          const projectId = requiredFiniteNumberArg(args, 'project_id', 'project_id is required');
+
+          const tasks = await cache.getTasks(workspaceId, projectId);
+
+          return jsonResponse({
+            workspace_id: workspaceId,
+            project_id: projectId,
+            count: tasks.length,
+            tasks: tasks.map((task) => ({
+              id: task.id,
+              name: task.name,
+              active: task.active,
+              tracked_seconds: task.tracked_seconds,
+              estimated_seconds: task.estimated_seconds,
+            })),
+          });
         }
 
         // Cache management

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -130,12 +130,21 @@ export class TogglAPI {
           throw new Error(`Toggl API request failed (${response.status}).`);
         }
 
-        // Handle 204 No Content
+        // Toggl returns 200 with an empty body for some successful write endpoints.
         if (response.status === 204) {
           return {} as T;
         }
 
-        return (await response.json()) as T;
+        if (response.headers.get('content-length') === '0') {
+          return {} as T;
+        }
+
+        const responseText = await response.text();
+        if (responseText.length === 0) {
+          return {} as T;
+        }
+
+        return JSON.parse(responseText) as T;
       } catch (error: any) {
         if (error?.noRetry || i === retries - 1) throw error;
         // Exponential backoff for transient/network errors
@@ -149,6 +158,10 @@ export class TogglAPI {
   // User methods
   async getMe(): Promise<User> {
     return this.request<User>('GET', '/me');
+  }
+
+  private async writeRequest<T>(method: string, endpoint: string, body?: unknown): Promise<T> {
+    return this.request<T>(method, endpoint, body, 1);
   }
 
   async getUser(_userId: number): Promise<User> {
@@ -263,7 +276,7 @@ export class TogglAPI {
       ...entry,
     };
 
-    return this.request<TimeEntry>('POST', `/workspaces/${workspaceId}/time_entries`, payload);
+    return this.writeRequest<TimeEntry>('POST', `/workspaces/${workspaceId}/time_entries`, payload);
   }
 
   async updateTimeEntry(
@@ -271,7 +284,7 @@ export class TogglAPI {
     timeEntryId: number,
     updates: UpdateTimeEntryRequest
   ): Promise<TimeEntry> {
-    return this.request<TimeEntry>(
+    return this.writeRequest<TimeEntry>(
       'PUT',
       `/workspaces/${workspaceId}/time_entries/${timeEntryId}`,
       updates
@@ -279,7 +292,10 @@ export class TogglAPI {
   }
 
   async deleteTimeEntry(workspaceId: number, timeEntryId: number): Promise<void> {
-    await this.request<void>('DELETE', `/workspaces/${workspaceId}/time_entries/${timeEntryId}`);
+    await this.writeRequest<void>(
+      'DELETE',
+      `/workspaces/${workspaceId}/time_entries/${timeEntryId}`
+    );
   }
 
   async startTimer(
@@ -287,13 +303,15 @@ export class TogglAPI {
     description?: string,
     projectId?: number,
     taskId?: number,
-    tags?: string[]
+    tags?: string[],
+    billable?: boolean
   ): Promise<TimeEntry> {
     const entry: Partial<CreateTimeEntryRequest> = {
       description,
       project_id: projectId,
       task_id: taskId,
       tags,
+      billable,
       start: new Date().toISOString(),
       duration: -1, // Negative duration indicates running timer
     };

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -34,6 +34,14 @@ function installMockTogglApi() {
     color: '#123456',
   };
   const client = { id: 40, workspace_id: 20, name: 'Client', archived: false };
+  const task = {
+    id: 45,
+    workspace_id: 20,
+    project_id: 30,
+    name: 'Review',
+    active: true,
+    tracked_seconds: 0,
+  };
   const tags = [{ id: 50, workspace_id: 20, name: 'tag' }];
   const entry = {
     id: 60,
@@ -48,7 +56,7 @@ function installMockTogglApi() {
     tag_ids: [50],
   };
 
-  fetchMock.mockImplementation(async (url: string, init?: { method?: string }) => {
+  fetchMock.mockImplementation(async (url: string, init?: { body?: string; method?: string }) => {
     const method = init?.method ?? 'GET';
 
     if (url.endsWith('/me'))
@@ -56,6 +64,7 @@ function installMockTogglApi() {
     if (url.endsWith('/workspaces')) return response({ json: [workspace] });
     if (url.endsWith('/workspaces/20')) return response({ json: workspace });
     if (url.endsWith('/workspaces/20/projects')) return response({ json: [project] });
+    if (url.endsWith('/workspaces/20/projects/30/tasks')) return response({ json: [task] });
     if (url.endsWith('/workspaces/20/clients')) return response({ json: [client] });
     if (url.endsWith('/workspaces/20/tags')) return response({ json: tags });
     if (url.includes('/me/time_entries/current')) return response({ json: null });
@@ -76,15 +85,34 @@ function installMockTogglApi() {
       });
     }
     if (method === 'POST' && url.endsWith('/workspaces/20/time_entries')) {
+      const body = JSON.parse(init?.body ?? '{}') as Record<string, unknown>;
       return response({
         json: {
           ...entry,
           id: 61,
-          stop: undefined,
-          duration: -1,
-          description: 'Started timer',
+          project_id: body.project_id ?? entry.project_id,
+          task_id: body.task_id,
+          stop: body.stop,
+          duration: body.duration ?? -1,
+          description: body.description ?? 'Started timer',
+          billable: body.billable,
+          start: body.start ?? entry.start,
         },
       });
+    }
+    if (method === 'PUT' && url.endsWith('/workspaces/20/time_entries/60')) {
+      const body = JSON.parse(init?.body ?? '{}') as Record<string, unknown>;
+      return response({
+        json: {
+          ...entry,
+          ...body,
+          id: 60,
+          workspace_id: 20,
+        },
+      });
+    }
+    if (method === 'DELETE' && url.endsWith('/workspaces/20/time_entries/60')) {
+      return response({ json: {} });
     }
 
     return response({ status: 404, json: { error: 'not found' } });
@@ -138,6 +166,40 @@ describe('mcp server handlers', () => {
         default: true,
         deprecated: true,
       });
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('lists task and time-entry write tool schemas', async () => {
+    const { client } = await createClient();
+
+    try {
+      const tools = await client.listTools();
+      const byName = new Map(tools.tools.map((tool) => [tool.name, tool]));
+
+      expect(byName.get('toggl_list_tasks')?.annotations).toMatchObject({
+        readOnlyHint: true,
+        idempotentHint: true,
+      });
+      expect(byName.get('toggl_list_tasks')?.inputSchema.required).toEqual(['project_id']);
+
+      expect(byName.get('toggl_create_time_entry')?.annotations).toMatchObject({
+        readOnlyHint: false,
+        idempotentHint: false,
+      });
+      expect(byName.get('toggl_update_time_entry')?.annotations).toMatchObject({
+        readOnlyHint: false,
+        idempotentHint: true,
+      });
+      expect(byName.get('toggl_delete_time_entry')?.annotations).toMatchObject({
+        destructiveHint: true,
+      });
+
+      const startTimerProps = byName.get('toggl_start_timer')?.inputSchema.properties as
+        | Record<string, unknown>
+        | undefined;
+      expect(startTimerProps).toHaveProperty('billable');
     } finally {
       await client.close();
     }
@@ -247,6 +309,14 @@ describe('mcp server handlers', () => {
         clients: [{ id: 40, name: 'Client' }],
       });
       await expect(
+        callTool(client, 'toggl_list_tasks', { workspace_id: 20, project_id: 30 })
+      ).resolves.toMatchObject({
+        workspace_id: 20,
+        project_id: 30,
+        count: 1,
+        tasks: [{ id: 45, name: 'Review' }],
+      });
+      await expect(
         callTool(client, 'toggl_warm_cache', { workspace_id: 20 })
       ).resolves.toMatchObject({
         success: true,
@@ -288,15 +358,143 @@ describe('mcp server handlers', () => {
           workspace_id: 20,
           description: 'Started timer',
           project_id: 30,
+          task_id: 45,
           tags: ['tag'],
+          billable: true,
         })
       ).resolves.toMatchObject({
         success: true,
-        entry: { id: 61, running: true },
+        entry: { id: 61, billable: true, running: true, task_name: 'Review' },
+      });
+      await expect(
+        callTool(client, 'toggl_create_time_entry', {
+          workspace_id: 20,
+          start: '2026-05-01T11:00:00Z',
+          duration: 1800,
+          description: 'Backfilled work',
+          project_id: 30,
+          task_id: 45,
+          billable: true,
+        })
+      ).resolves.toMatchObject({
+        success: true,
+        entry: { id: 61, description: 'Backfilled work', task_name: 'Review' },
+      });
+      await expect(
+        callTool(client, 'toggl_update_time_entry', {
+          workspace_id: 20,
+          entry_id: 60,
+          project_id: 30,
+          task_id: 45,
+          description: 'Categorized work',
+          billable: true,
+        })
+      ).resolves.toMatchObject({
+        success: true,
+        entry: { id: 60, description: 'Categorized work', task_name: 'Review' },
+      });
+      await expect(
+        callTool(client, 'toggl_delete_time_entry', { workspace_id: 20, entry_id: 60 })
+      ).resolves.toMatchObject({
+        success: true,
+        workspace_id: 20,
+        entry_id: 60,
       });
       await expect(callTool(client, 'toggl_stop_timer')).resolves.toMatchObject({
         success: false,
         message: 'No timer currently running',
+      });
+
+      const updateCall = fetchMock.mock.calls.find(
+        ([url, init]) =>
+          String(url).endsWith('/workspaces/20/time_entries/60') && init?.method === 'PUT'
+      );
+      expect(updateCall).toBeDefined();
+      expect(JSON.parse(updateCall![1]?.body as string)).toEqual({
+        description: 'Categorized work',
+        project_id: 30,
+        task_id: 45,
+        billable: true,
+      });
+    } finally {
+      await client.close();
+    }
+  });
+
+  it('returns user-input errors for invalid write tool arguments', async () => {
+    installMockTogglApi();
+
+    const { client } = await createClient();
+
+    try {
+      await expect(
+        callTool(client, 'toggl_update_time_entry', { workspace_id: 20, entry_id: 60 })
+      ).resolves.toMatchObject({
+        error: true,
+        code: 'INVALID_ARGUMENT',
+        message: 'No fields to update; provide at least one updatable field',
+      });
+      await expect(
+        callTool(client, 'toggl_create_time_entry', {
+          workspace_id: 20,
+          start: '2026-05-01T11:00:00Z',
+          stop: '2026-05-01T12:00:00Z',
+          duration: 3600,
+        })
+      ).resolves.toMatchObject({
+        error: true,
+        code: 'INVALID_ARGUMENT',
+        message: 'Provide either stop or duration, not both',
+      });
+      await expect(
+        callTool(client, 'toggl_create_time_entry', {
+          workspace_id: 20,
+          start: '2026-05-01T11:00:00Z',
+        })
+      ).resolves.toMatchObject({
+        error: true,
+        code: 'INVALID_ARGUMENT',
+        message: 'Provide either stop or duration',
+      });
+      await expect(
+        callTool(client, 'toggl_create_time_entry', {
+          workspace_id: 20,
+          start: '2026-05-01T11:00:00Z',
+          duration: '3600',
+        })
+      ).resolves.toMatchObject({
+        error: true,
+        code: 'INVALID_ARGUMENT',
+        message: 'Invalid argument: duration must be a finite number',
+      });
+      await expect(
+        callTool(client, 'toggl_update_time_entry', {
+          workspace_id: 20,
+          entry_id: 60,
+          billable: 'true',
+        })
+      ).resolves.toMatchObject({
+        error: true,
+        code: 'INVALID_ARGUMENT',
+        message: 'Invalid argument: billable must be a boolean',
+      });
+      await expect(
+        callTool(client, 'toggl_update_time_entry', {
+          workspace_id: 20,
+          entry_id: 60,
+          tags: 'tag',
+        })
+      ).resolves.toMatchObject({
+        error: true,
+        code: 'INVALID_ARGUMENT',
+        message: 'Invalid argument: tags must be an array of strings',
+      });
+      await expect(
+        callTool(client, 'toggl_list_tasks', { workspace_id: 20 })
+      ).resolves.toMatchObject({
+        error: true,
+        code: 'INVALID_ARGUMENT',
+        message: 'project_id is required',
       });
     } finally {
       await client.close();

--- a/tests/toggl-api.test.ts
+++ b/tests/toggl-api.test.ts
@@ -14,20 +14,34 @@ function response({
   text = '',
   json,
   retryAfter,
+  contentLength,
 }: {
   status: number;
   text?: string;
   json?: unknown;
   retryAfter?: string;
+  contentLength?: string;
 }) {
   return {
     status,
     ok: status >= 200 && status < 300,
     headers: {
-      get: vi.fn((name: string) => (name.toLowerCase() === 'retry-after' ? retryAfter : null)),
+      get: vi.fn((name: string) => {
+        const key = name.toLowerCase();
+        if (key === 'retry-after') return retryAfter;
+        if (key === 'content-length') return contentLength;
+        return null;
+      }),
     },
-    text: vi.fn(async () => text),
-    json: vi.fn(async () => json),
+    text: vi.fn(async () => {
+      if (text) return text;
+      if (json !== undefined) return JSON.stringify(json);
+      return '';
+    }),
+    json: vi.fn(async () => {
+      if (json !== undefined) return json;
+      return JSON.parse(text);
+    }),
   };
 }
 
@@ -84,5 +98,178 @@ describe('toggl api errors', () => {
     await expect(api.getWorkspaces()).rejects.not.toMatchObject({
       message: expect.stringContaining('abc123'),
     });
+  });
+
+  it('treats HTTP 200 with content-length: 0 as a successful empty response', async () => {
+    fetchMock.mockResolvedValue(response({ status: 200, contentLength: '0', text: '' }));
+
+    const api = new TogglAPI('token');
+    await expect(api.deleteTimeEntry(1, 100)).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('toggl api time entry CRUD and tasks', () => {
+  afterEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it('POSTs to the workspace time_entries endpoint with start, billable, and created_with', async () => {
+    fetchMock.mockResolvedValue(
+      response({
+        status: 200,
+        json: {
+          id: 100,
+          workspace_id: 1,
+          start: '2026-05-01T09:00:00Z',
+          stop: '2026-05-01T10:00:00Z',
+          duration: 3600,
+          description: 'Focused work',
+          billable: true,
+        },
+      })
+    );
+
+    const api = new TogglAPI('token');
+    const entry = await api.createTimeEntry(1, {
+      start: '2026-05-01T09:00:00Z',
+      stop: '2026-05-01T10:00:00Z',
+      description: 'Focused work',
+      billable: true,
+    });
+
+    expect(entry.id).toBe(100);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.track.toggl.com/api/v9/workspaces/1/time_entries');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      workspace_id: 1,
+      created_with: 'mcp-toggl',
+      start: '2026-05-01T09:00:00Z',
+      stop: '2026-05-01T10:00:00Z',
+      description: 'Focused work',
+      billable: true,
+    });
+  });
+
+  it('PUTs to the single time_entry endpoint with only the supplied update fields', async () => {
+    fetchMock.mockResolvedValue(
+      response({
+        status: 200,
+        json: {
+          id: 100,
+          workspace_id: 1,
+          start: '2026-05-01T09:00:00Z',
+          duration: 3600,
+          project_id: 50,
+          description: 'Categorized',
+        },
+      })
+    );
+
+    const api = new TogglAPI('token');
+    const entry = await api.updateTimeEntry(1, 100, {
+      project_id: 50,
+      description: 'Categorized',
+    });
+
+    expect(entry.id).toBe(100);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.track.toggl.com/api/v9/workspaces/1/time_entries/100');
+    expect(init.method).toBe('PUT');
+    expect(JSON.parse(init.body as string)).toEqual({
+      project_id: 50,
+      description: 'Categorized',
+    });
+  });
+
+  it('DELETEs the single time_entry endpoint without a body', async () => {
+    fetchMock.mockResolvedValue(response({ status: 200, contentLength: '0', text: '' }));
+
+    const api = new TogglAPI('token');
+    await api.deleteTimeEntry(1, 100);
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.track.toggl.com/api/v9/workspaces/1/time_entries/100');
+    expect(init.method).toBe('DELETE');
+    expect(init.body).toBeUndefined();
+  });
+
+  it('passes billable through startTimer to the underlying createTimeEntry payload', async () => {
+    fetchMock.mockResolvedValue(
+      response({
+        status: 200,
+        json: {
+          id: 101,
+          workspace_id: 1,
+          start: '2026-05-01T09:00:00Z',
+          duration: -1,
+          billable: true,
+        },
+      })
+    );
+
+    const api = new TogglAPI('token');
+    await api.startTimer(1, 'Working', undefined, undefined, undefined, true);
+
+    const [, init] = fetchMock.mock.calls[0]!;
+    expect(JSON.parse(init.body as string)).toMatchObject({
+      description: 'Working',
+      billable: true,
+      duration: -1,
+    });
+  });
+
+  it('lists tasks for a project in a workspace', async () => {
+    fetchMock.mockResolvedValue(
+      response({
+        status: 200,
+        json: [{ id: 70, workspace_id: 1, project_id: 50, name: 'Review', active: true }],
+      })
+    );
+
+    const api = new TogglAPI('token');
+    const tasks = await api.getTasks(1, 50);
+
+    expect(tasks).toEqual([
+      { id: 70, workspace_id: 1, project_id: 50, name: 'Review', active: true },
+    ]);
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.track.toggl.com/api/v9/workspaces/1/projects/50/tasks',
+      expect.objectContaining({ method: 'GET' })
+    );
+  });
+
+  it('does not retry create on 4xx client errors', async () => {
+    fetchMock.mockResolvedValue(response({ status: 400, text: 'invalid time entry' }));
+
+    const api = new TogglAPI('token');
+    await expect(
+      api.createTimeEntry(1, { start: '2050-01-01T00:00:00Z', duration: 60 })
+    ).rejects.toMatchObject({
+      code: 'TOGGL_API_CLIENT_ERROR',
+      status: 400,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry ambiguous write failures', async () => {
+    const api = new TogglAPI('token');
+
+    fetchMock.mockResolvedValue(response({ status: 500, text: 'server error' }));
+    await expect(
+      api.createTimeEntry(1, { start: '2026-05-01T09:00:00Z', duration: 60 })
+    ).rejects.toThrow(/500/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(response({ status: 500, text: 'server error' }));
+    await expect(api.updateTimeEntry(1, 100, { project_id: 50 })).rejects.toThrow(/500/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(response({ status: 500, text: 'server error' }));
+    await expect(api.deleteTimeEntry(1, 100)).rejects.toThrow(/500/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- refreshes PR #38 on top of the self-host HTTP foundation branch
- adds `toggl_create_time_entry`, `toggl_update_time_entry`, and `toggl_delete_time_entry`
- adds read-only `toggl_list_tasks` so task IDs are discoverable before assigning entries
- adds optional `billable` support to `toggl_start_timer`
- treats Toggl 200/empty-body write responses as success and disables retries for ambiguous write failures
- validates write-tool arguments before calling Toggl so invalid input returns `INVALID_ARGUMENT`
- carries forward original contributor work with attribution

## Breaking Changes
None.

## Related
- Addresses #7
- Refreshes/supersedes #38 pending review of this stacked branch
- Revisits prior work from #8 and #12 with attribution
- Stacked on #36 / `feat/self-host-streamable-http`

## Verification
- `npm run build`
- `npm test`
- `npm run test:coverage`
- `npm run lint` (exits 0 with existing no-explicit-any warnings)
- `npm audit --audit-level=high` (exits 0; existing moderate brace-expansion advisory remains)

Co-authored-by: Madison Rickert <3495636+madisonrickert@users.noreply.github.com>
Co-authored-by: Andreas Wurm <mail@andreaswurm.at>
Co-authored-by: Arnd Jan Gulmans <arndjan@gmail.com>