### PR TITLE
feat(toggl): add tag CRUD tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,15 @@ mcp-toggl --help
 | `toggl_list_projects`   | Lists projects for a workspace using cache-backed reads after first fetch.       |
 | `toggl_list_clients`    | Lists clients for a workspace using cache-backed reads after first fetch.        |
 | `toggl_list_tasks`      | Lists tasks for a project so entries can be assigned to a valid `task_id`.       |
+| `toggl_list_tags`       | Lists tags for a workspace using cache-backed reads after first fetch.           |
+
+### Tag Management
+
+| Tool               | What it does                                                        |
+| ------------------ | ------------------------------------------------------------------- |
+| `toggl_create_tag` | Creates a tag in a workspace and invalidates cached tag listings.   |
+| `toggl_update_tag` | Renames an existing tag and invalidates cached tag listings.        |
+| `toggl_delete_tag` | Deletes a tag from a workspace and invalidates cached tag listings. |
 
 ### Cache Management
 

--- a/server.json
+++ b/server.json
@@ -85,6 +85,22 @@
       "description": "List tasks in a project"
     },
     {
+      "name": "toggl_list_tags",
+      "description": "List tags in a workspace"
+    },
+    {
+      "name": "toggl_create_tag",
+      "description": "Create a tag"
+    },
+    {
+      "name": "toggl_update_tag",
+      "description": "Rename a tag"
+    },
+    {
+      "name": "toggl_delete_tag",
+      "description": "Delete a tag"
+    },
+    {
       "name": "toggl_warm_cache",
       "description": "Pre-fetch workspace, project, client, and tag data"
     },

--- a/src/cache-manager.ts
+++ b/src/cache-manager.ts
@@ -340,6 +340,15 @@ export class CacheManager {
     }
   }
 
+  invalidateWorkspaceTags(workspaceId: number): void {
+    this.tagsByWorkspace.delete(workspaceId);
+    this.tags.forEach((entry, tagId) => {
+      if (entry.data.workspace_id === workspaceId) {
+        this.tags.delete(tagId);
+      }
+    });
+  }
+
   // Warm cache by pre-fetching common entities
   async warmCache(workspaceId?: number): Promise<void> {
     // Log to stderr to avoid interfering with MCP stdio protocol

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,6 +68,8 @@ function isUserInputError(error: unknown): error is Error {
     'entry_id is required',
     'No fields to update',
     'project_id is required',
+    'tag_id is required',
+    'Tag name is required',
   ].some((prefix) => error.message.startsWith(prefix));
 }
 
@@ -770,6 +772,102 @@ const tools: Tool[] = [
       required: ['project_id'],
     },
   },
+  {
+    name: 'toggl_list_tags',
+    description: 'List tags for a workspace',
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
+        },
+      },
+    },
+  },
+  {
+    name: 'toggl_create_tag',
+    description: 'Create a new tag in a workspace',
+    annotations: {
+      readOnlyHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+          description: 'Tag name',
+        },
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
+        },
+      },
+      required: ['name'],
+    },
+  },
+  {
+    name: 'toggl_update_tag',
+    description: 'Rename an existing tag',
+    annotations: {
+      readOnlyHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tag_id: {
+          type: 'number',
+          description: 'Tag ID to update',
+        },
+        name: {
+          type: 'string',
+          description: 'New tag name',
+        },
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
+        },
+      },
+      required: ['tag_id', 'name'],
+    },
+  },
+  {
+    name: 'toggl_delete_tag',
+    description: 'Delete a tag from a workspace',
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        tag_id: {
+          type: 'number',
+          description: 'Tag ID to delete',
+        },
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
+        },
+      },
+      required: ['tag_id'],
+    },
+  },
 
   // Cache management
   {
@@ -1464,6 +1562,64 @@ export function createTogglServer(): Server {
               tracked_seconds: task.tracked_seconds,
               estimated_seconds: task.estimated_seconds,
             })),
+          });
+        }
+
+        case 'toggl_list_tags': {
+          const workspaceId = await resolveWorkspaceForTool(args, 'listing tags');
+          const tags = await cache.getTags(workspaceId);
+
+          return jsonResponse({
+            workspace_id: workspaceId,
+            count: tags.length,
+            tags: tags.map((tag) => ({
+              id: tag.id,
+              name: tag.name,
+            })),
+          });
+        }
+
+        case 'toggl_create_tag': {
+          const workspaceId = await resolveWorkspaceForTool(args, 'creating a tag');
+          const name = requiredNonEmptyStringArg(args, 'name', 'Tag name is required').trim();
+
+          const tag = await api.createTag(workspaceId, name);
+          cache.invalidateWorkspaceTags(workspaceId);
+
+          return jsonResponse({
+            success: true,
+            message: 'Tag created',
+            tag: { id: tag.id, name: tag.name, workspace_id: tag.workspace_id },
+          });
+        }
+
+        case 'toggl_update_tag': {
+          const workspaceId = await resolveWorkspaceForTool(args, 'updating a tag');
+          const tagId = requiredFiniteNumberArg(args, 'tag_id', 'tag_id is required');
+          const name = requiredNonEmptyStringArg(args, 'name', 'Tag name is required').trim();
+
+          const tag = await api.updateTag(workspaceId, tagId, name);
+          cache.invalidateWorkspaceTags(workspaceId);
+
+          return jsonResponse({
+            success: true,
+            message: 'Tag updated',
+            tag: { id: tag.id, name: tag.name, workspace_id: tag.workspace_id },
+          });
+        }
+
+        case 'toggl_delete_tag': {
+          const workspaceId = await resolveWorkspaceForTool(args, 'deleting a tag');
+          const tagId = requiredFiniteNumberArg(args, 'tag_id', 'tag_id is required');
+
+          await api.deleteTag(workspaceId, tagId);
+          cache.invalidateWorkspaceTags(workspaceId);
+
+          return jsonResponse({
+            success: true,
+            message: 'Tag deleted',
+            workspace_id: workspaceId,
+            tag_id: tagId,
           });
         }
 

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -52,6 +52,22 @@ export class TogglAPIError extends Error {
 
 const MAX_AUTO_RETRY_MS = 30_000;
 
+type TagResponse = Tag | Tag[] | { items?: Tag[] };
+
+function isTag(value: unknown): value is Tag {
+  if (!value || typeof value !== 'object') return false;
+  const maybeTag = value as Partial<Tag>;
+  return (
+    typeof maybeTag.id === 'number' &&
+    typeof maybeTag.workspace_id === 'number' &&
+    typeof maybeTag.name === 'string'
+  );
+}
+
+function isTagItemsResponse(value: unknown): value is { items?: Tag[] } {
+  return Boolean(value && typeof value === 'object' && 'items' in value);
+}
+
 export class TogglAPI {
   private baseUrl = 'https://api.track.toggl.com/api/v9';
   private timelineBaseUrl = 'https://track.toggl.com/api/v9';
@@ -164,6 +180,20 @@ export class TogglAPI {
     return this.request<T>(method, endpoint, body, 1);
   }
 
+  private tagFromResponse(response: TagResponse): Tag {
+    if (Array.isArray(response)) {
+      const [tag] = response;
+      if (isTag(tag)) return tag;
+    } else if (isTagItemsResponse(response) && Array.isArray(response.items)) {
+      const [tag] = response.items;
+      if (isTag(tag)) return tag;
+    } else if (isTag(response)) {
+      return response;
+    }
+
+    throw new Error('Toggl tag response did not include a tag');
+  }
+
   async getUser(_userId: number): Promise<User> {
     // Note: This might require admin permissions
     return this.request<User>('GET', `/me`);
@@ -230,11 +260,39 @@ export class TogglAPI {
 
   // Tag methods
   async getTags(workspaceId: number): Promise<Tag[]> {
-    return this.request<Tag[]>('GET', `/workspaces/${workspaceId}/tags`);
+    const response = await this.request<Tag[] | { items?: Tag[] }>(
+      'GET',
+      `/workspaces/${workspaceId}/tags`
+    );
+    return Array.isArray(response) ? response : (response.items ?? []);
   }
 
   async getTag(workspaceId: number, tagId: number): Promise<Tag> {
     return this.request<Tag>('GET', `/workspaces/${workspaceId}/tags/${tagId}`);
+  }
+
+  async createTag(workspaceId: number, name: string): Promise<Tag> {
+    const response = await this.writeRequest<TagResponse>(
+      'POST',
+      `/workspaces/${workspaceId}/tags`,
+      {
+        name,
+      }
+    );
+    return this.tagFromResponse(response);
+  }
+
+  async updateTag(workspaceId: number, tagId: number, name: string): Promise<Tag> {
+    const response = await this.writeRequest<TagResponse>(
+      'PUT',
+      `/workspaces/${workspaceId}/tags/${tagId}`,
+      { name }
+    );
+    return this.tagFromResponse(response);
+  }
+
+  async deleteTag(workspaceId: number, tagId: number): Promise<void> {
+    await this.writeRequest<void>('DELETE', `/workspaces/${workspaceId}/tags/${tagId}`);
   }
 
   // Time entry methods

--- a/tests/cache-manager.test.ts
+++ b/tests/cache-manager.test.ts
@@ -183,6 +183,34 @@ describe('cache manager', () => {
     expect(hydrated?.tag_names).toEqual(['automated', 'test']);
   });
 
+  it('invalidateWorkspaceTags forces a refetch and clears single-tag entries for one workspace', async () => {
+    const otherWorkspaceTag: Tag = { id: 99, workspace_id: 2, name: 'other-ws' };
+    const api = {
+      ...createAPI(),
+      getTags: vi.fn(async (workspaceId: number) =>
+        workspaceId === 1 ? tags : [otherWorkspaceTag]
+      ),
+    };
+    const cache = new CacheManager(config);
+    cache.setAPI(api);
+
+    await cache.getTags(1);
+    await cache.getTags(2);
+    await cache.getTags(1);
+    expect(api.getTags).toHaveBeenCalledTimes(2);
+
+    cache.invalidateWorkspaceTags(1);
+
+    const internalTags = (cache as unknown as { tags: Map<number, unknown> }).tags;
+    expect(internalTags.has(30)).toBe(false);
+    expect(internalTags.has(31)).toBe(false);
+    expect(internalTags.has(99)).toBe(true);
+
+    await expect(cache.getTags(1)).resolves.toEqual(tags);
+    await expect(cache.getTags(2)).resolves.toEqual([otherWorkspaceTag]);
+    expect(api.getTags).toHaveBeenCalledTimes(3);
+  });
+
   it('normalizes null tag fields and adds running duration metadata', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-01T10:01:00.000Z'));

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -66,7 +66,7 @@ function installMockTogglApi() {
     if (url.endsWith('/workspaces/20/projects')) return response({ json: [project] });
     if (url.endsWith('/workspaces/20/projects/30/tasks')) return response({ json: [task] });
     if (url.endsWith('/workspaces/20/clients')) return response({ json: [client] });
-    if (url.endsWith('/workspaces/20/tags')) return response({ json: tags });
+    if (method === 'GET' && url.endsWith('/workspaces/20/tags')) return response({ json: tags });
     if (url.includes('/me/time_entries/current')) return response({ json: null });
     if (url.includes('/me/time_entries')) return response({ json: [entry] });
     if (url.endsWith('/timeline')) {
@@ -112,6 +112,17 @@ function installMockTogglApi() {
       });
     }
     if (method === 'DELETE' && url.endsWith('/workspaces/20/time_entries/60')) {
+      return response({ json: {} });
+    }
+    if (method === 'POST' && url.endsWith('/workspaces/20/tags')) {
+      const body = JSON.parse(init?.body ?? '{}') as Record<string, unknown>;
+      return response({ json: [{ id: 51, workspace_id: 20, name: body.name }] });
+    }
+    if (method === 'PUT' && url.endsWith('/workspaces/20/tags/50')) {
+      const body = JSON.parse(init?.body ?? '{}') as Record<string, unknown>;
+      return response({ json: [{ id: 50, workspace_id: 20, name: body.name }] });
+    }
+    if (method === 'DELETE' && url.endsWith('/workspaces/20/tags/50')) {
       return response({ json: {} });
     }
 
@@ -193,6 +204,21 @@ describe('mcp server handlers', () => {
         idempotentHint: true,
       });
       expect(byName.get('toggl_delete_time_entry')?.annotations).toMatchObject({
+        destructiveHint: true,
+      });
+      expect(byName.get('toggl_list_tags')?.annotations).toMatchObject({
+        readOnlyHint: true,
+        idempotentHint: true,
+      });
+      expect(byName.get('toggl_create_tag')?.annotations).toMatchObject({
+        readOnlyHint: false,
+        idempotentHint: false,
+      });
+      expect(byName.get('toggl_update_tag')?.annotations).toMatchObject({
+        readOnlyHint: false,
+        idempotentHint: true,
+      });
+      expect(byName.get('toggl_delete_tag')?.annotations).toMatchObject({
         destructiveHint: true,
       });
 
@@ -317,6 +343,13 @@ describe('mcp server handlers', () => {
         tasks: [{ id: 45, name: 'Review' }],
       });
       await expect(
+        callTool(client, 'toggl_list_tags', { workspace_id: 20 })
+      ).resolves.toMatchObject({
+        workspace_id: 20,
+        count: 1,
+        tags: [{ id: 50, name: 'tag' }],
+      });
+      await expect(
         callTool(client, 'toggl_warm_cache', { workspace_id: 20 })
       ).resolves.toMatchObject({
         success: true,
@@ -399,6 +432,25 @@ describe('mcp server handlers', () => {
         success: true,
         workspace_id: 20,
         entry_id: 60,
+      });
+      await expect(
+        callTool(client, 'toggl_create_tag', { workspace_id: 20, name: 'new-tag' })
+      ).resolves.toMatchObject({
+        success: true,
+        tag: { id: 51, workspace_id: 20, name: 'new-tag' },
+      });
+      await expect(
+        callTool(client, 'toggl_update_tag', { workspace_id: 20, tag_id: 50, name: 'renamed' })
+      ).resolves.toMatchObject({
+        success: true,
+        tag: { id: 50, workspace_id: 20, name: 'renamed' },
+      });
+      await expect(
+        callTool(client, 'toggl_delete_tag', { workspace_id: 20, tag_id: 50 })
+      ).resolves.toMatchObject({
+        success: true,
+        workspace_id: 20,
+        tag_id: 50,
       });
       await expect(callTool(client, 'toggl_stop_timer')).resolves.toMatchObject({
         success: false,
@@ -495,6 +547,20 @@ describe('mcp server handlers', () => {
         error: true,
         code: 'INVALID_ARGUMENT',
         message: 'project_id is required',
+      });
+      await expect(
+        callTool(client, 'toggl_create_tag', { workspace_id: 20, name: ' ' })
+      ).resolves.toMatchObject({
+        error: true,
+        code: 'INVALID_ARGUMENT',
+        message: 'Tag name is required',
+      });
+      await expect(
+        callTool(client, 'toggl_update_tag', { workspace_id: 20, name: 'renamed' })
+      ).resolves.toMatchObject({
+        error: true,
+        code: 'INVALID_ARGUMENT',
+        message: 'tag_id is required',
       });
     } finally {
       await client.close();

--- a/tests/toggl-api.test.ts
+++ b/tests/toggl-api.test.ts
@@ -273,3 +273,109 @@ describe('toggl api time entry CRUD and tasks', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('toggl api tag CRUD', () => {
+  afterEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it('accepts raw-array workspace tag listings', async () => {
+    fetchMock.mockResolvedValue(
+      response({
+        status: 200,
+        json: [{ id: 30, workspace_id: 1, name: 'automated' }],
+      })
+    );
+
+    const api = new TogglAPI('token');
+    await expect(api.getTags(1)).resolves.toEqual([{ id: 30, workspace_id: 1, name: 'automated' }]);
+  });
+
+  it('accepts documented items-envelope workspace tag listings', async () => {
+    fetchMock.mockResolvedValue(
+      response({
+        status: 200,
+        json: { items: [{ id: 30, workspace_id: 1, name: 'automated' }] },
+      })
+    );
+
+    const api = new TogglAPI('token');
+    await expect(api.getTags(1)).resolves.toEqual([{ id: 30, workspace_id: 1, name: 'automated' }]);
+  });
+
+  it('POSTs to the workspace tags endpoint and normalizes array responses', async () => {
+    fetchMock.mockResolvedValue(
+      response({
+        status: 200,
+        json: [{ id: 30, workspace_id: 1, name: 'automated' }],
+      })
+    );
+
+    const api = new TogglAPI('token');
+    const tag = await api.createTag(1, 'automated');
+
+    expect(tag).toEqual({ id: 30, workspace_id: 1, name: 'automated' });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.track.toggl.com/api/v9/workspaces/1/tags');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual({ name: 'automated' });
+  });
+
+  it('PUTs to the single-tag endpoint and normalizes items-envelope responses', async () => {
+    fetchMock.mockResolvedValue(
+      response({
+        status: 200,
+        json: { items: [{ id: 30, workspace_id: 1, name: 'manual' }] },
+      })
+    );
+
+    const api = new TogglAPI('token');
+    const tag = await api.updateTag(1, 30, 'manual');
+
+    expect(tag).toEqual({ id: 30, workspace_id: 1, name: 'manual' });
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.track.toggl.com/api/v9/workspaces/1/tags/30');
+    expect(init.method).toBe('PUT');
+    expect(JSON.parse(init.body as string)).toEqual({ name: 'manual' });
+  });
+
+  it('fails tag writes when Toggl omits the created or updated tag', async () => {
+    fetchMock.mockResolvedValue(response({ status: 200, json: [] }));
+
+    const api = new TogglAPI('token');
+    await expect(api.createTag(1, 'automated')).rejects.toThrow(
+      'Toggl tag response did not include a tag'
+    );
+  });
+
+  it('DELETEs the single-tag endpoint without retrying empty successful responses', async () => {
+    fetchMock.mockResolvedValue(response({ status: 200, contentLength: '0', text: '' }));
+
+    const api = new TogglAPI('token');
+    await api.deleteTag(1, 30);
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.track.toggl.com/api/v9/workspaces/1/tags/30');
+    expect(init.method).toBe('DELETE');
+    expect(init.body).toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry tag writes on ambiguous failures', async () => {
+    const api = new TogglAPI('token');
+
+    fetchMock.mockResolvedValue(response({ status: 500, text: 'server error' }));
+    await expect(api.createTag(1, 'automated')).rejects.toThrow(/500/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(response({ status: 500, text: 'server error' }));
+    await expect(api.updateTag(1, 30, 'manual')).rejects.toThrow(/500/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(response({ status: 500, text: 'server error' }));
+    await expect(api.deleteTag(1, 30)).rejects.toThrow(/500/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Refreshes/supersedes #37 as a maintainer branch with Madison Rickert co-author attribution.
- Adds cache-backed `toggl_list_tags` plus `toggl_create_tag`, `toggl_update_tag`, and `toggl_delete_tag` MCP tools.
- Reuses the shared write behavior from #58 instead of duplicating the empty-success-body fix.
- Invalidates workspace tag cache entries after successful tag writes.
- Normalizes Toggl tag responses across raw arrays, `items` envelopes, and bare-tag responses.

## Verification
- `npm run build`
- `npm test`
- `npm run test:coverage`
- `npm run lint` (passes with existing `no-explicit-any` warnings)
- `npm audit --audit-level=high` (passes threshold; existing moderate `brace-expansion` advisory remains)

## Related
- Supersedes #37
- Stacked on #58 / `feat/time-entry-task-tools-refresh`
