### PR TITLE
feat: add toggl_update_time_entry tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ mcp-toggl --help
 | `toggl_get_current_entry` | Returns the running timer, elapsed seconds, and hydrated project/workspace context. |
 | `toggl_start_timer` | Starts a timer with description, optional project/task, and tags. |
 | `toggl_stop_timer` | Stops the currently running timer. |
+| `toggl_update_time_entry` | Updates an existing time entry (description, project/task, tags, start/stop, duration, billable). Only the fields you pass are changed. |
 
 ### Lookups
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -315,6 +315,64 @@ const tools: Tool[] = [
       required: [],
     },
   },
+  {
+    name: 'toggl_update_time_entry',
+    description:
+      'Update an existing time entry (description, project, task, tags, start/stop, duration, billable). Only fields provided are changed.',
+    annotations: {
+      readOnlyHint: false,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        time_entry_id: {
+          type: 'number',
+          description: 'ID of the time entry to update',
+        },
+        workspace_id: {
+          type: 'number',
+          description:
+            'Workspace ID. If omitted, uses TOGGL_DEFAULT_WORKSPACE_ID or the only available workspace; required when multiple workspaces exist.',
+        },
+        description: {
+          type: 'string',
+          description: 'New description for the time entry',
+        },
+        project_id: {
+          type: 'number',
+          description: 'New project ID',
+        },
+        task_id: {
+          type: 'number',
+          description: 'New task ID',
+        },
+        tags: {
+          type: 'array',
+          items: { type: 'string' },
+          description: 'Replacement tags for the entry',
+        },
+        start: {
+          type: 'string',
+          description: 'New start time (ISO 8601 datetime)',
+        },
+        stop: {
+          type: 'string',
+          description: 'New stop time (ISO 8601 datetime)',
+        },
+        duration: {
+          type: 'number',
+          description: 'New duration in seconds',
+        },
+        billable: {
+          type: 'boolean',
+          description: 'Whether the entry is billable',
+        },
+      },
+      required: ['time_entry_id'],
+    },
+  },
 
   // Reporting tools
   {
@@ -770,6 +828,43 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
                 {
                   success: true,
                   message: 'Timer stopped',
+                  entry: hydrated[0],
+                },
+                null,
+                2
+              ),
+            },
+          ],
+        };
+      }
+
+      case 'toggl_update_time_entry': {
+        const workspaceId = await resolveWorkspaceForTool(args, 'updating a time entry');
+        const timeEntryId = args?.time_entry_id as number;
+
+        const updates: Record<string, unknown> = {};
+        if (args?.description !== undefined) updates.description = args.description;
+        if (args?.project_id !== undefined) updates.project_id = args.project_id;
+        if (args?.task_id !== undefined) updates.task_id = args.task_id;
+        if (args?.tags !== undefined) updates.tags = args.tags;
+        if (args?.start !== undefined) updates.start = args.start;
+        if (args?.stop !== undefined) updates.stop = args.stop;
+        if (args?.duration !== undefined) updates.duration = args.duration;
+        if (args?.billable !== undefined) updates.billable = args.billable;
+
+        const updated = await api.updateTimeEntry(workspaceId, timeEntryId, updates);
+
+        await ensureCache();
+        const hydrated = await cache.hydrateTimeEntries([updated]);
+
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(
+                {
+                  success: true,
+                  message: 'Time entry updated',
                   entry: hydrated[0],
                 },
                 null,

--- a/tests/stdio-smoke.test.ts
+++ b/tests/stdio-smoke.test.ts
@@ -93,4 +93,41 @@ describe.skipIf(!existsSync(entryPoint))('stdio smoke checks', () => {
       await client.close();
     }
   });
+
+  it('exposes toggl_update_time_entry schema and reaches the Toggl API', async () => {
+    const client = new Client({ name: 'mcp-toggl-test', version: '1.0.0' });
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [entryPoint],
+      env: {
+        ...process.env,
+        TOGGL_API_KEY: 'dummy-token',
+        TOGGL_API_TOKEN: '',
+        TOGGL_TOKEN: '',
+      },
+    });
+
+    await client.connect(transport);
+
+    try {
+      const tools = await client.listTools();
+      const updateTool = tools.tools.find((tool) => tool.name === 'toggl_update_time_entry');
+
+      expect(updateTool).toBeDefined();
+      expect(updateTool?.inputSchema.required).toContain('time_entry_id');
+
+      const result = await client.callTool({
+        name: 'toggl_update_time_entry',
+        arguments: { time_entry_id: 123, workspace_id: 456, description: 'test' },
+      });
+      const payload = JSON.parse(result.content?.[0]?.text ?? '{}') as Record<string, unknown>;
+
+      // Dummy token means Toggl rejects the request, but it must reach the
+      // real handler (auth error) rather than falling through to "Unknown tool".
+      expect(payload.error).toBe(true);
+      expect(payload.message).not.toContain('Unknown tool');
+    } finally {
+      await client.close();
+    }
+  });
 });

--- a/tests/toggl-api.test.ts
+++ b/tests/toggl-api.test.ts
@@ -111,3 +111,41 @@ describe('list endpoint pagination', () => {
     expect(projects).toHaveLength(200);
   });
 });
+
+describe('updateTimeEntry', () => {
+  afterEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it('sends a PUT with only the provided fields', async () => {
+    fetchMock.mockResolvedValueOnce(
+      response({ status: 200, json: { id: 42, description: 'Updated', duration: 3600 } })
+    );
+
+    const api = new TogglAPI('token');
+    const result = await api.updateTimeEntry(2154504, 42, {
+      description: 'Updated',
+      duration: 3600,
+    });
+
+    expect(result).toMatchObject({ id: 42, description: 'Updated', duration: 3600 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, { method: string; body: string }];
+    expect(url).toContain('/workspaces/2154504/time_entries/42');
+    expect(options.method).toBe('PUT');
+    expect(JSON.parse(options.body)).toEqual({
+      description: 'Updated',
+      duration: 3600,
+    });
+  });
+
+  it('propagates a sanitized error when the entry does not belong to the workspace', async () => {
+    fetchMock.mockResolvedValueOnce(response({ status: 403, text: 'Forbidden' }));
+
+    const api = new TogglAPI('token');
+    await expect(api.updateTimeEntry(2154504, 42, { description: 'x' })).rejects.toThrow(
+      /Authentication failed/
+    );
+  });
+});


### PR DESCRIPTION
The TogglAPI client already had a working updateTimeEntry() method (used internally by stop_timer) but it was never exposed as an MCP tool, so agents had no way to fix a time entry's description, project, duration, or start/stop time after the fact.

Add the toggl_update_time_entry tool: accepts time_entry_id plus any subset of description, project_id, task_id, tags, start, stop, duration, and billable, and only sends the fields provided.

Tests: stdio smoke test asserting the tool is registered and reaches the real handler, plus unit coverage of TogglAPI.updateTimeEntry's request payload and error handling.