### PR TITLE
feat(toggl): add project CRUD tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,10 +151,10 @@ mcp-toggl --help
 
 ### Project Management
 
-| Tool | What it does |
-| --- | --- |
-| `toggl_create_project` | Creates a project with optional client, color, billable flag, and estimated hours. |
-| `toggl_update_project` | Updates project fields. Set `active: false` to archive; pass `client_id: null` to detach the client. |
+| Tool                   | What it does                                                                                                                        |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `toggl_create_project` | Creates a project with optional client, color, billable flag, and estimated hours.                                                  |
+| `toggl_update_project` | Updates project fields. Set `active: false` to archive; pass `client_id: null` to detach the client.                                |
 | `toggl_delete_project` | Deletes a project. Optional `time_entry_deletion_mode: "delete" \| "unassign"` controls what happens to the project's time entries. |
 
 ### Cache Management

--- a/README.md
+++ b/README.md
@@ -149,6 +149,14 @@ mcp-toggl --help
 | `toggl_list_clients`    | Lists clients for a workspace using cache-backed reads after first fetch.        |
 | `toggl_list_tasks`      | Lists tasks for a project so entries can be assigned to a valid `task_id`.       |
 
+### Project Management
+
+| Tool | What it does |
+| --- | --- |
+| `toggl_create_project` | Creates a project with optional client, color, billable flag, and estimated hours. |
+| `toggl_update_project` | Updates project fields. Set `active: false` to archive; pass `client_id: null` to detach the client. |
+| `toggl_delete_project` | Deletes a project. Optional `time_entry_deletion_mode: "delete" \| "unassign"` controls what happens to the project's time entries. |
+
 ### Cache Management
 
 | Tool                | What it does                                                                           |

--- a/server.json
+++ b/server.json
@@ -77,6 +77,18 @@
       "description": "List projects in a workspace"
     },
     {
+      "name": "toggl_create_project",
+      "description": "Create a project"
+    },
+    {
+      "name": "toggl_update_project",
+      "description": "Update a project"
+    },
+    {
+      "name": "toggl_delete_project",
+      "description": "Delete a project"
+    },
+    {
       "name": "toggl_list_clients",
       "description": "List clients in a workspace"
     },

--- a/src/cache-manager.ts
+++ b/src/cache-manager.ts
@@ -206,6 +206,15 @@ export class CacheManager {
     }
   }
 
+  invalidateWorkspaceProjects(workspaceId: number): void {
+    this.projectsByWorkspace.delete(workspaceId);
+    this.projects.forEach((entry, projectId) => {
+      if (entry.data.workspace_id === workspaceId) {
+        this.projects.delete(projectId);
+      }
+    });
+  }
+
   // Client methods
   async getClient(id: number, workspaceId?: number): Promise<Client | null> {
     const cached = this.getCached(this.clients, id);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1578,15 +1578,16 @@ export function createTogglServer(): Server {
           const updates: UpdateProjectRequest = {};
 
           if (args?.name !== undefined) {
-            updates.name = requiredNonEmptyStringArg(args, 'name', 'Project name is required').trim();
+            updates.name = requiredNonEmptyStringArg(
+              args,
+              'name',
+              'Project name is required'
+            ).trim();
           }
 
           if (args && 'client_id' in args) {
             const clientId = args.client_id;
-            if (
-              clientId !== null &&
-              (typeof clientId !== 'number' || !Number.isFinite(clientId))
-            ) {
+            if (clientId !== null && (typeof clientId !== 'number' || !Number.isFinite(clientId))) {
               invalidArgument('client_id must be a finite number or null');
             }
             updates.client_id = clientId;

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,15 @@ import {
   parseLocalYMD,
   localDateRangeFromArgs,
 } from './utils.js';
-import type { CacheConfig, TimelineEvent, TimeEntry, UpdateTimeEntryRequest } from './types.js';
+import type {
+  CacheConfig,
+  CreateProjectRequest,
+  ProjectDeleteMode,
+  TimelineEvent,
+  TimeEntry,
+  UpdateProjectRequest,
+  UpdateTimeEntryRequest,
+} from './types.js';
 
 function parseInclusiveEndDate(value: string): Date {
   const date = parseLocalYMD(value);
@@ -68,6 +76,7 @@ function isUserInputError(error: unknown): error is Error {
     'entry_id is required',
     'No fields to update',
     'project_id is required',
+    'Project name is required',
   ].some((prefix) => error.message.startsWith(prefix));
 }
 
@@ -747,6 +756,112 @@ const tools: Tool[] = [
     },
   },
   {
+    name: 'toggl_create_project',
+    description: 'Create a new project in a workspace',
+    annotations: {
+      readOnlyHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Project name' },
+        client_id: { type: 'number', description: 'Client ID to assign the project to' },
+        is_private: {
+          type: 'boolean',
+          description: 'Whether the project is private. Defaults to false.',
+        },
+        active: {
+          type: 'boolean',
+          description: 'Whether the project is active. Defaults to true.',
+        },
+        color: { type: 'string', description: 'Hex color (e.g. "#06aaf5")' },
+        billable: {
+          type: 'boolean',
+          description:
+            'Whether time tracked on this project is billable by default. Note: some Toggl plans (Free) ignore this flag.',
+        },
+        auto_estimates: { type: 'boolean', description: 'Enable auto-estimates' },
+        estimated_hours: { type: 'number', description: 'Estimated hours for the project' },
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
+        },
+      },
+      required: ['name'],
+    },
+  },
+  {
+    name: 'toggl_update_project',
+    description:
+      'Update fields on an existing project. Pass only the fields to change. Set active=false to archive; pass client_id=null to remove the client assignment.',
+    annotations: {
+      readOnlyHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        project_id: { type: 'number', description: 'Project ID to update' },
+        name: { type: 'string', description: 'New project name' },
+        client_id: {
+          type: ['number', 'null'],
+          description: 'New client ID; pass null to remove the assignment',
+        },
+        is_private: { type: 'boolean' },
+        active: {
+          type: 'boolean',
+          description: 'Set to false to archive the project',
+        },
+        color: { type: 'string', description: 'Hex color (e.g. "#06aaf5")' },
+        billable: {
+          type: 'boolean',
+          description:
+            'Whether time tracked on this project is billable by default. Note: some Toggl plans (Free) ignore this flag.',
+        },
+        auto_estimates: { type: 'boolean' },
+        estimated_hours: { type: 'number' },
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
+        },
+      },
+      required: ['project_id'],
+    },
+  },
+  {
+    name: 'toggl_delete_project',
+    description: 'Delete a project by ID',
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        project_id: { type: 'number', description: 'Project ID to delete' },
+        time_entry_deletion_mode: {
+          type: 'string',
+          enum: ['delete', 'unassign'],
+          description:
+            "How to handle time entries on this project: 'delete' removes them; 'unassign' detaches them. If omitted, Toggl applies its default.",
+        },
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
+        },
+      },
+      required: ['project_id'],
+    },
+  },
+  {
     name: 'toggl_list_tasks',
     description: 'List tasks for a project in a workspace',
     annotations: {
@@ -1418,6 +1533,116 @@ export function createTogglServer(): Server {
               },
             ],
           };
+        }
+
+        case 'toggl_create_project': {
+          const workspaceId = await resolveWorkspaceForTool(args, 'creating a project');
+          const project: CreateProjectRequest = {
+            name: requiredNonEmptyStringArg(args, 'name', 'Project name is required').trim(),
+          };
+
+          const clientId = optionalFiniteNumberArg(args, 'client_id');
+          if (clientId !== undefined) project.client_id = clientId;
+
+          const isPrivate = optionalBooleanArg(args, 'is_private');
+          if (isPrivate !== undefined) project.is_private = isPrivate;
+
+          const active = optionalBooleanArg(args, 'active');
+          if (active !== undefined) project.active = active;
+
+          const color = optionalStringArg(args, 'color');
+          if (color !== undefined) project.color = color;
+
+          const billable = optionalBooleanArg(args, 'billable');
+          if (billable !== undefined) project.billable = billable;
+
+          const autoEstimates = optionalBooleanArg(args, 'auto_estimates');
+          if (autoEstimates !== undefined) project.auto_estimates = autoEstimates;
+
+          const estimatedHours = optionalFiniteNumberArg(args, 'estimated_hours');
+          if (estimatedHours !== undefined) project.estimated_hours = estimatedHours;
+
+          const created = await api.createProject(workspaceId, project);
+          cache.invalidateWorkspaceProjects(workspaceId);
+
+          return jsonResponse({
+            success: true,
+            message: 'Project created',
+            project: created,
+          });
+        }
+
+        case 'toggl_update_project': {
+          const workspaceId = await resolveWorkspaceForTool(args, 'updating a project');
+          const projectId = requiredFiniteNumberArg(args, 'project_id', 'project_id is required');
+          const updates: UpdateProjectRequest = {};
+
+          if (args?.name !== undefined) {
+            updates.name = requiredNonEmptyStringArg(args, 'name', 'Project name is required').trim();
+          }
+
+          if (args && 'client_id' in args) {
+            const clientId = args.client_id;
+            if (
+              clientId !== null &&
+              (typeof clientId !== 'number' || !Number.isFinite(clientId))
+            ) {
+              invalidArgument('client_id must be a finite number or null');
+            }
+            updates.client_id = clientId;
+          }
+
+          const isPrivate = optionalBooleanArg(args, 'is_private');
+          if (isPrivate !== undefined) updates.is_private = isPrivate;
+
+          const active = optionalBooleanArg(args, 'active');
+          if (active !== undefined) updates.active = active;
+
+          const color = optionalStringArg(args, 'color');
+          if (color !== undefined) updates.color = color;
+
+          const billable = optionalBooleanArg(args, 'billable');
+          if (billable !== undefined) updates.billable = billable;
+
+          const autoEstimates = optionalBooleanArg(args, 'auto_estimates');
+          if (autoEstimates !== undefined) updates.auto_estimates = autoEstimates;
+
+          const estimatedHours = optionalFiniteNumberArg(args, 'estimated_hours');
+          if (estimatedHours !== undefined) updates.estimated_hours = estimatedHours;
+
+          if (Object.keys(updates).length === 0) {
+            throw new Error('No fields to update; provide at least one updatable field');
+          }
+
+          const updated = await api.updateProject(workspaceId, projectId, updates);
+          cache.invalidateWorkspaceProjects(workspaceId);
+
+          return jsonResponse({
+            success: true,
+            message: 'Project updated',
+            project: updated,
+          });
+        }
+
+        case 'toggl_delete_project': {
+          const workspaceId = await resolveWorkspaceForTool(args, 'deleting a project');
+          const projectId = requiredFiniteNumberArg(args, 'project_id', 'project_id is required');
+          const rawMode = optionalStringArg(args, 'time_entry_deletion_mode');
+          if (rawMode !== undefined && rawMode !== 'delete' && rawMode !== 'unassign') {
+            invalidArgument('time_entry_deletion_mode must be delete or unassign');
+          }
+          const mode = rawMode as ProjectDeleteMode | undefined;
+
+          await api.deleteProject(workspaceId, projectId, mode);
+          cache.invalidateWorkspaceProjects(workspaceId);
+
+          return jsonResponse({
+            success: true,
+            message: 'Project deleted',
+            workspace_id: workspaceId,
+            project_id: projectId,
+            time_entry_deletion_mode: mode,
+          });
         }
 
         case 'toggl_list_clients': {

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -182,10 +182,7 @@ export class TogglAPI {
   }
 
   // Project methods
-  async getProjects(
-    workspaceId: number,
-    active?: 'true' | 'false' | 'both'
-  ): Promise<Project[]> {
+  async getProjects(workspaceId: number, active?: 'true' | 'false' | 'both'): Promise<Project[]> {
     const query = active ? `?active=${active}` : '';
     return this.request<Project[]>('GET', `/workspaces/${workspaceId}/projects${query}`);
   }
@@ -202,7 +199,10 @@ export class TogglAPI {
           'GET',
           `/workspaces/${workspace.id}/projects/${projectId}`
         );
-      } catch {
+      } catch (error) {
+        if (!(error instanceof TogglAPIError) || error.status !== 404) {
+          throw error;
+        }
         continue;
       }
     }
@@ -235,7 +235,10 @@ export class TogglAPI {
     timeEntryDeletionMode?: ProjectDeleteMode
   ): Promise<void> {
     const query = timeEntryDeletionMode ? `?teDeletionMode=${timeEntryDeletionMode}` : '';
-    await this.writeRequest<void>('DELETE', `/workspaces/${workspaceId}/projects/${projectId}${query}`);
+    await this.writeRequest<void>(
+      'DELETE',
+      `/workspaces/${workspaceId}/projects/${projectId}${query}`
+    );
   }
 
   // Client methods

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -210,7 +210,7 @@ export class TogglAPI {
   }
 
   async createProject(workspaceId: number, project: CreateProjectRequest): Promise<Project> {
-    return this.request<Project>('POST', `/workspaces/${workspaceId}/projects`, {
+    return this.writeRequest<Project>('POST', `/workspaces/${workspaceId}/projects`, {
       ...project,
       active: project.active ?? true,
       is_private: project.is_private ?? false,
@@ -222,7 +222,7 @@ export class TogglAPI {
     projectId: number,
     updates: UpdateProjectRequest
   ): Promise<Project> {
-    return this.request<Project>(
+    return this.writeRequest<Project>(
       'PUT',
       `/workspaces/${workspaceId}/projects/${projectId}`,
       updates
@@ -235,7 +235,7 @@ export class TogglAPI {
     timeEntryDeletionMode?: ProjectDeleteMode
   ): Promise<void> {
     const query = timeEntryDeletionMode ? `?teDeletionMode=${timeEntryDeletionMode}` : '';
-    await this.request<void>('DELETE', `/workspaces/${workspaceId}/projects/${projectId}${query}`);
+    await this.writeRequest<void>('DELETE', `/workspaces/${workspaceId}/projects/${projectId}${query}`);
   }
 
   // Client methods

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -179,18 +179,29 @@ export class TogglAPI {
   }
 
   // Project methods
-  async getProjects(workspaceId: number): Promise<Project[]> {
-    return this.request<Project[]>('GET', `/workspaces/${workspaceId}/projects`);
+  async getProjects(
+    workspaceId: number,
+    active?: 'true' | 'false' | 'both'
+  ): Promise<Project[]> {
+    const query = active ? `?active=${active}` : '';
+    return this.request<Project[]>('GET', `/workspaces/${workspaceId}/projects${query}`);
   }
 
-  async getProject(projectId: number): Promise<Project> {
-    // First, we need to find which workspace this project belongs to
-    // This is a limitation of Toggl API v9 - no direct project endpoint
+  async getProject(projectId: number, workspaceId?: number): Promise<Project> {
+    if (workspaceId) {
+      return this.request<Project>('GET', `/workspaces/${workspaceId}/projects/${projectId}`);
+    }
+    // Fallback: try the direct endpoint per workspace until one matches.
     const workspaces = await this.getWorkspaces();
     for (const workspace of workspaces) {
-      const projects = await this.getProjects(workspace.id);
-      const project = projects.find((p) => p.id === projectId);
-      if (project) return project;
+      try {
+        return await this.request<Project>(
+          'GET',
+          `/workspaces/${workspace.id}/projects/${projectId}`
+        );
+      } catch {
+        continue;
+      }
     }
     throw new Error(`Project ${projectId} not found`);
   }

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -11,6 +11,9 @@ import type {
   TimeEntriesRequest,
   CreateTimeEntryRequest,
   UpdateTimeEntryRequest,
+  CreateProjectRequest,
+  UpdateProjectRequest,
+  ProjectDeleteMode,
   TimelineEvent,
 } from './types.js';
 
@@ -204,6 +207,35 @@ export class TogglAPI {
       }
     }
     throw new Error(`Project ${projectId} not found`);
+  }
+
+  async createProject(workspaceId: number, project: CreateProjectRequest): Promise<Project> {
+    return this.request<Project>('POST', `/workspaces/${workspaceId}/projects`, {
+      ...project,
+      active: project.active ?? true,
+      is_private: project.is_private ?? false,
+    });
+  }
+
+  async updateProject(
+    workspaceId: number,
+    projectId: number,
+    updates: UpdateProjectRequest
+  ): Promise<Project> {
+    return this.request<Project>(
+      'PUT',
+      `/workspaces/${workspaceId}/projects/${projectId}`,
+      updates
+    );
+  }
+
+  async deleteProject(
+    workspaceId: number,
+    projectId: number,
+    timeEntryDeletionMode?: ProjectDeleteMode
+  ): Promise<void> {
+    const query = timeEntryDeletionMode ? `?teDeletionMode=${timeEntryDeletionMode}` : '';
+    await this.request<void>('DELETE', `/workspaces/${workspaceId}/projects/${projectId}${query}`);
   }
 
   // Client methods

--- a/src/types.ts
+++ b/src/types.ts
@@ -238,6 +238,32 @@ export interface UpdateTimeEntryRequest {
   duration?: number;
 }
 
+export interface CreateProjectRequest {
+  name: string;
+  client_id?: number;
+  is_private?: boolean;
+  active?: boolean;
+  color?: string;
+  billable?: boolean;
+  auto_estimates?: boolean;
+  estimated_hours?: number;
+}
+
+export interface UpdateProjectRequest {
+  name?: string;
+  // null clears the client assignment (Toggl accepts null in the PUT body).
+  client_id?: number | null;
+  is_private?: boolean;
+  active?: boolean;
+  color?: string;
+  billable?: boolean;
+  auto_estimates?: boolean;
+  estimated_hours?: number;
+}
+
+// 'delete' removes the project's time entries; 'unassign' detaches them.
+export type ProjectDeleteMode = 'delete' | 'unassign';
+
 export interface TimelineEvent {
   id: number;
   start_time: number; // Unix timestamp in seconds

--- a/tests/cache-manager.test.ts
+++ b/tests/cache-manager.test.ts
@@ -158,6 +158,33 @@ describe('cache manager', () => {
     expect(cache.getStats().hits).toBeGreaterThan(statsAfterWarm.hits);
   });
 
+  it('invalidateWorkspaceProjects forces a refetch and clears single-project entries for one workspace', async () => {
+    const otherWorkspaceProject: Project = { id: 99, workspace_id: 2, name: 'Other Project' };
+    const api = {
+      ...createAPI(),
+      getProjects: vi.fn(async (workspaceId: number) =>
+        workspaceId === 1 ? [project] : [otherWorkspaceProject]
+      ),
+    };
+    const cache = new CacheManager(config);
+    cache.setAPI(api);
+
+    await cache.getProjects(1);
+    await cache.getProjects(2);
+    await cache.getProjects(1);
+    expect(api.getProjects).toHaveBeenCalledTimes(2);
+
+    cache.invalidateWorkspaceProjects(1);
+
+    const internalProjects = (cache as unknown as { projects: Map<number, unknown> }).projects;
+    expect(internalProjects.has(10)).toBe(false);
+    expect(internalProjects.has(99)).toBe(true);
+
+    await expect(cache.getProjects(1)).resolves.toEqual([project]);
+    await expect(cache.getProjects(2)).resolves.toEqual([otherWorkspaceProject]);
+    expect(api.getProjects).toHaveBeenCalledTimes(3);
+  });
+
   it('hydrates tags from the workspace tag collection without the single-tag endpoint', async () => {
     const api = createAPI();
     const cache = new CacheManager(config);

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -63,7 +63,9 @@ function installMockTogglApi() {
       return response({ json: { id: 10, email: 'private@example.com', fullname: 'Private User' } });
     if (url.endsWith('/workspaces')) return response({ json: [workspace] });
     if (url.endsWith('/workspaces/20')) return response({ json: workspace });
-    if (url.endsWith('/workspaces/20/projects')) return response({ json: [project] });
+    if (method === 'GET' && url.endsWith('/workspaces/20/projects')) {
+      return response({ json: [project] });
+    }
     if (url.endsWith('/workspaces/20/projects/30/tasks')) return response({ json: [task] });
     if (url.endsWith('/workspaces/20/clients')) return response({ json: [client] });
     if (url.endsWith('/workspaces/20/tags')) return response({ json: tags });
@@ -112,6 +114,31 @@ function installMockTogglApi() {
       });
     }
     if (method === 'DELETE' && url.endsWith('/workspaces/20/time_entries/60')) {
+      return response({ json: {} });
+    }
+    if (method === 'POST' && url.endsWith('/workspaces/20/projects')) {
+      const body = JSON.parse(init?.body ?? '{}') as Record<string, unknown>;
+      return response({
+        json: {
+          ...project,
+          ...body,
+          id: 31,
+          workspace_id: 20,
+        },
+      });
+    }
+    if (method === 'PUT' && url.endsWith('/workspaces/20/projects/30')) {
+      const body = JSON.parse(init?.body ?? '{}') as Record<string, unknown>;
+      return response({
+        json: {
+          ...project,
+          ...body,
+          id: 30,
+          workspace_id: 20,
+        },
+      });
+    }
+    if (method === 'DELETE' && url.endsWith('/workspaces/20/projects/30?teDeletionMode=unassign')) {
       return response({ json: {} });
     }
 
@@ -171,7 +198,7 @@ describe('mcp server handlers', () => {
     }
   });
 
-  it('lists task and time-entry write tool schemas', async () => {
+  it('lists task, project, and time-entry write tool schemas', async () => {
     const { client } = await createClient();
 
     try {
@@ -183,6 +210,20 @@ describe('mcp server handlers', () => {
         idempotentHint: true,
       });
       expect(byName.get('toggl_list_tasks')?.inputSchema.required).toEqual(['project_id']);
+
+      expect(byName.get('toggl_create_project')?.annotations).toMatchObject({
+        readOnlyHint: false,
+        idempotentHint: false,
+      });
+      expect(byName.get('toggl_create_project')?.inputSchema.required).toEqual(['name']);
+      expect(byName.get('toggl_update_project')?.annotations).toMatchObject({
+        readOnlyHint: false,
+        idempotentHint: true,
+      });
+      expect(byName.get('toggl_update_project')?.inputSchema.required).toEqual(['project_id']);
+      expect(byName.get('toggl_delete_project')?.annotations).toMatchObject({
+        destructiveHint: true,
+      });
 
       expect(byName.get('toggl_create_time_entry')?.annotations).toMatchObject({
         readOnlyHint: false,
@@ -315,6 +356,55 @@ describe('mcp server handlers', () => {
         project_id: 30,
         count: 1,
         tasks: [{ id: 45, name: 'Review' }],
+      });
+      await expect(
+        callTool(client, 'toggl_create_project', {
+          workspace_id: 20,
+          name: 'New Project',
+          client_id: 40,
+          color: '#06aaf5',
+          active: true,
+          is_private: false,
+        })
+      ).resolves.toMatchObject({
+        success: true,
+        project: {
+          id: 31,
+          workspace_id: 20,
+          name: 'New Project',
+          client_id: 40,
+          color: '#06aaf5',
+        },
+      });
+      await expect(
+        callTool(client, 'toggl_update_project', {
+          workspace_id: 20,
+          project_id: 30,
+          name: 'Renamed Project',
+          client_id: null,
+          active: false,
+        })
+      ).resolves.toMatchObject({
+        success: true,
+        project: {
+          id: 30,
+          workspace_id: 20,
+          name: 'Renamed Project',
+          client_id: null,
+          active: false,
+        },
+      });
+      await expect(
+        callTool(client, 'toggl_delete_project', {
+          workspace_id: 20,
+          project_id: 30,
+          time_entry_deletion_mode: 'unassign',
+        })
+      ).resolves.toMatchObject({
+        success: true,
+        workspace_id: 20,
+        project_id: 30,
+        time_entry_deletion_mode: 'unassign',
       });
       await expect(
         callTool(client, 'toggl_warm_cache', { workspace_id: 20 })
@@ -495,6 +585,42 @@ describe('mcp server handlers', () => {
         error: true,
         code: 'INVALID_ARGUMENT',
         message: 'project_id is required',
+      });
+      await expect(
+        callTool(client, 'toggl_create_project', { workspace_id: 20, name: ' ' })
+      ).resolves.toMatchObject({
+        error: true,
+        code: 'INVALID_ARGUMENT',
+        message: 'Project name is required',
+      });
+      await expect(
+        callTool(client, 'toggl_update_project', { workspace_id: 20, project_id: 30 })
+      ).resolves.toMatchObject({
+        error: true,
+        code: 'INVALID_ARGUMENT',
+        message: 'No fields to update; provide at least one updatable field',
+      });
+      await expect(
+        callTool(client, 'toggl_update_project', {
+          workspace_id: 20,
+          project_id: 30,
+          client_id: '40',
+        })
+      ).resolves.toMatchObject({
+        error: true,
+        code: 'INVALID_ARGUMENT',
+        message: 'Invalid argument: client_id must be a finite number or null',
+      });
+      await expect(
+        callTool(client, 'toggl_delete_project', {
+          workspace_id: 20,
+          project_id: 30,
+          time_entry_deletion_mode: 'archive',
+        })
+      ).resolves.toMatchObject({
+        error: true,
+        code: 'INVALID_ARGUMENT',
+        message: 'Invalid argument: time_entry_deletion_mode must be delete or unassign',
       });
     } finally {
       await client.close();

--- a/tests/toggl-api.test.ts
+++ b/tests/toggl-api.test.ts
@@ -137,6 +137,43 @@ describe('toggl api project CRUD', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it('continues fallback project lookup after 404 project misses', async () => {
+    fetchMock
+      .mockResolvedValueOnce(
+        response({
+          status: 200,
+          json: [
+            { id: 1, name: 'Workspace 1' },
+            { id: 2, name: 'Workspace 2' },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(response({ status: 404, text: 'not found' }))
+      .mockResolvedValueOnce(
+        response({ status: 200, json: { id: 50, workspace_id: 2, name: 'Web' } })
+      );
+
+    const api = new TogglAPI('token');
+    await expect(api.getProject(50)).resolves.toEqual({
+      id: 50,
+      workspace_id: 2,
+      name: 'Web',
+    });
+  });
+
+  it('preserves non-404 project lookup failures during workspace fallback', async () => {
+    fetchMock
+      .mockResolvedValueOnce(response({ status: 200, json: [{ id: 1, name: 'Workspace 1' }] }))
+      .mockResolvedValueOnce(response({ status: 429, retryAfter: '60' }));
+
+    const api = new TogglAPI('token');
+    await expect(api.getProject(50)).rejects.toMatchObject({
+      code: 'RATE_LIMITED',
+      status: 429,
+      retry_after_seconds: 60,
+    });
+  });
+
   it('POSTs to the workspace projects endpoint and applies active/is_private defaults', async () => {
     fetchMock.mockResolvedValue(
       response({

--- a/tests/toggl-api.test.ts
+++ b/tests/toggl-api.test.ts
@@ -210,6 +210,24 @@ describe('toggl api project CRUD', () => {
     });
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it('does not retry ambiguous project write failures', async () => {
+    const api = new TogglAPI('token');
+
+    fetchMock.mockResolvedValue(response({ status: 500, text: 'server error' }));
+    await expect(api.createProject(1, { name: 'New Project' })).rejects.toThrow(/500/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(response({ status: 500, text: 'server error' }));
+    await expect(api.updateProject(1, 50, { name: 'Renamed' })).rejects.toThrow(/500/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(response({ status: 500, text: 'server error' }));
+    await expect(api.deleteProject(1, 50)).rejects.toThrow(/500/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('toggl api time entry CRUD and tasks', () => {

--- a/tests/toggl-api.test.ts
+++ b/tests/toggl-api.test.ts
@@ -109,6 +109,109 @@ describe('toggl api errors', () => {
   });
 });
 
+describe('toggl api project CRUD', () => {
+  afterEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it('GETs the active filter onto the projects endpoint when supplied', async () => {
+    fetchMock.mockResolvedValue(response({ status: 200, json: [] }));
+
+    const api = new TogglAPI('token');
+    await api.getProjects(1, 'true');
+
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.track.toggl.com/api/v9/workspaces/1/projects?active=true');
+  });
+
+  it('GETs the project directly when workspace_id is provided', async () => {
+    fetchMock.mockResolvedValue(
+      response({ status: 200, json: { id: 50, workspace_id: 1, name: 'Web' } })
+    );
+
+    const api = new TogglAPI('token');
+    await api.getProject(50, 1);
+
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.track.toggl.com/api/v9/workspaces/1/projects/50');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('POSTs to the workspace projects endpoint and applies active/is_private defaults', async () => {
+    fetchMock.mockResolvedValue(
+      response({
+        status: 200,
+        json: { id: 50, workspace_id: 1, name: 'New Project', active: true, is_private: false },
+      })
+    );
+
+    const api = new TogglAPI('token');
+    const project = await api.createProject(1, { name: 'New Project' });
+
+    expect(project.id).toBe(50);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.track.toggl.com/api/v9/workspaces/1/projects');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual({
+      name: 'New Project',
+      active: true,
+      is_private: false,
+    });
+  });
+
+  it('PUTs to the single project endpoint with only the supplied update fields', async () => {
+    fetchMock.mockResolvedValue(
+      response({
+        status: 200,
+        json: { id: 50, workspace_id: 1, name: 'Renamed', client_id: null },
+      })
+    );
+
+    const api = new TogglAPI('token');
+    await api.updateProject(1, 50, { name: 'Renamed', client_id: null });
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.track.toggl.com/api/v9/workspaces/1/projects/50');
+    expect(init.method).toBe('PUT');
+    expect(JSON.parse(init.body as string)).toEqual({ name: 'Renamed', client_id: null });
+  });
+
+  it('DELETEs the single project endpoint without a body', async () => {
+    fetchMock.mockResolvedValue(response({ status: 200, contentLength: '0', text: '' }));
+
+    const api = new TogglAPI('token');
+    await api.deleteProject(1, 50);
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.track.toggl.com/api/v9/workspaces/1/projects/50');
+    expect(init.method).toBe('DELETE');
+    expect(init.body).toBeUndefined();
+  });
+
+  it('passes teDeletionMode through deleteProject as a query string', async () => {
+    fetchMock.mockResolvedValue(response({ status: 200, contentLength: '0', text: '' }));
+
+    const api = new TogglAPI('token');
+    await api.deleteProject(1, 50, 'unassign');
+
+    const [url] = fetchMock.mock.calls[0]!;
+    expect(url).toBe(
+      'https://api.track.toggl.com/api/v9/workspaces/1/projects/50?teDeletionMode=unassign'
+    );
+  });
+
+  it('does not retry createProject on 4xx client errors', async () => {
+    fetchMock.mockResolvedValue(response({ status: 400, text: 'name is required' }));
+
+    const api = new TogglAPI('token');
+    await expect(api.createProject(1, { name: '' })).rejects.toMatchObject({
+      code: 'TOGGL_API_CLIENT_ERROR',
+      status: 400,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('toggl api time entry CRUD and tasks', () => {
   afterEach(() => {
     fetchMock.mockReset();


### PR DESCRIPTION
## Summary
- Refreshes/supersedes #39 as a maintainer branch with Madison Rickert co-author attribution preserved in the cherry-picked commits.
- Adds `toggl_create_project`, `toggl_update_project`, and `toggl_delete_project` MCP tools.
- Reuses the shared write behavior from #58 instead of duplicating the successful-empty-body fix.
- Invalidates workspace project cache entries after successful project writes.
- Keeps direct project lookup optimization, but preserves non-404 Toggl errors during workspace fallback.
- Adds `server.json`, cache, API, and MCP handler coverage for the new public tool surface.

## Verification
- `npm run build`
- `npm test`
- `npm run test:coverage`
- `npm run lint` (passes with existing `no-explicit-any` warnings)
- `npm audit --audit-level=high` (passes threshold; existing moderate `brace-expansion` advisory remains)
- read-only review subagent pass after fixing the fallback error propagation issue

## Related
- Supersedes #39
- Stacked on #58 / `feat/time-entry-task-tools-refresh`
