### PR TITLE
feat(toggl): add client CRUD tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,14 @@ mcp-toggl --help
 | `toggl_list_clients`    | Lists clients for a workspace using cache-backed reads after first fetch.        |
 | `toggl_list_tasks`      | Lists tasks for a project so entries can be assigned to a valid `task_id`.       |
 
+### Client Management
+
+| Tool | What it does |
+| --- | --- |
+| `toggl_create_client` | Creates a client with optional notes and external reference. |
+| `toggl_update_client` | Updates a client. Toggl requires `name` on every update; pass the existing name when only changing notes or external reference. |
+| `toggl_delete_client` | Deletes a client by ID. |
+
 ### Cache Management
 
 | Tool                | What it does                                                                           |

--- a/server.json
+++ b/server.json
@@ -81,6 +81,18 @@
       "description": "List clients in a workspace"
     },
     {
+      "name": "toggl_create_client",
+      "description": "Create a client"
+    },
+    {
+      "name": "toggl_update_client",
+      "description": "Update a client"
+    },
+    {
+      "name": "toggl_delete_client",
+      "description": "Delete a client"
+    },
+    {
       "name": "toggl_list_tasks",
       "description": "List tasks in a project"
     },

--- a/src/cache-manager.ts
+++ b/src/cache-manager.ts
@@ -250,6 +250,15 @@ export class CacheManager {
     }
   }
 
+  invalidateWorkspaceClients(workspaceId: number): void {
+    this.clientsByWorkspace.delete(workspaceId);
+    this.clients.forEach((entry, clientId) => {
+      if (entry.data.workspace_id === workspaceId) {
+        this.clients.delete(clientId);
+      }
+    });
+  }
+
   // Task methods
   async getTask(id: number, workspaceId: number, projectId: number): Promise<Task | null> {
     const cached = this.getCached(this.tasks, id);

--- a/src/cache-manager.ts
+++ b/src/cache-manager.ts
@@ -12,6 +12,19 @@ import type {
   CacheConfig,
 } from './types.js';
 
+interface CacheAPI {
+  getWorkspace(id: number): Promise<Workspace>;
+  getWorkspaces(): Promise<Workspace[]>;
+  getProject(id: number): Promise<Project>;
+  getProjects(workspaceId: number): Promise<Project[]>;
+  getClient(id: number): Promise<Client>;
+  getClients(workspaceId: number): Promise<Client[]>;
+  getTask(workspaceId: number, projectId: number, taskId: number): Promise<Task>;
+  getTasks(workspaceId: number, projectId: number): Promise<Task[]>;
+  getUser(id: number): Promise<User>;
+  getTags(workspaceId: number): Promise<Tag[]>;
+}
+
 export class CacheManager {
   private workspaces: Map<number, CacheEntry<Workspace>> = new Map();
   private projects: Map<number, CacheEntry<Project>> = new Map();
@@ -32,14 +45,14 @@ export class CacheManager {
   };
 
   private config: CacheConfig;
-  private api: any; // Will be set after API client is created
+  private api: CacheAPI | null = null; // Will be set after API client is created
 
   constructor(config: CacheConfig) {
     this.config = config;
   }
 
-  setAPI(api: any): void {
-    this.api = api;
+  setAPI(api: unknown): void {
+    this.api = api as CacheAPI;
   }
 
   // Check if cache entry is still valid

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,14 @@ import {
   parseLocalYMD,
   localDateRangeFromArgs,
 } from './utils.js';
-import type { CacheConfig, TimelineEvent, TimeEntry, UpdateTimeEntryRequest } from './types.js';
+import type {
+  CacheConfig,
+  CreateClientRequest,
+  TimelineEvent,
+  TimeEntry,
+  UpdateClientRequest,
+  UpdateTimeEntryRequest,
+} from './types.js';
 
 function parseInclusiveEndDate(value: string): Date {
   const date = parseLocalYMD(value);
@@ -68,6 +75,8 @@ function isUserInputError(error: unknown): error is Error {
     'entry_id is required',
     'No fields to update',
     'project_id is required',
+    'client_id is required',
+    'Client name is required',
   ].some((prefix) => error.message.startsWith(prefix));
 }
 
@@ -744,6 +753,79 @@ const tools: Tool[] = [
             'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
         },
       },
+    },
+  },
+  {
+    name: 'toggl_create_client',
+    description: 'Create a new client in a workspace',
+    annotations: {
+      readOnlyHint: false,
+      idempotentHint: false,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        name: { type: 'string', description: 'Client name' },
+        notes: { type: 'string', description: 'Optional notes for the client' },
+        external_reference: {
+          type: 'string',
+          description: 'Optional external system reference (e.g. JIRA/Salesforce ID)',
+        },
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
+        },
+      },
+      required: ['name'],
+    },
+  },
+  {
+    name: 'toggl_update_client',
+    description:
+      'Update an existing client. Toggl requires name on every update; pass the existing name unchanged when only adjusting notes or external_reference.',
+    annotations: {
+      readOnlyHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        client_id: { type: 'number', description: 'Client ID to update' },
+        name: { type: 'string', description: 'Client name (required by Toggl on update)' },
+        notes: { type: 'string' },
+        external_reference: { type: 'string' },
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
+        },
+      },
+      required: ['client_id', 'name'],
+    },
+  },
+  {
+    name: 'toggl_delete_client',
+    description: 'Delete a client by ID',
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        client_id: { type: 'number', description: 'Client ID to delete' },
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
+        },
+      },
+      required: ['client_id'],
     },
   },
   {
@@ -1445,6 +1527,74 @@ export function createTogglServer(): Server {
               },
             ],
           };
+        }
+
+        case 'toggl_create_client': {
+          const workspaceId = await resolveWorkspaceForTool(args, 'creating a client');
+          const clientRequest: CreateClientRequest = {
+            name: requiredNonEmptyStringArg(args, 'name', 'Client name is required').trim(),
+          };
+
+          const notes = optionalStringArg(args, 'notes');
+          if (notes !== undefined) clientRequest.notes = notes;
+
+          const externalReference = optionalStringArg(args, 'external_reference');
+          if (externalReference !== undefined) {
+            clientRequest.external_reference = externalReference;
+          }
+
+          const created = await api.createClient(workspaceId, clientRequest);
+          cache.invalidateWorkspaceClients(workspaceId);
+
+          return jsonResponse({
+            success: true,
+            message: 'Client created',
+            client: created,
+          });
+        }
+
+        case 'toggl_update_client': {
+          const workspaceId = await resolveWorkspaceForTool(args, 'updating a client');
+          const clientId = requiredFiniteNumberArg(args, 'client_id', 'client_id is required');
+          const updates: UpdateClientRequest = {
+            name: requiredNonEmptyStringArg(
+              args,
+              'name',
+              'Client name is required (Toggl requires name on every update)'
+            ).trim(),
+          };
+
+          const notes = optionalStringArg(args, 'notes');
+          if (notes !== undefined) updates.notes = notes;
+
+          const externalReference = optionalStringArg(args, 'external_reference');
+          if (externalReference !== undefined) {
+            updates.external_reference = externalReference;
+          }
+
+          const updated = await api.updateClient(workspaceId, clientId, updates);
+          cache.invalidateWorkspaceClients(workspaceId);
+
+          return jsonResponse({
+            success: true,
+            message: 'Client updated',
+            client: updated,
+          });
+        }
+
+        case 'toggl_delete_client': {
+          const workspaceId = await resolveWorkspaceForTool(args, 'deleting a client');
+          const clientId = requiredFiniteNumberArg(args, 'client_id', 'client_id is required');
+
+          await api.deleteClient(workspaceId, clientId);
+          cache.invalidateWorkspaceClients(workspaceId);
+
+          return jsonResponse({
+            success: true,
+            message: 'Client deleted',
+            workspace_id: workspaceId,
+            client_id: clientId,
+          });
         }
 
         case 'toggl_list_tasks': {

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,14 +28,17 @@ import {
   toLocalYMD,
   parseLocalYMD,
   localDateRangeFromArgs,
+  isDatePeriod,
 } from './utils.js';
 import type {
   CacheConfig,
   CreateClientRequest,
+  ProjectSummary,
   TimelineEvent,
   TimeEntry,
   UpdateClientRequest,
   UpdateTimeEntryRequest,
+  WorkspaceSummary,
 } from './types.js';
 
 function parseInclusiveEndDate(value: string): Date {
@@ -57,6 +60,15 @@ function jsonResponse(data: unknown) {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : 'An error occurred';
+}
+
+function dateRangeFromPeriod(period: unknown) {
+  if (!isDatePeriod(period)) {
+    throw new Error(
+      `Invalid period: ${String(period)}. Must be one of: today, yesterday, week, lastWeek, month, lastMonth`
+    );
+  }
+  return getDateRange(period);
 }
 
 function isUserInputError(error: unknown): error is Error {
@@ -1005,9 +1017,9 @@ export function createTogglServer(): Server {
                   {
                     authenticated: true,
                     user: {
-                      id: (me as any).id,
-                      email: maskEmail((me as any).email),
-                      fullname: (me as any).fullname,
+                      id: me.id,
+                      email: maskEmail(me.email),
+                      fullname: me.fullname,
                     },
                     workspaces: workspaces.map((w) => ({ id: w.id, name: w.name })),
                   },
@@ -1025,8 +1037,8 @@ export function createTogglServer(): Server {
 
           let entries: TimeEntry[];
 
-          if (args?.period) {
-            const range = getDateRange(args.period as any);
+          if (args?.period !== undefined) {
+            const range = dateRangeFromPeriod(args.period);
             entries = await api.getTimeEntriesForDateRange(range.start, range.end);
           } else if (args?.start_date || args?.end_date) {
             const start = args?.start_date ? parseLocalYMD(args.start_date as string) : new Date();
@@ -1354,8 +1366,8 @@ export function createTogglServer(): Server {
 
           let entries: TimeEntry[];
 
-          if (args?.period) {
-            const range = getDateRange(args.period as any);
+          if (args?.period !== undefined) {
+            const range = dateRangeFromPeriod(args.period);
             entries = await api.getTimeEntriesForDateRange(range.start, range.end);
           } else if (args?.start_date && args?.end_date) {
             const start = parseLocalYMD(args.start_date as string);
@@ -1373,7 +1385,7 @@ export function createTogglServer(): Server {
           const hydrated = await cache.hydrateTimeEntries(entries);
           const byProject = groupEntriesByProject(hydrated);
 
-          const summaries: any[] = [];
+          const summaries: ProjectSummary[] = [];
           byProject.forEach((projectEntries, projectName) => {
             summaries.push(generateProjectSummary(projectName, projectEntries));
           });
@@ -1404,8 +1416,8 @@ export function createTogglServer(): Server {
 
           let entries: TimeEntry[];
 
-          if (args?.period) {
-            const range = getDateRange(args.period as any);
+          if (args?.period !== undefined) {
+            const range = dateRangeFromPeriod(args.period);
             entries = await api.getTimeEntriesForDateRange(range.start, range.end);
           } else if (args?.start_date && args?.end_date) {
             const start = parseLocalYMD(args.start_date as string);
@@ -1419,7 +1431,7 @@ export function createTogglServer(): Server {
           const hydrated = await cache.hydrateTimeEntries(entries);
           const byWorkspace = groupEntriesByWorkspace(hydrated);
 
-          const summaries: any[] = [];
+          const summaries: WorkspaceSummary[] = [];
           byWorkspace.forEach((wsEntries, wsName) => {
             const wsId = wsEntries[0]?.workspace_id || 0;
             summaries.push(generateWorkspaceSummary(wsName, wsId, wsEntries));

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -14,6 +14,7 @@ import type {
   CreateClientRequest,
   UpdateClientRequest,
   TimelineEvent,
+  JsonValue,
 } from './types.js';
 
 export class TimelineNotEnabledError extends Error {
@@ -54,6 +55,17 @@ export class TogglAPIError extends Error {
 
 const MAX_AUTO_RETRY_MS = 30_000;
 
+type ReportRequestParams = Record<string, JsonValue | undefined>;
+
+function hasNoRetry(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'noRetry' in error &&
+    Boolean((error as { noRetry?: unknown }).noRetry)
+  );
+}
+
 export class TogglAPI {
   private baseUrl = 'https://api.track.toggl.com/api/v9';
   private timelineBaseUrl = 'https://track.toggl.com/api/v9';
@@ -71,7 +83,7 @@ export class TogglAPI {
   }
 
   // Generic API request method
-  private async request<T>(method: string, endpoint: string, body?: any, retries = 3): Promise<T> {
+  private async request<T>(method: string, endpoint: string, body?: unknown, retries = 3): Promise<T> {
     const url = `${this.baseUrl}${endpoint}`;
 
     for (let i = 0; i < retries; i++) {
@@ -147,8 +159,8 @@ export class TogglAPI {
         }
 
         return JSON.parse(responseText) as T;
-      } catch (error: any) {
-        if (error?.noRetry || i === retries - 1) throw error;
+      } catch (error: unknown) {
+        if (hasNoRetry(error) || i === retries - 1) throw error;
         // Exponential backoff for transient/network errors
         await new Promise((resolve) => setTimeout(resolve, (i + 1) * 1000));
       }
@@ -392,7 +404,7 @@ export class TogglAPI {
   }
 
   // Reports API endpoints (if needed)
-  async getDetailedReport(workspaceId: number, params: any): Promise<any> {
+  async getDetailedReport(workspaceId: number, params: ReportRequestParams): Promise<unknown> {
     // This would use the Reports API v3 if needed
     // https://api.track.toggl.com/reports/api/v3/workspace/{workspace_id}/search/time_entries
     const reportsUrl = `https://api.track.toggl.com/reports/api/v3/workspace/${workspaceId}/search/time_entries`;
@@ -470,10 +482,10 @@ export class TogglAPI {
         }
 
         return data.filter(isTimelineEvent);
-      } catch (error: any) {
+      } catch (error: unknown) {
         if (
           error instanceof TimelineNotEnabledError ||
-          error?.noRetry ||
+          hasNoRetry(error) ||
           attempt === maxRetries - 1
         ) {
           throw error;

--- a/src/toggl-api.ts
+++ b/src/toggl-api.ts
@@ -11,6 +11,8 @@ import type {
   TimeEntriesRequest,
   CreateTimeEntryRequest,
   UpdateTimeEntryRequest,
+  CreateClientRequest,
+  UpdateClientRequest,
   TimelineEvent,
 } from './types.js';
 
@@ -198,6 +200,26 @@ export class TogglAPI {
   // Client methods
   async getClients(workspaceId: number): Promise<Client[]> {
     return this.request<Client[]>('GET', `/workspaces/${workspaceId}/clients`);
+  }
+
+  async createClient(workspaceId: number, client: CreateClientRequest): Promise<Client> {
+    return this.writeRequest<Client>('POST', `/workspaces/${workspaceId}/clients`, client);
+  }
+
+  async updateClient(
+    workspaceId: number,
+    clientId: number,
+    updates: UpdateClientRequest
+  ): Promise<Client> {
+    return this.writeRequest<Client>(
+      'PUT',
+      `/workspaces/${workspaceId}/clients/${clientId}`,
+      updates
+    );
+  }
+
+  async deleteClient(workspaceId: number, clientId: number): Promise<void> {
+    await this.writeRequest<void>('DELETE', `/workspaces/${workspaceId}/clients/${clientId}`);
   }
 
   async getClient(clientId: number): Promise<Client> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -238,6 +238,19 @@ export interface UpdateTimeEntryRequest {
   duration?: number;
 }
 
+export interface CreateClientRequest {
+  name: string;
+  notes?: string;
+  external_reference?: string;
+}
+
+export interface UpdateClientRequest {
+  // Required by Toggl on PUT.
+  name: string;
+  notes?: string;
+  external_reference?: string;
+}
+
 export interface TimelineEvent {
   id: number;
   start_time: number; // Unix timestamp in seconds

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,6 +4,9 @@ export interface TogglConfig {
   defaultWorkspaceId?: number;
 }
 
+export type JsonPrimitive = string | number | boolean | null;
+export type JsonValue = JsonPrimitive | JsonValue[] | { [key: string]: JsonValue };
+
 export interface CacheConfig {
   ttl: number; // Time-to-live in milliseconds
   maxSize: number; // Maximum number of cached entities
@@ -52,8 +55,8 @@ export interface Project {
   rate_last_updated?: string;
   currency?: string;
   recurring?: boolean;
-  recurring_parameters?: any;
-  current_period?: any;
+  recurring_parameters?: JsonValue;
+  current_period?: JsonValue;
   fixed_fee?: number;
   actual_hours?: number;
   wid?: number;
@@ -292,11 +295,11 @@ export interface TogglError {
   code: string;
   message: string;
   tip?: string;
-  details?: any;
+  details?: unknown;
 }
 
 // Tool response types
-export interface ToolResponse<T = any> {
+export interface ToolResponse<T = unknown> {
   success: boolean;
   data?: T;
   error?: TogglError;

--- a/tests/cache-manager.test.ts
+++ b/tests/cache-manager.test.ts
@@ -158,6 +158,33 @@ describe('cache manager', () => {
     expect(cache.getStats().hits).toBeGreaterThan(statsAfterWarm.hits);
   });
 
+  it('invalidateWorkspaceClients forces a refetch and clears single-client entries for one workspace', async () => {
+    const otherWorkspaceClient: Client = { id: 99, workspace_id: 2, name: 'Other Client' };
+    const api = {
+      ...createAPI(),
+      getClients: vi.fn(async (workspaceId: number) =>
+        workspaceId === 1 ? [client] : [otherWorkspaceClient]
+      ),
+    };
+    const cache = new CacheManager(config);
+    cache.setAPI(api);
+
+    await cache.getClients(1);
+    await cache.getClients(2);
+    await cache.getClients(1);
+    expect(api.getClients).toHaveBeenCalledTimes(2);
+
+    cache.invalidateWorkspaceClients(1);
+
+    const internalClients = (cache as unknown as { clients: Map<number, unknown> }).clients;
+    expect(internalClients.has(20)).toBe(false);
+    expect(internalClients.has(99)).toBe(true);
+
+    await expect(cache.getClients(1)).resolves.toEqual([client]);
+    await expect(cache.getClients(2)).resolves.toEqual([otherWorkspaceClient]);
+    expect(api.getClients).toHaveBeenCalledTimes(3);
+  });
+
   it('hydrates tags from the workspace tag collection without the single-tag endpoint', async () => {
     const api = createAPI();
     const cache = new CacheManager(config);

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -616,6 +616,17 @@ describe('mcp server handlers', () => {
         code: 'INVALID_ARGUMENT',
         message: 'Invalid argument: notes must be a string',
       });
+      for (const toolName of [
+        'toggl_get_time_entries',
+        'toggl_project_summary',
+        'toggl_workspace_summary',
+      ]) {
+        await expect(callTool(client, toolName, { period: '' })).resolves.toMatchObject({
+          error: true,
+          code: 'INVALID_ARGUMENT',
+          message: 'Invalid period: . Must be one of: today, yesterday, week, lastWeek, month, lastMonth',
+        });
+      }
     } finally {
       await client.close();
     }

--- a/tests/mcp-server.test.ts
+++ b/tests/mcp-server.test.ts
@@ -65,7 +65,9 @@ function installMockTogglApi() {
     if (url.endsWith('/workspaces/20')) return response({ json: workspace });
     if (url.endsWith('/workspaces/20/projects')) return response({ json: [project] });
     if (url.endsWith('/workspaces/20/projects/30/tasks')) return response({ json: [task] });
-    if (url.endsWith('/workspaces/20/clients')) return response({ json: [client] });
+    if (method === 'GET' && url.endsWith('/workspaces/20/clients')) {
+      return response({ json: [client] });
+    }
     if (url.endsWith('/workspaces/20/tags')) return response({ json: tags });
     if (url.includes('/me/time_entries/current')) return response({ json: null });
     if (url.includes('/me/time_entries')) return response({ json: [entry] });
@@ -112,6 +114,31 @@ function installMockTogglApi() {
       });
     }
     if (method === 'DELETE' && url.endsWith('/workspaces/20/time_entries/60')) {
+      return response({ json: {} });
+    }
+    if (method === 'POST' && url.endsWith('/workspaces/20/clients')) {
+      const body = JSON.parse(init?.body ?? '{}') as Record<string, unknown>;
+      return response({
+        json: {
+          ...client,
+          ...body,
+          id: 41,
+          workspace_id: 20,
+        },
+      });
+    }
+    if (method === 'PUT' && url.endsWith('/workspaces/20/clients/40')) {
+      const body = JSON.parse(init?.body ?? '{}') as Record<string, unknown>;
+      return response({
+        json: {
+          ...client,
+          ...body,
+          id: 40,
+          workspace_id: 20,
+        },
+      });
+    }
+    if (method === 'DELETE' && url.endsWith('/workspaces/20/clients/40')) {
       return response({ json: {} });
     }
 
@@ -171,7 +198,7 @@ describe('mcp server handlers', () => {
     }
   });
 
-  it('lists task and time-entry write tool schemas', async () => {
+  it('lists task, client, and time-entry write tool schemas', async () => {
     const { client } = await createClient();
 
     try {
@@ -183,6 +210,23 @@ describe('mcp server handlers', () => {
         idempotentHint: true,
       });
       expect(byName.get('toggl_list_tasks')?.inputSchema.required).toEqual(['project_id']);
+
+      expect(byName.get('toggl_create_client')?.annotations).toMatchObject({
+        readOnlyHint: false,
+        idempotentHint: false,
+      });
+      expect(byName.get('toggl_create_client')?.inputSchema.required).toEqual(['name']);
+      expect(byName.get('toggl_update_client')?.annotations).toMatchObject({
+        readOnlyHint: false,
+        idempotentHint: true,
+      });
+      expect(byName.get('toggl_update_client')?.inputSchema.required).toEqual([
+        'client_id',
+        'name',
+      ]);
+      expect(byName.get('toggl_delete_client')?.annotations).toMatchObject({
+        destructiveHint: true,
+      });
 
       expect(byName.get('toggl_create_time_entry')?.annotations).toMatchObject({
         readOnlyHint: false,
@@ -307,6 +351,46 @@ describe('mcp server handlers', () => {
         workspace_id: 20,
         count: 1,
         clients: [{ id: 40, name: 'Client' }],
+      });
+      await expect(
+        callTool(client, 'toggl_create_client', {
+          workspace_id: 20,
+          name: 'New Client',
+          notes: 'priority',
+          external_reference: 'crm-123',
+        })
+      ).resolves.toMatchObject({
+        success: true,
+        client: {
+          id: 41,
+          workspace_id: 20,
+          name: 'New Client',
+          notes: 'priority',
+          external_reference: 'crm-123',
+        },
+      });
+      await expect(
+        callTool(client, 'toggl_update_client', {
+          workspace_id: 20,
+          client_id: 40,
+          name: 'Renamed Client',
+          notes: 'updated',
+        })
+      ).resolves.toMatchObject({
+        success: true,
+        client: {
+          id: 40,
+          workspace_id: 20,
+          name: 'Renamed Client',
+          notes: 'updated',
+        },
+      });
+      await expect(
+        callTool(client, 'toggl_delete_client', { workspace_id: 20, client_id: 40 })
+      ).resolves.toMatchObject({
+        success: true,
+        workspace_id: 20,
+        client_id: 40,
       });
       await expect(
         callTool(client, 'toggl_list_tasks', { workspace_id: 20, project_id: 30 })
@@ -495,6 +579,42 @@ describe('mcp server handlers', () => {
         error: true,
         code: 'INVALID_ARGUMENT',
         message: 'project_id is required',
+      });
+      await expect(
+        callTool(client, 'toggl_create_client', { workspace_id: 20, name: ' ' })
+      ).resolves.toMatchObject({
+        error: true,
+        code: 'INVALID_ARGUMENT',
+        message: 'Client name is required',
+      });
+      await expect(
+        callTool(client, 'toggl_update_client', { workspace_id: 20, client_id: 40, name: ' ' })
+      ).resolves.toMatchObject({
+        error: true,
+        code: 'INVALID_ARGUMENT',
+        message: 'Client name is required (Toggl requires name on every update)',
+      });
+      await expect(
+        callTool(client, 'toggl_update_client', {
+          workspace_id: 20,
+          client_id: '40',
+          name: 'Client',
+        })
+      ).resolves.toMatchObject({
+        error: true,
+        code: 'INVALID_ARGUMENT',
+        message: 'Invalid argument: client_id must be a finite number',
+      });
+      await expect(
+        callTool(client, 'toggl_create_client', {
+          workspace_id: 20,
+          name: 'Client',
+          notes: 123,
+        })
+      ).resolves.toMatchObject({
+        error: true,
+        code: 'INVALID_ARGUMENT',
+        message: 'Invalid argument: notes must be a string',
       });
     } finally {
       await client.close();

--- a/tests/toggl-api.test.ts
+++ b/tests/toggl-api.test.ts
@@ -109,6 +109,85 @@ describe('toggl api errors', () => {
   });
 });
 
+describe('toggl api client CRUD', () => {
+  afterEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it('POSTs to the workspace clients endpoint with name and notes', async () => {
+    fetchMock.mockResolvedValue(
+      response({
+        status: 200,
+        json: { id: 200, workspace_id: 1, name: 'Acme', notes: 'top tier' },
+      })
+    );
+
+    const api = new TogglAPI('token');
+    const client = await api.createClient(1, { name: 'Acme', notes: 'top tier' });
+
+    expect(client.id).toBe(200);
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.track.toggl.com/api/v9/workspaces/1/clients');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual({ name: 'Acme', notes: 'top tier' });
+  });
+
+  it('PUTs to the single client endpoint with the supplied update fields', async () => {
+    fetchMock.mockResolvedValue(
+      response({ status: 200, json: { id: 200, workspace_id: 1, name: 'Acme Inc.' } })
+    );
+
+    const api = new TogglAPI('token');
+    await api.updateClient(1, 200, { name: 'Acme Inc.', notes: 'renamed' });
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.track.toggl.com/api/v9/workspaces/1/clients/200');
+    expect(init.method).toBe('PUT');
+    expect(JSON.parse(init.body as string)).toEqual({ name: 'Acme Inc.', notes: 'renamed' });
+  });
+
+  it('DELETEs the single client endpoint without a body', async () => {
+    fetchMock.mockResolvedValue(response({ status: 200, contentLength: '0', text: '' }));
+
+    const api = new TogglAPI('token');
+    await api.deleteClient(1, 200);
+
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(url).toBe('https://api.track.toggl.com/api/v9/workspaces/1/clients/200');
+    expect(init.method).toBe('DELETE');
+    expect(init.body).toBeUndefined();
+  });
+
+  it('does not retry createClient on 4xx client errors', async () => {
+    fetchMock.mockResolvedValue(response({ status: 400, text: 'name is required' }));
+
+    const api = new TogglAPI('token');
+    await expect(api.createClient(1, { name: '' })).rejects.toMatchObject({
+      code: 'TOGGL_API_CLIENT_ERROR',
+      status: 400,
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry ambiguous client write failures', async () => {
+    const api = new TogglAPI('token');
+
+    fetchMock.mockResolvedValue(response({ status: 500, text: 'server error' }));
+    await expect(api.createClient(1, { name: 'Acme' })).rejects.toThrow(/500/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(response({ status: 500, text: 'server error' }));
+    await expect(api.updateClient(1, 200, { name: 'Acme Inc.' })).rejects.toThrow(/500/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue(response({ status: 500, text: 'server error' }));
+    await expect(api.deleteClient(1, 200)).rejects.toThrow(/500/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});
+
 describe('toggl api time entry CRUD and tasks', () => {
   afterEach(() => {
     fetchMock.mockReset();


### PR DESCRIPTION
## Summary
- Refreshes/supersedes #40 as a maintainer branch with Madison Rickert co-author attribution preserved in the cherry-picked commits.
- Adds `toggl_create_client`, `toggl_update_client`, and `toggl_delete_client` MCP tools.
- Reuses the shared write behavior from #58 instead of duplicating the successful-empty-body fix.
- Invalidates workspace client cache entries after successful client writes.
- Adds `server.json`, cache, API, and MCP handler coverage for the new public tool surface.

## Verification
- `npm run build`
- `npm test`
- `npm run test:coverage`
- `npm run lint` (passes with existing `no-explicit-any` warnings)
- `npm audit --audit-level=high` (passes threshold; existing moderate `brace-expansion` advisory remains)
- read-only review subagent pass with no actionable issues

## Related
- Supersedes #40
- Stacked on #58 / `feat/time-entry-task-tools-refresh`
